### PR TITLE
fix: prevent audio from being played inside the gifpicker

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
@@ -264,6 +264,7 @@ const GifItem = (props: {
     <Gif
       loop
       autoplay
+      muted
       preload="auto"
       role="listitem"
       style={props.style}


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
