### PR TITLE
fix: checkboxes doubble toggle, autostart and made toggle logic reusable

### DIFF
--- a/packages/client/components/app/interface/settings/user/Native.tsx
+++ b/packages/client/components/app/interface/settings/user/Native.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createSignal, onMount } from "solid-js";
 
 import { Trans } from "@lingui-solid/solid/macro";
 
@@ -34,8 +34,8 @@ declare global {
     desktopConfig: {
       get(): DesktopConfig;
       set(config: Partial<DesktopConfig>): void;
-      getAutostart(): boolean;
-      setAutostart(value: boolean): void;
+      getAutostart(): Promise<boolean>;
+      setAutostart(value: boolean): Promise<boolean>;
     };
   }
 }
@@ -44,9 +44,7 @@ declare global {
  * Desktop Configuration Page
  */
 export default function Native() {
-  const [autostart, setAutostart] = createSignal(
-    window.desktopConfig.getAutostart(),
-  );
+  const [autostart, setAutostart] = createSignal(false);
   const [config, setConfig] = createSignal(window.desktopConfig.get());
 
   function set(config: Partial<DesktopConfig>) {
@@ -54,17 +52,65 @@ export default function Native() {
     setConfig((conf) => ({ ...conf, ...config }));
   }
 
+  onMount(async () => {
+    const value = await window.desktopConfig.getAutostart();
+    setAutostart(value);
+  });
+
+  async function toggleAutostart() {
+    const newValue = !autostart();
+    const savedValue = await window.desktopConfig.setAutostart(newValue);
+    setAutostart(savedValue);
+  }
+
+  const toggles: Partial<Record<keyof DesktopConfig, () => void>> = {
+    minimiseToTray: () => set({ minimiseToTray: !config().minimiseToTray }),
+    customFrame: () => set({ customFrame: !config().customFrame }),
+    discordRpc: () => set({ discordRpc: !config().discordRpc }),
+    spellchecker: () => set({ spellchecker: !config().spellchecker }),
+    hardwareAcceleration: () =>
+      set({ hardwareAcceleration: !config().hardwareAcceleration }),
+  };
+
+  function CheckboxButton<K extends keyof DesktopConfig>(
+    key: K,
+    icon: string,
+    label: string,
+    description: string,
+  ) {
+    return (
+      <CategoryButton
+        action={
+          <Checkbox
+            checked={config()[key]}
+            onClick={(e) => e.stopPropagation()}
+            onChange={(e) => {
+              e.stopPropagation();
+              toggles[key]!();
+            }}
+          />
+        }
+        onClick={toggles[key]}
+        icon={<Symbol>{icon}</Symbol>}
+        description={<Trans>{description}</Trans>}
+      >
+        <Trans>{label}</Trans>
+      </CategoryButton>
+    );
+  }
+
   return (
     <Column gap="lg">
       <CategoryButton.Group>
         <CategoryButton
-          action={<Checkbox checked={autostart()} />}
-          onClick={() =>
-            setAutostart((value) => {
-              window.desktopConfig.setAutostart(!value);
-              return !value;
-            })
+          action={
+            <Checkbox
+              checked={autostart()}
+              onClick={(e) => e.stopPropagation()}
+              onChange={toggleAutostart}
+            />
           }
+          onClick={toggleAutostart}
           icon={<Symbol>exit_to_app</Symbol>}
           description={
             <Trans>Launch Stoat when you log into your computer.</Trans>
@@ -72,75 +118,39 @@ export default function Native() {
         >
           <Trans>Start with Computer</Trans>
         </CategoryButton>
-        <CategoryButton
-          action={<Checkbox checked={config().minimiseToTray} />}
-          onClick={() =>
-            set({
-              minimiseToTray: !config().minimiseToTray,
-            })
-          }
-          icon={<Symbol>cancel_presentation</Symbol>}
-          description={
-            <Trans>Instead of closing, Stoat will hide in your tray.</Trans>
-          }
-        >
-          <Trans>Minimise to Tray</Trans>
-        </CategoryButton>
-        <CategoryButton
-          action={<Checkbox checked={config().customFrame} />}
-          onClick={() =>
-            set({
-              customFrame: !config().customFrame,
-            })
-          }
-          icon={<Symbol>web_asset</Symbol>}
-          description={<Trans>Let Stoat use its own custom titlebar.</Trans>}
-        >
-          <Trans>Custom window frame</Trans>
-        </CategoryButton>
+        {CheckboxButton(
+          "minimiseToTray",
+          "cancel_presentation",
+          "Minimise to Tray",
+          "Instead of closing, Stoat will hide in your tray.",
+        )}
+        {CheckboxButton(
+          "customFrame",
+          "web_asset",
+          "Custom window frame",
+          "Let Stoat use its own custom titlebar.",
+        )}
       </CategoryButton.Group>
 
       <CategoryButton.Group>
-        <CategoryButton
-          action={<Checkbox checked={config().discordRpc} />}
-          onClick={() =>
-            set({
-              discordRpc: !config().discordRpc,
-            })
-          }
-          icon={<Symbol>groups_2</Symbol>}
-          description={<Trans>Rep Stoat using Discord rich presence.</Trans>}
-        >
-          <Trans>Discord RPC</Trans>
-        </CategoryButton>
-        <CategoryButton
-          action={<Checkbox checked={config().spellchecker} />}
-          onClick={() =>
-            set({
-              spellchecker: !config().spellchecker,
-            })
-          }
-          icon={<Symbol>spellcheck</Symbol>}
-          description={
-            <Trans>Show corrections and suggestions as you type.</Trans>
-          }
-        >
-          <Trans>Spellchecker</Trans>
-        </CategoryButton>
-        <CategoryButton
-          action={<Checkbox checked={config().hardwareAcceleration} />}
-          onClick={() =>
-            set({
-              hardwareAcceleration: !config().hardwareAcceleration,
-            })
-          }
-          icon={<Symbol>speed</Symbol>}
-          description={
-            <Trans>Use the graphics card to improve performance.</Trans>
-          }
-        >
-          <Trans>Hardware Acceleration</Trans>
-        </CategoryButton>
+        {CheckboxButton(
+          "discordRpc",
+          "groups_2",
+          "Discord RPC",
+          "Rep Stoat using Discord rich presence.",
+        )}
+        {CheckboxButton(
+          "spellchecker",
+          "spellcheck",
+          "Spellchecker",
+          "Show corrections and suggestions as you type.",
+        )}
+        {CheckboxButton(
+          "hardwareAcceleration",
+          "speed",
+          "Hardware Acceleration",
+          "Use the graphics card to improve performance.",
+        )}
       </CategoryButton.Group>
 
       <CategoryButton.Group>


### PR DESCRIPTION
- Fix autostart by reading it asynchronously on mount and updating the stored value before updating UI state.
- Prevent checkbox/toggle double-click issues by stopping event propagation and reusing a shared toggle handler.

## Related Issues
- https://github.com/stoatchat/for-web/issues/643
- https://github.com/stoatchat/for-web/issues/581
- https://github.com/stoatchat/for-web/issues/667
- https://github.com/stoatchat/for-web/issues/679
- https://github.com/stoatchat/for-desktop/issues/10
- https://github.com/stoatchat/for-desktop/issues/14
- https://github.com/stoatchat/for-desktop/issues/44


## Notes
This PR only changes the web UI (Native.tsx). The desktop IPC change is already in a separate PR and is linked [here](https://github.com/stoatchat/for-desktop/pull/68) for context.
##
![YWxit6yIEs](https://github.com/user-attachments/assets/8fde20ce-f505-4d8f-acf0-da2fe137707b)
