### PR TITLE
fix: codemirror bounding box not taking full composer height

### DIFF
--- a/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
+++ b/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
@@ -245,6 +245,7 @@ export function TextEditor2(props: Props) {
 const editor = css({
   display: "inline-flex",
   height: "100%",
+  width: "100%",
   flexGrow: 1,
   alignSelf: "center",
 


### PR DESCRIPTION
Another issue that nobody reported until now, apparently.

As far as I know, TextEditor2 is used in about 2 or 3 places currently, i've checked them all and it seems to work just fine. 