### PR TITLE
fix: email field autocomplete not working for some browsers

### DIFF
--- a/packages/client/components/auth/src/flows/Form.tsx
+++ b/packages/client/components/auth/src/flows/Form.tsx
@@ -22,6 +22,7 @@ const useFieldConfiguration = () => {
       type: "email" as const,
       name: () => t`Email`,
       placeholder: () => t`Please enter your email.`,
+      autocomplete: "email",
     },
     password: {
       minLength: 8,


### PR DESCRIPTION
This PR only adds the `autocomplete="email"` hint to the email input field.