### PR TITLE
fix: Bypass email registration page if the server configuration has email disabled

### DIFF
--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -1,7 +1,8 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
-import { useApi, useClient } from "@revolt/client";
+import { useApi, useClient, useClientLifecycle } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
+import { useModals } from "@revolt/modal";
 import { useNavigate, useParams } from "@revolt/routing";
 import { Button, Row, iconSize } from "@revolt/ui";
 
@@ -20,6 +21,8 @@ export default function FlowCreate() {
   const getClient = useClient();
   const navigate = useNavigate();
   const { code } = useParams();
+  const modals = useModals();
+  const { login } = useClientLifecycle();
 
   /**
    * Create an account
@@ -38,13 +41,19 @@ export default function FlowCreate() {
       ...(invite ? { invite } : {}),
     });
 
-    // FIXME: should tell client if email was sent
-    //        or if email even needs to be confirmed
-
-    // TODO: log straight in if no email confirmation?
-
-    setFlowCheckEmail(email);
-    navigate("/login/check", { replace: true });
+    if (getClient().configuration?.features.email) {
+      setFlowCheckEmail(email);
+      navigate("/login/check", { replace: true });
+    } else {
+      await login(
+        {
+          email,
+          password,
+        },
+        modals,
+      );
+      navigate("/login/auth", { replace: true });
+    }
   }
 
   const isInviteOnly = () => {

--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -41,10 +41,8 @@ export default function FlowCreate() {
       ...(invite ? { invite } : {}),
     });
 
-    if (getClient().configuration?.features.email) {
-      setFlowCheckEmail(email);
-      navigate("/login/check", { replace: true });
-    } else {
+    const client = getClient();
+    if (client.configuration && !client.configuration.features.email) {
       await login(
         {
           email,
@@ -53,6 +51,9 @@ export default function FlowCreate() {
         modals,
       );
       navigate("/login/auth", { replace: true });
+    } else {
+      setFlowCheckEmail(email);
+      navigate("/login/check", { replace: true });
     }
   }
 


### PR DESCRIPTION
After registration, the verify email page is shown regardless of whether email is enabled or not. This PR makes the account creation flow skip email verification and log straight in if the server is configured with email disabled.

Requires https://github.com/stoatchat/javascript-client-sdk/pull/127 due to the configuration currently not being loaded automatically by the javascript client sdk.

Resolves #759

Tested by @alice_werefox and @dadadah