### PR TITLE
fix(auth): skip email-check screen when server email is disabled

### DIFF
--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -34,13 +34,27 @@ export default function FlowCreate() {
       captcha,
     });
 
-    // FIXME: should tell client if email was sent
-    //        or if email even needs to be confirmed
+    let requiresEmailVerification = true;
 
-    // TODO: log straight in if no email confirmation?
+    try {
+      const config = (await api.get("/")) as {
+        features?: {
+          email?: boolean;
+        };
+      };
 
-    setFlowCheckEmail(email);
-    navigate("/login/check", { replace: true });
+      requiresEmailVerification = config.features?.email !== false;
+    } catch {
+      // Keep existing behavior if config is unavailable.
+      requiresEmailVerification = true;
+    }
+
+    if (requiresEmailVerification) {
+      setFlowCheckEmail(email);
+      navigate("/login/check", { replace: true });
+    } else {
+      navigate("/login/auth", { replace: true });
+    }
   }
 
   return (


### PR DESCRIPTION
Summary

After successful account creation in the signup flow:

Fetch server configuration via GET /.

Read features.email from the response.

If email is disabled, navigate directly to /login/auth.

If the config fetch fails, retain existing fallback behavior and route to /login/check.


This resolves #759 and provides an alternative to #760 that does not depend on javascript-client-sdk configuration loading timing.


Why

The previous implementation relied on client SDK config initialization timing, which can introduce race conditions.
This approach explicitly fetches server config after signup, making the flow deterministic and independent of SDK load order.


Validation

Attempted:

./node_modules/.bin/tsc -p tsconfig.json --noEmit

(executed in packages/client)

Result: Blocked by a pre-existing base branch issue:

TS2688: Cannot find type definition file for '@testing-library/jest-dom'