### PR TITLE
fix: Pass room to Tracks in RoomAudioManager

### DIFF
--- a/packages/client/components/rtc/components/RoomAudioManager.tsx
+++ b/packages/client/components/rtc/components/RoomAudioManager.tsx
@@ -1,5 +1,5 @@
 import { createEffect, createMemo } from "solid-js";
-import { AudioTrack, useTracks } from "solid-livekit-components";
+import { AudioTrack, useTracks, useMaybeRoomContext } from "solid-livekit-components";
 
 import { getTrackReferenceId, isLocal } from "@livekit/components-core";
 import { Key } from "@solid-primitives/keyed";
@@ -13,6 +13,8 @@ export function RoomAudioManager() {
   const voice = useVoice();
   const state = useState();
 
+  const roomFromContext = useMaybeRoomContext();
+
   const tracks = useTracks(
     [
       Track.Source.Microphone,
@@ -22,6 +24,7 @@ export function RoomAudioManager() {
     {
       updateOnlyOn: [],
       onlySubscribed: false,
+	  room: roomFromContext?.(),
     },
   );
 


### PR DESCRIPTION
This PR fixes #577 (I had no permission to reopen it and was being too fast). Sometimes(only me as far as I know) something causes the room in Tracks to break causing a fail to join. This is fixed by passing it