### PR TITLE
fix: sliders in appearance not rendering

### DIFF
--- a/packages/client/components/ui/components/design/Slider.tsx
+++ b/packages/client/components/ui/components/design/Slider.tsx
@@ -31,7 +31,7 @@ export function Slider(props: Props) {
 
   createEffect(
     on(ref, (ref) => {
-      if (ref) {
+      if (ref && local.labelFormatter) {
         ref.labelFormatter = local.labelFormatter;
       }
     }),


### PR DESCRIPTION
Commit 09dc8a305bdc984f0f41e19960ca3f6f1a9a7fa6 added a optional `labelFormatter` prop to the Slider component.

However, it doesn't check whether the function was passed before assigning it to the mdui component reference, causing the slider to silently fail to render.

This PR fixes that by adding a check to see whether `labelFormatter` was passed or not.