### PR TITLE
fix: use ch unit instead of px to avoid wrapping

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -264,7 +264,7 @@ const infoText = cva({
   variants: {
     prefix: {
       true: {
-        width: "calc(36px + 2 * var(--gap-sm))",
+        width: "calc(7ch * var(--gap-sm))",
         fontSize: "0.7em",
 
         display: "block",


### PR DESCRIPTION
## Before
<img width="480" height="58" alt="image" src="https://github.com/user-attachments/assets/418a9544-61fa-4ef8-9f52-0d37466abe31" />

## After
<img width="475" height="52" alt="image" src="https://github.com/user-attachments/assets/87af3eee-1d0e-415b-9b35-70c01b0b39ef" />

