### PR TITLE
fix: prevent false-positive link scrutiny from URL normalization

### DIFF
--- a/packages/client/components/modal/modals/LinkWarning.tsx
+++ b/packages/client/components/modal/modals/LinkWarning.tsx
@@ -18,12 +18,18 @@ export function LinkWarningModal(
   const [value, setValue] = createSignal(false);
 
   const scrutiny = createMemo(() => {
-    if (props.url.toString() !== props.display) {
+    let destUrlString = props.url.toString();
+    if (destUrlString !== props.display) {
       try {
-        new URL(props.display);
-        return 2;
+        let displayUrl = new URL(props.display);
+        if (destUrlString !== displayUrl.toString()) {
+          return 2;
+        } else {
+          return 1;
+        }
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (_) {
+        // URL parsing failed; the link is likely not intentionally misleading.
         return 1;
       }
     }


### PR DESCRIPTION
Currently the URL scrutiny checks fail on bare domains (`https://example.com`) because the `URL` constructor adds a trailing slash.  (`new URL("https://example.com").toString()` is `https://example.com/`)

This PR fixes that by also checking against the normalized version of the display URL.

Before:
<img width="500" height="333" alt="Screenshot From 2025-10-01 12-32-55" src="https://github.com/user-attachments/assets/bdab6cce-c0de-46f3-9efe-39294cc3c609" />
After:
<img width="500" height="233" alt="image" src="https://github.com/user-attachments/assets/bcfa72d9-a774-4e5f-bc7e-f060696df95b" />
