### PR TITLE
fix: mention context menu option not appearing

### DIFF
--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -77,6 +77,7 @@ export function UserContextMenu(props: {
    * Mention the user
    */
   function mention() {
+    if (!state.draft._setNodeReplacement) return;
     state.draft._setNodeReplacement([props.user.toString()]);
   }
 


### PR DESCRIPTION
Also fix said option to properly insert the mention using `state.draft._setNodeReplacement`