### PR TITLE
chore: properly localize authifier errors

### DIFF
--- a/packages/client/components/i18n/catalogs/ar/messages.po
+++ b/packages/client/components/i18n/catalogs/ar/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/as/messages.po
+++ b/packages/client/components/i18n/catalogs/as/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/az/messages.po
+++ b/packages/client/components/i18n/catalogs/az/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/be/messages.po
+++ b/packages/client/components/i18n/catalogs/be/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/bg/messages.po
+++ b/packages/client/components/i18n/catalogs/bg/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/bn/messages.po
+++ b/packages/client/components/i18n/catalogs/bn/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/bottom/messages.po
+++ b/packages/client/components/i18n/catalogs/bottom/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/br/messages.po
+++ b/packages/client/components/i18n/catalogs/br/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ca/messages.po
+++ b/packages/client/components/i18n/catalogs/ca/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ceb/messages.po
+++ b/packages/client/components/i18n/catalogs/ceb/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ckb/messages.po
+++ b/packages/client/components/i18n/catalogs/ckb/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/cs/messages.po
+++ b/packages/client/components/i18n/catalogs/cs/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/da/messages.po
+++ b/packages/client/components/i18n/catalogs/da/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/de/messages.po
+++ b/packages/client/components/i18n/catalogs/de/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/dev/messages.po
+++ b/packages/client/components/i18n/catalogs/dev/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/el/messages.po
+++ b/packages/client/components/i18n/catalogs/el/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/en/messages.po
+++ b/packages/client/components/i18n/catalogs/en/messages.po
@@ -2688,8 +2688,8 @@ msgid "This message is empty and has not been sent."
 msgstr "This message is empty and has not been sent."
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
-msgstr "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
+msgstr "This password has previously appeared in security leaks, please use another password."
 
 #: components/app/interface/settings/server/Overview.tsx
 msgid "This server is about..."

--- a/packages/client/components/i18n/catalogs/en_US/messages.po
+++ b/packages/client/components/i18n/catalogs/en_US/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/enchantment/messages.po
+++ b/packages/client/components/i18n/catalogs/enchantment/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/eo/messages.po
+++ b/packages/client/components/i18n/catalogs/eo/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/es/messages.po
+++ b/packages/client/components/i18n/catalogs/es/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/es_419/messages.po
+++ b/packages/client/components/i18n/catalogs/es_419/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/et/messages.po
+++ b/packages/client/components/i18n/catalogs/et/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/fa/messages.po
+++ b/packages/client/components/i18n/catalogs/fa/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/fi/messages.po
+++ b/packages/client/components/i18n/catalogs/fi/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/fil/messages.po
+++ b/packages/client/components/i18n/catalogs/fil/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/fr/messages.po
+++ b/packages/client/components/i18n/catalogs/fr/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ga/messages.po
+++ b/packages/client/components/i18n/catalogs/ga/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/hi/messages.po
+++ b/packages/client/components/i18n/catalogs/hi/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/hr/messages.po
+++ b/packages/client/components/i18n/catalogs/hr/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/hu/messages.po
+++ b/packages/client/components/i18n/catalogs/hu/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/hy/messages.po
+++ b/packages/client/components/i18n/catalogs/hy/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/id/messages.po
+++ b/packages/client/components/i18n/catalogs/id/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/is/messages.po
+++ b/packages/client/components/i18n/catalogs/is/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/it/messages.po
+++ b/packages/client/components/i18n/catalogs/it/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ja/messages.po
+++ b/packages/client/components/i18n/catalogs/ja/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ko/messages.po
+++ b/packages/client/components/i18n/catalogs/ko/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/lb/messages.po
+++ b/packages/client/components/i18n/catalogs/lb/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/leet/messages.po
+++ b/packages/client/components/i18n/catalogs/leet/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/lt/messages.po
+++ b/packages/client/components/i18n/catalogs/lt/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/lv/messages.po
+++ b/packages/client/components/i18n/catalogs/lv/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/mk/messages.po
+++ b/packages/client/components/i18n/catalogs/mk/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ms/messages.po
+++ b/packages/client/components/i18n/catalogs/ms/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/nb_NO/messages.po
+++ b/packages/client/components/i18n/catalogs/nb_NO/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/nl/messages.po
+++ b/packages/client/components/i18n/catalogs/nl/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/owo/messages.po
+++ b/packages/client/components/i18n/catalogs/owo/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/piglatin/messages.po
+++ b/packages/client/components/i18n/catalogs/piglatin/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/pl/messages.po
+++ b/packages/client/components/i18n/catalogs/pl/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/pr/messages.po
+++ b/packages/client/components/i18n/catalogs/pr/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/pt_BR/messages.po
+++ b/packages/client/components/i18n/catalogs/pt_BR/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/pt_PT/messages.po
+++ b/packages/client/components/i18n/catalogs/pt_PT/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ro/messages.po
+++ b/packages/client/components/i18n/catalogs/ro/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ru/messages.po
+++ b/packages/client/components/i18n/catalogs/ru/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/si/messages.po
+++ b/packages/client/components/i18n/catalogs/si/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/sk/messages.po
+++ b/packages/client/components/i18n/catalogs/sk/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/sl/messages.po
+++ b/packages/client/components/i18n/catalogs/sl/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/sq/messages.po
+++ b/packages/client/components/i18n/catalogs/sq/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/sr/messages.po
+++ b/packages/client/components/i18n/catalogs/sr/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/sv/messages.po
+++ b/packages/client/components/i18n/catalogs/sv/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ta/messages.po
+++ b/packages/client/components/i18n/catalogs/ta/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/th/messages.po
+++ b/packages/client/components/i18n/catalogs/th/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/tokipona/messages.po
+++ b/packages/client/components/i18n/catalogs/tokipona/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/tr/messages.po
+++ b/packages/client/components/i18n/catalogs/tr/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/uk/messages.po
+++ b/packages/client/components/i18n/catalogs/uk/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/ur/messages.po
+++ b/packages/client/components/i18n/catalogs/ur/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/vec/messages.po
+++ b/packages/client/components/i18n/catalogs/vec/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/vi/messages.po
+++ b/packages/client/components/i18n/catalogs/vi/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/zh_Hans/messages.po
+++ b/packages/client/components/i18n/catalogs/zh_Hans/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/catalogs/zh_Hant/messages.po
+++ b/packages/client/components/i18n/catalogs/zh_Hant/messages.po
@@ -2688,7 +2688,7 @@ msgid "This message is empty and has not been sent."
 msgstr ""
 
 #: components/i18n/errors.ts
-msgid "This password has been compromised before, please use another password."
+msgid "This password has previously appeared in security leaks, please use another password."
 msgstr ""
 
 #: components/app/interface/settings/server/Overview.tsx

--- a/packages/client/components/i18n/errors.ts
+++ b/packages/client/components/i18n/errors.ts
@@ -111,7 +111,7 @@ export function useError() {
         case "LockedOut":
           return t`You have been locked out for entering a wrong password multiple times. Please wait a couple minutes and try again.`;
         case "CompromisedPassword":
-          return t`This password has been compromised before, please use another password.`;
+          return t`This password has previously appeared in security leaks, please use another password.`;
         case "UnverifiedAccount":
           return t`This account is not activated! Please check your account's inbox and try again.`;
         case "TotpAlreadyEnabled":


### PR DESCRIPTION
I think i need feedback on how some of these are worded.

But this PR adds translation strings for some common authifier errors, so people don't come into the support channel asking why they suddenly can't log into their accounts when they've entered their password wrong a bunch of times.