### PR TITLE
fix: hardware acceleration config button

### DIFF
--- a/packages/client/components/app/interface/settings/user/Native.tsx
+++ b/packages/client/components/app/interface/settings/user/Native.tsx
@@ -128,10 +128,10 @@ export default function Native() {
           <Trans>Spellchecker</Trans>
         </CategoryButton>
         <CategoryButton
-          action={<Checkbox checked={config().spellchecker} />}
+          action={<Checkbox checked={config().hardwareAcceleration} />}
           onClick={() =>
             set({
-              spellchecker: !config().spellchecker,
+              hardwareAcceleration: !config().hardwareAcceleration,
             })
           }
           icon={<Symbol>speed</Symbol>}


### PR DESCRIPTION
In `Native.tsx` the "Hardware Acceleration" button was tied to the `spellchecker` boolean instead of the `hardwareAcceleration` boolean, causing a click on either the "Spellchecker" or "Hardware Acceleration" button to toggle both buttons simultaneously.

This fixes that behavior by assigning the "Hardware Acceleration" button to the `hardwareAcceleration` boolean, which I assume is the correct choice.