### PR TITLE
fix: role hierarchy enforcement

### DIFF
--- a/packages/client/components/app/interface/settings/server/roles/ServerRoleOverview.tsx
+++ b/packages/client/components/app/interface/settings/server/roles/ServerRoleOverview.tsx
@@ -1,13 +1,20 @@
 import { BiRegularListUl } from "solid-icons/bi";
-import { Show } from "solid-js";
+import { Show, createMemo } from "solid-js";
 
-import { Trans } from "@lingui-solid/solid/macro";
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { useMutation } from "@tanstack/solid-query";
 import { Server } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
 import { useModals } from "@revolt/modal";
-import { CategoryButton, Column, Draggable, Text, iconSize } from "@revolt/ui";
+import {
+  CategoryButton,
+  Column,
+  Draggable,
+  Text,
+  Tooltip,
+  iconSize,
+} from "@revolt/ui";
 import { createDragHandle } from "@revolt/ui/components/utils/Draggable";
 
 import MdDragIndicator from "@material-design-icons/svg/outlined/drag_indicator.svg?component-solid";
@@ -21,6 +28,7 @@ import { useSettingsNavigation } from "../../Settings";
 export function ServerRoleOverview(props: { context: Server }) {
   const { navigate } = useSettingsNavigation();
   const { openModal, showError } = useModals();
+  const { t } = useLingui();
 
   const change = useMutation(() => ({
     mutationFn: (order: string[]) => props.context.setRoleOrdering(order),
@@ -35,6 +43,83 @@ export function ServerRoleOverview(props: { context: Server }) {
         navigate(`roles/${roleId}`);
       },
     });
+  }
+
+  const originalAssignedRoleRanks = createMemo(() => {
+    const member = props.context.member;
+    if (!member) return [];
+    const result = [];
+    for (const id of member.roles) {
+      const role = props.context.roles.get(id);
+      if (role) {
+        result.push({
+          id: id,
+          rank: role.rank ?? Infinity,
+        });
+      }
+    }
+    return result;
+  });
+
+  // Highest Rank is needed to determine which roles the user can manage.
+  function getMyHighestRank() {
+    const server = props.context;
+    const member = server.member;
+
+    if (member && member.user && member.user.id === server.ownerId) {
+      return -Infinity;
+    }
+
+    const ranks = originalAssignedRoleRanks();
+    if (ranks.length === 0) {
+      return Infinity;
+    }
+
+    let minRank = Infinity;
+    for (const r of ranks) {
+      if (r.rank < minRank) {
+        minRank = r.rank;
+      }
+    }
+    return minRank;
+  }
+
+  function handleReorder(newOrder: string[]) {
+    const roles = props.context.orderedRoles;
+    const myRank = getMyHighestRank();
+
+    let firstMovableIdx = -1;
+    for (let i = 0; i < roles.length; i++) {
+      const rank = roles[i].rank ?? Infinity;
+      if (rank > myRank) {
+        firstMovableIdx = i;
+        break;
+      }
+    }
+    if (firstMovableIdx === -1) return;
+
+    const lockedIds = roles.slice(0, firstMovableIdx).map((r) => r.id);
+    const movableIds = roles.slice(firstMovableIdx).map((r) => r.id);
+
+    const newLocked = [];
+    const newMovable = [];
+    for (const id of newOrder) {
+      if (lockedIds.includes(id)) {
+        newLocked.push(id);
+      } else if (movableIds.includes(id)) {
+        newMovable.push(id);
+      }
+    }
+
+    // If locked roles got moved, put them back at the top.
+    if (newLocked.length < lockedIds.length) {
+      change.mutate([...lockedIds, ...newMovable]);
+      return;
+    }
+    // If locked section is unchanged, allow the new order.
+    if (newLocked.join() === lockedIds.join()) {
+      change.mutate([...newLocked, ...newMovable]);
+    }
   }
 
   return (
@@ -69,32 +154,86 @@ export function ServerRoleOverview(props: { context: Server }) {
         <Draggable
           dragHandles
           items={props.context.orderedRoles}
-          onChange={change.mutate}
+          onChange={handleReorder}
         >
-          {(entry) => (
-            <ItemContainer>
-              <MdDragIndicator
-                fill="var(--md-sys-color-on-surface)"
-                {...createDragHandle(entry.dragDisabled, entry.setDragDisabled)}
-              />
+          {(entry) => {
+            const server = props.context;
+            const member = server.member;
+            const isOwner = member && member.user?.id === server.ownerId;
+            const myRank = getMyHighestRank();
+            const roleRank = entry.item.rank ?? Infinity;
+            // allow moving/editing for roles with a lower rank
+            const canEdit = isOwner || myRank < roleRank;
+            const tooltipMsg = canEdit
+              ? undefined
+              : t`You cannot move or adjust roles equal to or higher than your own.`;
 
-              <CategoryButton
-                icon={
-                  <RoleIcon
+            return tooltipMsg ? (
+              <Tooltip content={tooltipMsg} placement="top">
+                <ItemContainer>
+                  <span
                     style={{
-                      background:
-                        entry.item.colour ??
-                        "var(--md-sys-color-outline-variant)",
+                      opacity: 0.35,
+                      filter: "grayscale(1)",
+                      "pointer-events": "none",
                     }}
-                  />
-                }
-                action="chevron"
-                onClick={() => navigate(`roles/${entry.item.id}`)}
-              >
-                {entry.item.name}
-              </CategoryButton>
-            </ItemContainer>
-          )}
+                  >
+                    <MdDragIndicator
+                      style={{ cursor: "not-allowed" }}
+                      {...createDragHandle(() => true, entry.setDragDisabled)}
+                    />
+                  </span>
+                  <span
+                    style={{
+                      width: "100%",
+                      opacity: 0.35,
+                      filter: "grayscale(1)",
+                    }}
+                  >
+                    <CategoryButton
+                      icon={
+                        <RoleIcon
+                          style={{
+                            background:
+                              entry.item.colour ??
+                              "var(--md-sys-color-outline-variant)",
+                          }}
+                        />
+                      }
+                      action="chevron"
+                      disabled={true}
+                    >
+                      {entry.item.name}
+                    </CategoryButton>
+                  </span>
+                </ItemContainer>
+              </Tooltip>
+            ) : (
+              <ItemContainer>
+                <MdDragIndicator
+                  {...createDragHandle(
+                    entry.dragDisabled,
+                    entry.setDragDisabled,
+                  )}
+                />
+                <CategoryButton
+                  icon={
+                    <RoleIcon
+                      style={{
+                        background:
+                          entry.item.colour ??
+                          "var(--md-sys-color-outline-variant)",
+                      }}
+                    />
+                  }
+                  action="chevron"
+                  onClick={() => navigate(`roles/${entry.item.id}`)}
+                >
+                  {entry.item.name}
+                </CategoryButton>
+              </ItemContainer>
+            );
+          }}
         </Draggable>
       </Column>
     </Column>


### PR DESCRIPTION
Makes the role management UI actually respect the role hierarchy. Now, you can only drag and reorder roles that are below your own highest role, owner can still modify all the roles

Required -> https://github.com/stoatchat/javascript-client-sdk/pull/128

![firefox_EfYNKOJGAB](https://github.com/user-attachments/assets/8555e7ee-7791-490b-9e35-3369c3c20822)


![electron_xxQJnqkaXt](https://github.com/user-attachments/assets/6dfa9f9d-2cfd-428e-b5d6-0f0775b2ffa2)
