### PR TITLE
fix: zoomed-in browser view hiding thumbnails

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -230,7 +230,6 @@ const Body = styled("div", {
 
     minWidth: 0,
     overflow: "hidden",
-    maxHeight: "200vh",
     paddingInlineEnd: "var(--gap-lg)",
   },
   variants: {


### PR DESCRIPTION
removed max-height: 200vh causing thumbnails to overflow and be hidden in message container. preventing too many images from being sent should not be handled by arbitrary height enforcement.

fixes issue #877
