### PR TITLE
fix: Preserve msg ID in anchor links

### DIFF
--- a/packages/client/components/markdown/plugins/anchors.tsx
+++ b/packages/client/components/markdown/plugins/anchors.tsx
@@ -94,7 +94,9 @@ export function RenderAnchor(
             (channel()!.serverId
               ? `/server/${channel()!.serverId}/channel/${channel()!.id}`
               : `/channel/${channel()!.id}`) +
-              (params.exactMessage && params.messageId ? `/${params.messageId}` : ""),
+              (params.exactMessage && params.messageId
+                ? `/${params.messageId}`
+                : ""),
             location.origin,
           ).toString();
 


### PR DESCRIPTION
Include the trailing message ID when present so clicking a link navigates directly to the referenced message

![chrome_2eAg7ROgNT](https://github.com/user-attachments/assets/39449ade-4b20-4c6a-b3c5-1e16659bee21)
