### PR TITLE
fix: also check m3Variant in theme clean function

### DIFF
--- a/packages/client/components/state/stores/Theme.ts
+++ b/packages/client/components/state/stores/Theme.ts
@@ -167,6 +167,22 @@ export class Theme extends AbstractStore<"theme", TypeTheme> {
       data.m3Accent = input.m3Accent;
     }
 
+    if (
+      [
+        "monochrome",
+        "neutral",
+        "tonal_spot",
+        "vibrant",
+        "expressive",
+        "fidelity",
+        "content",
+        "rainbow",
+        "fruit_salad",
+      ].includes(input.m3Variant!)
+    ) {
+      data.m3Variant = input.m3Variant!;
+    }
+
     if (typeof input.blur === "boolean") {
       data.blur = input.blur;
     }


### PR DESCRIPTION
Turns out that the clean function did not check for the m3Variant property in the Theme store, causing it to reset to it's default value on reload.