### PR TITLE
fix: wrap long links and fix underline in LinkWarning modal

### DIFF
--- a/packages/client/components/modal/modals/LinkWarning.tsx
+++ b/packages/client/components/modal/modals/LinkWarning.tsx
@@ -55,7 +55,7 @@ export function LinkWarningModal(
         <span>
           <Trans>Are you sure you want to go to </Trans>
           <Link>{props.url.toString()}</Link>
-          <Trans>?</Trans>
+          ?
         </span>
         <Switch
           fallback={


### PR DESCRIPTION
Before:
<img width="817" height="328" alt="Screenshot From 2025-09-30 22-44-54" src="https://github.com/user-attachments/assets/de1d243f-2ef1-453d-84f7-0d3068eb3442" />
After:
<img width="817" height="328" alt="Screenshot From 2025-09-30 23-28-59" src="https://github.com/user-attachments/assets/33636dc2-d30b-4ffd-af98-d8fcd94e1de0" />

The existing underlines styles weren't taking effect -- there's some bug in the interaction between the `<Trans>` component and inner `styled` components.  This PR works around that by moving the `<Link>` components outside of the `<Trans>`, but that has the side-effect of leaving trailing spaces in the `<Trans>` component and separating the `?`.  I'm not sure how to manage that better -- if you know how, feel free to edit this PR, or just close it and fix it separately.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
