### PR TITLE
fix: chat auto-scroll is fragile in chromium environments

### DIFF
--- a/packages/client/components/ui/components/utils/ListView2.tsx
+++ b/packages/client/components/ui/components/utils/ListView2.tsx
@@ -59,15 +59,28 @@ interface Props {
 }
 
 /**
+ * Threshold (in pixels) which we consider the user to be
+ * "at the bottom" of the scroll container, in column-reverse layout.
+ */
+const BOTTOM_THRESHOLD = 1;
+
+/**
  * Dynamic list view with ability to move through history
  *
  * This component only provides the scrolling behaviour
  */
 export function ListView2(props: Props) {
   let ref: HTMLDivElement | undefined;
+  let contentRef: HTMLDivElement | undefined;
+
+  let wasAtBottom = true;
+  let suppressSnap = false;
 
   function consumeDOMUpdate(update?: ListView2Update) {
     if (!update) return;
+
+    suppressSnap = true;
+    wasAtBottom = false;
 
     const currentRect = update.scrollAnchorId
       ? document.getElementById(update.scrollAnchorId)?.getBoundingClientRect()
@@ -90,7 +103,10 @@ export function ListView2(props: Props) {
             top: ref.scrollTop + (updatedRect.top - currentRect.top),
           });
         }
+        suppressSnap = false;
       });
+    } else {
+      suppressSnap = false;
     }
   }
 
@@ -101,6 +117,34 @@ export function ListView2(props: Props) {
   async function loadEnd() {
     consumeDOMUpdate(await props.fetchBottom());
   }
+
+  createEffect(() => {
+    const el = ref;
+    if (!el) return;
+
+    const onScroll = () => {
+      if (!suppressSnap) {
+        wasAtBottom = el.scrollTop >= -BOTTOM_THRESHOLD;
+      }
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    onCleanup(() => el.removeEventListener("scroll", onScroll));
+  });
+
+  createEffect(() => {
+    const el = contentRef;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      if (!suppressSnap && wasAtBottom && ref && ref.scrollTop < 0) {
+        ref.scrollTop = 0;
+      }
+    });
+
+    observer.observe(el);
+    onCleanup(() => observer.disconnect());
+  });
 
   return (
     <div
@@ -113,7 +157,7 @@ export function ListView2(props: Props) {
       }}
     >
       <div class={container()}>
-        <div>
+        <div ref={contentRef}>
           <Show when={!props.atStart()}>
             <Skeleton
               align="end"

--- a/packages/client/components/ui/components/utils/ListView2.tsx
+++ b/packages/client/components/ui/components/utils/ListView2.tsx
@@ -59,12 +59,6 @@ interface Props {
 }
 
 /**
- * Threshold (in pixels) which we consider the user to be
- * "at the bottom" of the scroll container, in column-reverse layout.
- */
-const BOTTOM_THRESHOLD = 1;
-
-/**
  * Dynamic list view with ability to move through history
  *
  * This component only provides the scrolling behaviour
@@ -73,14 +67,29 @@ export function ListView2(props: Props) {
   let ref: HTMLDivElement | undefined;
   let contentRef: HTMLDivElement | undefined;
 
-  let wasAtBottom = true;
   let suppressSnap = false;
+  let wasSnapped = true;
+  let contentMutating = false;
+
+  function isNewestMessageVisible() {
+    if (!ref || !contentRef) return false;
+
+    const messages = contentRef.querySelectorAll<HTMLElement>("[id]");
+    const newest = messages[messages.length - 1];
+    if (!newest) return false;
+
+    const containerRect = ref.getBoundingClientRect();
+    const msgRect = newest.getBoundingClientRect();
+
+    return (
+      msgRect.top < containerRect.bottom && msgRect.bottom > containerRect.top
+    );
+  }
 
   function consumeDOMUpdate(update?: ListView2Update) {
     if (!update) return;
 
     suppressSnap = true;
-    wasAtBottom = false;
 
     const currentRect = update.scrollAnchorId
       ? document.getElementById(update.scrollAnchorId)?.getBoundingClientRect()
@@ -123,8 +132,8 @@ export function ListView2(props: Props) {
     if (!el) return;
 
     const onScroll = () => {
-      if (!suppressSnap) {
-        wasAtBottom = el.scrollTop >= -BOTTOM_THRESHOLD;
+      if (!suppressSnap && !contentMutating) {
+        wasSnapped = isNewestMessageVisible();
       }
     };
 
@@ -136,14 +145,24 @@ export function ListView2(props: Props) {
     const el = contentRef;
     if (!el) return;
 
-    const observer = new ResizeObserver(() => {
-      if (!suppressSnap && wasAtBottom && ref && ref.scrollTop < 0) {
-        ref.scrollTop = 0;
+    const mutationObserver = new MutationObserver(() => {
+      contentMutating = true;
+    });
+
+    mutationObserver.observe(el, { childList: true, subtree: true });
+
+    const resizeObserver = new ResizeObserver(() => {
+      contentMutating = false;
+      if (!suppressSnap && ref && wasSnapped && ref.scrollTop < 0) {
+        ref.scrollTo({ top: 0, behavior: "smooth" });
       }
     });
 
-    observer.observe(el);
-    onCleanup(() => observer.disconnect());
+    resizeObserver.observe(el);
+    onCleanup(() => {
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+    });
   });
 
   return (


### PR DESCRIPTION
Potential fix for #660 and #700

In Chromium environments (including Electron, so this affects the desktop apps too), I've found the existing auto-scroll to be quite fragile, breaking fairly often (multiple times an hour) from regular usage. Every time it happens, it requires switching chat channels or pressing `Esc` a couple times to get it functioning again. It's a minor nuisance, but it does get frustrating. I was unable to reproduce the issue on Firefox, which is why I'm assuming this is a Chromium specific issue.

To get around what appears to be a CSS issue on Chromium, I've added a scroll event listener and ResizeObserver/MutationObserver that will keep the chat history snapped to the bottom as long as the most recent message was still visible (even partially).

Live example of the two instances side-by-side (in Brave browser), mimicking actions (left prod, right local). You can see prod lost auto scroll (scrolling back down does **not** re-engage the scrolling).
<img width="3300" height="1204" alt="stoat" src="https://github.com/user-attachments/assets/d608f9c8-fd70-41ae-bdca-841853fa484e" />

NOTE: While I have tested this in a browser environment, I have **not** tested this inside a local Electron instance.

Feedback is welcome, this is my first contribution to both Stoat and a Solid.js project in general (more of a Vue/Nuxt guy).