### PR TITLE
fix(stoatchat#754): Add white margin to QR code for 2FA

### DIFF
--- a/packages/client/components/modal/modals/MFAEnableTOTP.tsx
+++ b/packages/client/components/modal/modals/MFAEnableTOTP.tsx
@@ -31,6 +31,16 @@ const Qr = styled("div", {
     placeItems: "center",
   },
 });
+/**
+ * Larger white wrapper for QR code with padding
+ */
+const QrWrapper = styled("div", {
+  base: {
+    background: "white",
+    padding: "1rem", 
+    borderRadius: "4px",
+  },
+});
 
 /**
  * Modal to display QR code and secret key for MFA and accept the correct code
@@ -98,18 +108,20 @@ export function MFAEnableTOTPModal(
           </Text>
 
           <Column align>
-            <Qr>
-              <QRCodeSVG
-                value={uri()}
-                backgroundColor="white"
-                foregroundColor="black"
-                level="medium"
-                height={140}
-                width={140}
-                backgroundAlpha={1}
-                foregroundAlpha={1}
-              />
-            </Qr>
+          <QrWrapper>
+              <Qr>
+                <QRCodeSVG
+                  value={uri()}
+                  backgroundColor="white"
+                  foregroundColor="black"
+                  level="medium"
+                  height={140}
+                  width={140}
+                  backgroundAlpha={1}
+                  foregroundAlpha={1}
+                />
+              </Qr>
+            </QrWrapper>
             <Code>{props.secret}</Code>
           </Column>
 


### PR DESCRIPTION
## Description

Fixes #754

Adds a white margin wrapper around the QR code to ensure proper scanning compatibility with authenticator apps like Aegis, ZXing, and standard camera apps.

## Changes

- Added `QrWrapper` styled component with white background and padding (`1rem`)
- Wrapped the existing `Qr` component inside `QrWrapper`
- QR code now has proper white margin as required by QR code standards

## Testing

The QR code should now be scannable by all authenticator apps without needing manual editing in image editors.

## Related

Closes #754