### PR TITLE
fix: ensure mfa ticket is created before deleting server

### DIFF
--- a/packages/client/components/modal/modals/DeleteServer.tsx
+++ b/packages/client/components/modal/modals/DeleteServer.tsx
@@ -19,8 +19,10 @@ export function DeleteServerModal(
   const deleteServer = useMutation(() => ({
     mutationFn: async () => {
       const mfa = await client().account.mfa();
-      await mfaFlow(mfa as never);
-      await props.server.delete(); // TODO: should use ticket in API
+      const ticket = await mfaFlow(mfa);
+      if (ticket) {
+        await props.server.delete();
+      }
     },
     onError: showError,
   }));


### PR DESCRIPTION
Closes: https://github.com/stoatchat/for-web/issues/874

Before `await mfaFlow(mfa)` was called without checking its result if MFA failed the promise rejected → `onError` triggered, but the code continued to `props.server.delete()`
