### PR TITLE
fix: border radius on connected button groups

### DIFF
--- a/packages/client/components/ui/components/design/Button.tsx
+++ b/packages/client/components/ui/components/design/Button.tsx
@@ -281,22 +281,27 @@ const button = cva({
     size: {
       xs: {
         height: "32px",
+        "--max-radius": "16px",
         "--padding-inline": "12px",
       },
       sm: {
         height: "40px",
+        "--max-radius": "20px",
         "--padding-inline": "16px",
       },
       md: {
         height: "56px",
+        "--max-radius": "28px",
         "--padding-inline": "24px",
       },
       lg: {
         height: "96px",
+        "--max-radius": "48px",
         "--padding-inline": "48px",
       },
       xl: {
         height: "136px",
+        "--max-radius": "68px",
         "--padding-inline": "64px",
       },
 
@@ -418,23 +423,8 @@ const button = cva({
     // hard-code values for rounded connected group shapes
     {
       shape: "round",
-      size: ["sm", "xs"],
       css: {
-        borderRadius: "48px",
-      },
-    },
-    {
-      shape: "round",
-      size: ["md"],
-      css: {
-        borderRadius: "64px",
-      },
-    },
-    {
-      shape: "round",
-      size: ["xl", "lg"],
-      css: {
-        borderRadius: "160px",
+        borderRadius: "var(--max-radius)",
       },
     },
 
@@ -444,7 +434,8 @@ const button = cva({
       size: ["sm", "xs"],
       group: "connected-start",
       css: {
-        borderRadius: "48px var(--borderRadius-md) var(--borderRadius-md) 48px",
+        borderRadius:
+          "var(--max-radius) var(--borderRadius-md) var(--borderRadius-md) var(--max-radius)",
       },
     },
     {
@@ -452,7 +443,8 @@ const button = cva({
       size: "md",
       group: "connected-start",
       css: {
-        borderRadius: "64px var(--borderRadius-lg) var(--borderRadius-lg) 64px",
+        borderRadius:
+          "var(--max-radius) var(--borderRadius-lg) var(--borderRadius-lg) var(--max-radius)",
       },
     },
     {
@@ -461,7 +453,7 @@ const button = cva({
       group: "connected-start",
       css: {
         borderRadius:
-          "160px var(--borderRadius-xl) var(--borderRadius-xl) 160px",
+          "var(--max-radius) var(--borderRadius-xl) var(--borderRadius-xl) var(--max-radius)",
       },
     },
 
@@ -471,7 +463,8 @@ const button = cva({
       size: ["sm", "xs"],
       group: "connected-end",
       css: {
-        borderRadius: "var(--borderRadius-md) 48px 48px var(--borderRadius-md)",
+        borderRadius:
+          "var(--borderRadius-md) var(--max-radius) var(--max-radius) var(--borderRadius-md)",
       },
     },
     {
@@ -479,7 +472,8 @@ const button = cva({
       size: "md",
       group: "connected-end",
       css: {
-        borderRadius: "var(--borderRadius-lg) 64px 64px var(--borderRadius-lg)",
+        borderRadius:
+          "var(--borderRadius-lg) var(--max-radius) var(--max-radius) var(--borderRadius-lg)",
       },
     },
     {
@@ -488,7 +482,7 @@ const button = cva({
       group: "connected-end",
       css: {
         borderRadius:
-          "var(--borderRadius-xl) 160px 160px var(--borderRadius-xl)",
+          "var(--borderRadius-xl) var(--max-radius) var(--max-radius) var(--borderRadius-xl)",
       },
     },
 


### PR DESCRIPTION
Hopefully you don't mind this PR, apologies in advance if I did it wrong! The inconsistency was bothering me.

Before:
<img width="770" height="234" alt="image" src="https://github.com/user-attachments/assets/aab3db1f-842d-4d9a-852b-833dbd2c41df" />

After:
<img width="770" height="234" alt="image" src="https://github.com/user-attachments/assets/277c33a4-056c-467a-91d7-59cbb344b9fa" />

roughly copied from the commit message:

> The current styling causes border radii on connected groups to be inconsistent between buttons in the middle vs buttons on the end of the group. (This is most obvious in the Appearance tab in the settings.)
> 
> This is due to how the CSS spec handles `border-radius` values that cause overlapping corners (ex. the ones used to create pill-shaped buttons here) - instead of only reducing the conflicting corners, all corners are reduced proportionally as needed:
> https://drafts.csswg.org/css-backgrounds/#corner-overlap
> 
> This is fixed by introducing a `--max-radius` CSS variable that is half of the button's height, which achieves the same effect without having corner overlaps. As a bonus, we reduce the `shape: "round"` variants to a single one that references the variable.
> 
> Note that there could potentially still be a consistency issue if a button is less wide than tall, but that seems very unlikely.