### PR TITLE
fix: Incorrect password field on account creation

### DIFF
--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -49,7 +49,7 @@ export default function FlowCreate() {
         <Trans>Hello!</Trans>
       </FlowTitle>
       <Form onSubmit={create} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
-        <Fields fields={["email", "password"]} />
+        <Fields fields={["email", "new-password"]} />
         <Row justify>
           <a href="..">
             <Button variant="text">


### PR DESCRIPTION
Don't be too cruel with me, i was just attempting to check out stoat and noticed that trying to create an account asks you to "Enter your current password" and doesn't have password suggesting.

I have replaced "password" with "new-password" according to the file Form.tsx, this is not AI-assisted, i've done it raw on my web browser.