### PR TITLE
fix(file-input): reject unsupported image formats on upload

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,7 @@ let
 
 in pkgs.mkShell {
   packages = with pkgs; [
+    nodejs_24
     mise
     cargo-binstall
     (writeShellScriptBin "fish" ''

--- a/packages/client/components/state/stores/Draft.ts
+++ b/packages/client/components/state/stores/Draft.ts
@@ -90,6 +90,11 @@ export const ALLOWED_IMAGE_TYPES = [
 ];
 
 /**
+ * Human-readable labels for each entry in ALLOWED_IMAGE_TYPES (same order)
+ */
+export const ALLOWED_IMAGE_TYPE_LABELS = ["JPEG", "PNG", "GIF", "WebP"];
+
+/**
  * Message drafts store
  */
 export class Draft extends AbstractStore<"draft", TypeDraft> {

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -160,7 +160,7 @@ const FormFileInput = (
             const file = files[0];
             if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
               const error = new Error(
-                t`The file "${file.name}" has an unsupported format.`,
+                t`The file "${file.name}" has an unsupported format. Supported formats are: JPEG, PNG, GIF, and WebP.`,
               );
               error.name = t`Unsupported file format`;
               openModal({ type: "error2", error });

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -5,8 +5,8 @@ import {
   For,
   Match,
   Show,
-  Switch,
   splitProps,
+  Switch,
 } from "solid-js";
 
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
@@ -15,7 +15,10 @@ import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { useModals } from "../../../modal";
-import { ALLOWED_IMAGE_TYPES } from "../../../state/stores/Draft";
+import {
+  ALLOWED_IMAGE_TYPE_LABELS,
+  ALLOWED_IMAGE_TYPES,
+} from "../../../state/stores/Draft";
 
 import { Button, Checkbox, Radio2, Text, TextField } from "../design";
 import { TextEditor2 } from "../features/texteditor/TextEditor2";
@@ -159,8 +162,9 @@ const FormFileInput = (
           if (files && remote.accept === "image/*") {
             const file = files[0];
             if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+              const formatList = ALLOWED_IMAGE_TYPE_LABELS.join(", ");
               const error = new Error(
-                t`The file "${file.name}" has an unsupported format. Supported formats are: JPEG, PNG, GIF, and WebP.`,
+                t`The file "${file.name}" has an unsupported format. Supported formats are: ${formatList}.`,
               );
               error.name = t`Unsupported file format`;
               openModal({ type: "error2", error });

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -9,10 +9,13 @@ import {
   splitProps,
 } from "solid-js";
 
-import { Trans } from "@lingui-solid/solid/macro";
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { VirtualContainer } from "@minht11/solid-virtual-container";
 import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
+
+import { useModals } from "../../../modal";
+import { ALLOWED_IMAGE_TYPES } from "../../../state/stores/Draft";
 
 import { Button, Checkbox, Radio2, Text, TextField } from "../design";
 import { TextEditor2 } from "../features/texteditor/TextEditor2";
@@ -138,6 +141,11 @@ const FormFileInput = (
   >,
 ) => {
   const [local, remote] = splitProps(props, ["label", "control"]);
+  const { t } = useLingui();
+  const { openModal } = useModals();
+
+  // track last accepted value so we can restore it if an invalid file is rejected
+  let lastAcceptedValue = local.control.value;
 
   return (
     <>
@@ -148,8 +156,22 @@ const FormFileInput = (
         {...remote}
         file={local.control.value}
         onFiles={(files) => {
-          // TODO: do validation of files here
+          if (files && remote.accept === "image/*") {
+            const file = files[0];
+            if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+              const error = new Error(
+                t`The file "${file.name}" has an unsupported format.`,
+              );
+              error.name = t`Unsupported file format`;
+              openModal({ type: "error2", error });
+              // FileInput resets to null before passing the new file for
+              // reactivity reasons, so restore the last accepted value
+              local.control.setValue(lastAcceptedValue);
+              return;
+            }
+          }
 
+          if (files) lastAcceptedValue = files;
           local.control.setValue(files);
           local.control.markDirty(true);
         }}


### PR DESCRIPTION
# Summary
## [Fixes #859 ](https://github.com/stoatchat/for-web/issues/859)
The server banner (and other image file inputs) allowed .avif and other unsupported formats to be selected and submitted, despite the backend rejecting them.

# What changed
Form2.FileInput now validates the selected file's MIME type against the list of supported image formats (image/jpeg, image/png, image/gif, image/webp) before accepting it. If an unsupported format is chosen, an error modal is shown and the file is not set on the form control.
This is enforced in the shared Form2.FileInput wrapper, so it covers all image upload inputs across the app (server banners, user profile banners, server icons, channel icons, avatars, and webhook avatars).

# Testing
Try uploading an .avif file to the server banner, you should now see an error modal with the message "The file '...' has an unsupported format." and the banner should remain unchanged.