### PR TITLE
feat(messaging): animate profile picture on hover

### DIFF
--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -1,4 +1,4 @@
-import { For, Match, Show, Switch, onMount } from "solid-js";
+import { For, Match, Show, Switch, createSignal, onMount } from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
 import { Message as MessageInterface, WebsiteEmbed } from "stoat.js";
@@ -74,6 +74,8 @@ export function Message(props: Props) {
   const { t } = useLingui();
   const client = useClient();
 
+  const [isHovering, setIsHovering] = createSignal(false);
+
   /**
    * Determine whether this message only contains a GIF
    */
@@ -103,6 +105,7 @@ export function Message(props: Props) {
   return (
     <MessageContainer
       message={props.message}
+      onHover={setIsHovering}
       username={
         <div use:floating={floatingUserMenusFromMessage(props.message)}>
           <Username
@@ -116,7 +119,14 @@ export function Message(props: Props) {
           class={avatarContainer()}
           use:floating={floatingUserMenusFromMessage(props.message)}
         >
-          <Avatar size={36} src={props.message.avatarURL} />
+          <Avatar
+            size={36}
+            src={
+              isHovering()
+                ? props.message.animatedAvatarURL
+                : props.message.avatarURL
+            }
+          />
         </div>
       }
       contextMenu={() => <MessageContextMenu message={props.message} />}

--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -93,6 +93,11 @@ type Props = CommonProps & {
   sendStatus?: "sending" | "failed";
 
   /**
+   * Whether we are hovering this message
+   */
+  onHover?: (hovering: boolean) => void;
+
+  /**
    * Component to render message context menu
    */
   contextMenu?: () => JSX.Element;
@@ -305,6 +310,8 @@ export function MessageContainer(props: Props) {
 
   return (
     <div
+      onMouseEnter={() => props.onHover && props.onHover(true)}
+      onMouseLeave={() => props.onHover && props.onHover(false)}
       class={
         "group " +
         base({


### PR DESCRIPTION
Small little parity feature that adds back the ability to see animated profile pictures on messages. If and when we add accessibility settings to the app, this should be dictated by the user's `reduce-motion` preference.

Demo
---
https://github.com/user-attachments/assets/523430dd-4bad-45fa-848b-3d2f20286bc3

