### PR TITLE
feat: show file size limits where applicable

### DIFF
--- a/packages/client/components/app/interface/settings/channel/Overview.tsx
+++ b/packages/client/components/app/interface/settings/channel/Overview.tsx
@@ -106,7 +106,14 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
           <Text class="label">
             <Trans>Channel Info</Trans>
           </Text>
-          <Form2.FileInput control={editGroup.controls.icon} accept="image/*" />
+          <Form2.FileInput
+            control={editGroup.controls.icon}
+            accept="image/*"
+            maxSize={
+              client().configuration?.features.limits.default
+                .file_upload_size_limits["icons"] ?? 2.5e6
+            }
+          />
           <Form2.TextField
             minlength={1}
             maxlength={32}

--- a/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
+++ b/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
@@ -97,6 +97,10 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
             accept="image/*"
             label={t`Webhook Icon`}
             imageJustify={false}
+            maxSize={
+              client().configuration?.features.limits.default
+                .file_upload_size_limits["icons"] ?? 4e6
+            }
           />
           <Form2.TextField
             name="name"

--- a/packages/client/components/app/interface/settings/server/Overview.tsx
+++ b/packages/client/components/app/interface/settings/server/Overview.tsx
@@ -224,6 +224,10 @@ export default function ServerOverview(props: ServerSettingsProps) {
             accept="image/*"
             label={t`Server Icon`}
             imageJustify={false}
+            maxSize={
+              client().configuration?.features.limits.default
+                .file_upload_size_limits["icons"] ?? 2.5e5
+            }
           />
           <Form2.FileInput
             control={editGroup.controls.banner}
@@ -232,6 +236,10 @@ export default function ServerOverview(props: ServerSettingsProps) {
             imageAspect="232/100"
             imageRounded={false}
             imageJustify={false}
+            maxSize={
+              client().configuration?.features.limits.default
+                .file_upload_size_limits["banners"] ?? 6e6
+            }
           />
           <Form2.TextField
             minlength={1}

--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -81,8 +81,10 @@ export function EmojiList(props: { server: Server }) {
                 accept="image/*"
                 imageJustify={false}
                 allowRemoval={false}
-                // TODO: Replace this with limit
-                maxSize={500_000}
+                maxSize={
+                  client().configuration?.features.limits.default
+                    .file_upload_size_limits["emojis"] ?? 5e5
+                }
                 hideErrors={true}
               />
             </Column>

--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -160,6 +160,10 @@ export function UserProfileEditor(props: Props) {
           accept="image/*"
           label={t`Avatar`}
           imageJustify={false}
+          maxSize={
+            client().configuration?.features.limits.default
+              .file_upload_size_limits["avatars"] ?? 4e6
+          }
         />
         <Form2.FileInput
           control={editGroup.controls.banner}
@@ -168,6 +172,10 @@ export function UserProfileEditor(props: Props) {
           imageAspect="232/100"
           imageRounded={false}
           imageJustify={false}
+          maxSize={
+            client().configuration?.features.limits.default
+              .file_upload_size_limits["background"] ?? 6e6
+          }
         />
         <Form2.TextField
           minlength={2}

--- a/packages/client/components/modal/modals/ServerIdentity.tsx
+++ b/packages/client/components/modal/modals/ServerIdentity.tsx
@@ -118,6 +118,10 @@ export function ServerIdentityModal(
               accept="image/*"
               label={t`Server Avatar`}
               imageJustify={false}
+              maxSize={
+                client().configuration?.features.limits.default
+                  .file_upload_size_limits["avatars"] ?? 4e6
+              }
             />
           </Show>
           <Form2.TextField

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -22,6 +22,7 @@ import {
   Radio2,
   Text,
   TextField,
+  typography,
 } from "../design";
 import { TextEditor2 } from "../features/texteditor/TextEditor2";
 import { Row } from "../layout";
@@ -194,6 +195,11 @@ const FormFileInput = (
         required={local.control.isRequired}
         disabled={local.control.isDisabled}
       />
+      <Show when={local.maxSize}>
+        <span class={typography({ class: "label", size: "small" })}>
+          (max. {humanFileSize(local.maxSize!)})
+        </span>
+      </Show>
       <Show
         when={
           !local.hideErrors && local.control.isTouched && !local.control.isValid

--- a/packages/client/components/ui/components/utils/files/FileInput.tsx
+++ b/packages/client/components/ui/components/utils/files/FileInput.tsx
@@ -4,7 +4,6 @@ import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { ALLOWED_IMAGE_TYPES } from "@revolt/state";
-
 import { Button, Ripple } from "../../design";
 import { Row } from "../../layout";
 import { Symbol } from "../Symbol";
@@ -145,6 +144,7 @@ export function FileInput(props: Props) {
               <img src={imageSrc()} />
             </Show>
           </ImagePreview>
+
           <Show when={props.allowRemoval !== false}>
             <Button
               size="icon"


### PR DESCRIPTION
Should clear up some confusion about what the file size limits are across the app. Obviously, the app needs a way to get this from the backend (ideally via the root endpoint), but for now this shall suffice.

# Screenshots
<img width="536" height="467" alt="image" src="https://github.com/user-attachments/assets/e3a87955-07fc-4f3a-bdca-e833ad0dae3e" />
<img width="1166" height="252" alt="image" src="https://github.com/user-attachments/assets/1341ba0b-d7ee-46fc-ad78-13d864f92b56" />
<img width="615" height="455" alt="image" src="https://github.com/user-attachments/assets/511408f6-a20d-4e02-a691-224adb24649d" />
