### PR TITLE
fix: call removeFriend() on "Cancel friend request" button click

### DIFF
--- a/packages/client/components/ui/components/features/profiles/ProfileActions.tsx
+++ b/packages/client/components/ui/components/features/profiles/ProfileActions.tsx
@@ -61,7 +61,7 @@ export function ProfileActions(props: {
         </IconButton>
       </Show>
       <Show when={props.user.relationship === "Outgoing"}>
-        <Button onPress={() => props.user.addFriend()}>
+        <Button onPress={() => props.user.removeFriend()}>
           Cancel friend request
         </Button>
       </Show>


### PR DESCRIPTION
The main "Cancel friend request" button incorrectly called `addFriend()`, preventing outgoing friend requests from being canceled. This fix changes it to call `removeFriend()` instead.

Related issue in stoatchat/stoatchat#443