### PR TITLE
FEAT: Improve Report Modal

### DIFF
--- a/packages/client/components/modal/modals/ReportContent.tsx
+++ b/packages/client/components/modal/modals/ReportContent.tsx
@@ -1,5 +1,5 @@
 import { createFormControl, createFormGroup } from "solid-forms";
-import { For, Match, Switch } from "solid-js";
+import { For, Match, Switch, createSignal } from "solid-js";
 
 import { Trans } from "@lingui-solid/solid/macro";
 import { t } from "@lingui/core/macro";
@@ -19,6 +19,9 @@ import {
 
 import { useModals } from "..";
 import { Modals } from "../types";
+
+import { TextEditor } from "@revolt/ui";
+import { AutoCompleteSearchSpace } from "@revolt/ui/components/design/TextEditor";
 
 const CONTENT_REPORT_REASONS: API.ContentReportReason[] = [
   "Illegal",
@@ -88,6 +91,17 @@ export function ReportContentModal(
   const reasons =
     props.target instanceof User ? USER_REPORT_REASONS : CONTENT_REPORT_REASONS;
 
+  const [detailValue, setDetailValue] = createSignal(
+    group.controls.detail.value,
+  );
+
+  const autoCompleteSpace: AutoCompleteSearchSpace = {
+    users: props.client.users.toList(),
+    channels: props.client.channels.toList(),
+    roles: [],
+    members: [],
+  };
+
   async function onSubmit() {
     try {
       const category = group.controls.category.value;
@@ -155,7 +169,7 @@ export function ReportContentModal(
       isDisabled={group.isPending}
     >
       <form onSubmit={Form2.submitHandler(group, onSubmit)}>
-        <Column>
+        <Column gap="md">
           <div class={contentContainer()}>
             {props.target instanceof User ? (
               <Column align>
@@ -176,7 +190,10 @@ export function ReportContentModal(
             )}
           </div>
 
-          <Form2.TextField.Select control={group.controls.category}>
+          <Form2.TextField.Select
+            control={group.controls.category}
+            placement="top"
+          >
             <MenuItem value="">
               <Trans>Please select a reason</Trans>
             </MenuItem>
@@ -185,22 +202,31 @@ export function ReportContentModal(
             </For>
           </Form2.TextField.Select>
 
-          {/* TODO: use TextEditor? */}
           <Form2.TextField
-            name="detail"
-            control={group.controls.detail}
             label={t`Give us some detail`}
-          />
+            control={group.controls.detail}
+          >
+            <TextEditor
+              initialValue={[detailValue()]}
+              autoCompleteSearchSpace={autoCompleteSpace}
+              placeholder={t`Provide more detail here...`}
+              onChange={(value) => {
+                setDetailValue(value);
+                group.controls.detail.setValue(value);
+              }}
+            />
+          </Form2.TextField>
         </Column>
       </form>
     </Dialog>
   );
 }
-
 const contentContainer = cva({
   base: {
+    width: "100%",
     maxWidth: "100%",
-    maxHeight: "240px",
+    maxHeight: "50vh", 
+    overflowY: "auto", 
     "& > div": {
       marginTop: "0 !important",
       pointerEvents: "none",


### PR DESCRIPTION
I've improved the report modal as I noticed some jankiness with it. Unfortunately, I was unable to fix all the problems I found (despite spending a couple hours – It's likely something super easy, but I've given up on fixing that one issue due to my time spent on that issue alone).

---

# **What This Changes/Fixes**
- Report modal now uses **TextEditor** – AutoComplete is questionable at best
- Container scales properly (previously, images would dwarf the UI).
  - Example of previous behaviour:  
    <img width="492" height="494" alt="image" src="https://github.com/user-attachments/assets/2bb1294e-0b0c-43fc-83c0-8e0bad937883" />
- Report reasons will no longer be entirely off the screen.

---

# **What I Couldn't Fix**
- The reasons pop-out not aligning to the input.  
  I have managed to make it less ugly using `placement="top"`.

---

## Please make sure to check the following tasks before opening and submitting a PR:

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)  
- [X] I have tested my changes locally and they are working as intended
