### PR TITLE
fix: reset counter for ordered list items in markdown elements

### DIFF
--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -824,7 +824,7 @@ export function Messages(props: Props) {
         fetchBottom={caseFetchDownwards}
       >
         <div>
-          <div ref={listRef} style={{ "counter-reset": "list-counter" }}>
+          <div ref={listRef}>
             <Show when={atStart()}>
               <ConversationStart channel={props.channel} />
             </Show>

--- a/packages/client/components/markdown/elements.ts
+++ b/packages/client/components/markdown/elements.ts
@@ -114,11 +114,12 @@ export const orderedList = styled("ol", {
     listStylePosition: "outside",
     paddingLeft: "1.5em",
     listStyleType: "none",
-    
+    counterReset: "list-counter var(--start-number, 0)",
+
     "& li": {
       display: "list-item",
       counterIncrement: "list-counter",
-      
+
       "&::before": {
         content: 'counter(list-counter) ". "',
         fontWeight: "inherit",

--- a/packages/client/components/markdown/index.tsx
+++ b/packages/client/components/markdown/index.tsx
@@ -53,6 +53,24 @@ import { defaults } from "./solid-markdown/defaults";
  */
 const Null = () => null;
 
+function RenderOrderedList(props: {
+  start?: string;
+  style?: any;
+  [key: string]: any;
+}) {
+  return (
+    <elements.orderedList
+      {...props}
+      style={{
+        ...(props.start
+          ? { "--start-number": (parseInt(props.start, 10) - 1).toString() }
+          : {}),
+        ...props.style,
+      }}
+    />
+  );
+}
+
 /**
  * Custom Markdown components
  */
@@ -77,7 +95,7 @@ const components = () => ({
   pre: RenderCodeblock,
   li: elements.listItem,
   ul: elements.unorderedList,
-  ol: elements.orderedList,
+  ol: RenderOrderedList,
   blockquote: elements.blockquote,
   table: elements.table,
   th: elements.tableHeader,


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended

Fixed an issue with numbering in lists.

<img width="1280" height="118" alt="image" src="https://github.com/user-attachments/assets/08a600fc-7b63-4d30-b535-5d9f2d14f8f5" />


vs

<img width="1280" height="121" alt="image" src="https://github.com/user-attachments/assets/db28e7a0-bf98-4d62-838a-2c11a9c37c1a" />
In the app at the time of writing.