### PR TITLE
feat: implement scrollable message input with 15-line limit

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/MessageBox.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/MessageBox.tsx
@@ -96,13 +96,16 @@ const Base = styled("div", {
   base: {
     flexGrow: 1,
 
-    paddingInlineEnd: "var(--gap-md)",
-    paddingBlock: "var(--gap-sm)",
+    paddingInlineEnd: "0",
+    paddingBlock: "0",
     borderStartRadius: "var(--borderRadius-xl)",
 
     display: "flex",
     background: "var(--md-sys-color-surface-container-high)",
     color: "var(--md-sys-color-on-surface)",
+
+    maxHeight: "calc(15 * 1.5 * var(--message-size) + 16px)",
+    position: "relative",
   },
   variants: {
     hasActionsAppend: {
@@ -131,6 +134,33 @@ const Parent = styled("div", {
 });
 
 /**
+ * Scrollable content area
+ */
+const Content = styled("div", {
+  base: {
+    display: "flex",
+    flexGrow: 1,
+    overflowY: "auto",
+    paddingInlineEnd: "var(--gap-md)",
+    paddingBlock: "var(--gap-sm)",
+
+    "&::-webkit-scrollbar": {
+      width: "8px",
+    },
+    "&::-webkit-scrollbar-track": {
+      background: "transparent",
+    },
+    "&::-webkit-scrollbar-thumb": {
+      background: "var(--md-sys-color-surface-container-highest)",
+      borderRadius: "10px",
+    },
+    "&::-webkit-scrollbar-thumb:hover": {
+      background: "var(--md-sys-color-on-surface-variant)",
+    },
+  },
+});
+
+/**
  * Blocked message
  */
 const Blocked = styled(Row, {
@@ -151,6 +181,7 @@ export const InlineIcon = styled("div", {
     display: "flex",
     alignItems: "end",
     justifyContent: "center",
+    paddingBlock: "var(--gap-sm)",
   },
   variants: {
     size: {
@@ -195,31 +226,33 @@ export function MessageBox(props: Props) {
             </InlineIcon>
           </Match>
         </Switch>
-        <Switch
-          fallback={
-            <>
-              <TextEditor2
-                placeholder={props.placeholder}
-                initialValue={props.initialValue}
-                nodeReplacement={props.nodeReplacement}
-                onChange={props.setContent}
-                onComplete={props.onSendMessage}
-                onTyping={props.onTyping}
-                onPreviousContext={props.onEditLastMessage}
-                autoCompleteSearchSpace={props.autoCompleteSearchSpace}
-              />
-              <Show when={props.sendingAllowed}>{props.actionsEnd}</Show>
-            </>
-          }
-        >
-          <Match when={!props.sendingAllowed}>
-            <Blocked align>
-              <Trans>
-                You don't have permission to send messages in this channel.
-              </Trans>
-            </Blocked>
-          </Match>
-        </Switch>
+        <Content>
+          <Switch
+            fallback={
+              <>
+                <TextEditor2
+                  placeholder={props.placeholder}
+                  initialValue={props.initialValue}
+                  nodeReplacement={props.nodeReplacement}
+                  onChange={props.setContent}
+                  onComplete={props.onSendMessage}
+                  onTyping={props.onTyping}
+                  onPreviousContext={props.onEditLastMessage}
+                  autoCompleteSearchSpace={props.autoCompleteSearchSpace}
+                />
+              </>
+            }
+          >
+            <Match when={!props.sendingAllowed}>
+              <Blocked align>
+                <Trans>
+                  You don't have permission to send messages in this channel.
+                </Trans>
+              </Blocked>
+            </Match>
+          </Switch>
+        </Content>
+        <Show when={props.sendingAllowed}>{props.actionsEnd}</Show>
       </Base>
       <Show when={props.sendingAllowed}>{props.actionsAppend}</Show>
     </Parent>

--- a/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
+++ b/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
@@ -244,7 +244,6 @@ export function TextEditor2(props: Props) {
 
 const editor = css({
   display: "inline-flex",
-  height: "100%",
   width: "100%",
   flexGrow: 1,
   alignSelf: "center",
@@ -257,7 +256,10 @@ const editor = css({
 
   "& .cm-editor": {
     width: "100%",
-    alignSelf: "center",
+  },
+
+  "& .cm-scroller": {
+    overflow: "visible",
   },
 
   "& .cm-editor.cm-focused": {


### PR DESCRIPTION
Hello dear developers,

I’ve updated the message input field to improve the user experience with long messages. Now, after 15 line breaks, the field stops expanding and automatically enables a scrollbar. This prevents the input area from becoming excessively large and taking up too much screen space, much like how it works on Discord.

I've attached two videos to demonstrate the change:

The first image shows how it was before (unchecked expansion).
The second image shows the new behavior with the scrollable field and fixed action buttons.
This keeps the interface clean and ensures the action buttons (GIF, Emoji, etc.) stay fixed and accessible at the bottom.

What do you think about this update? I'd love to hear your thoughts or any feedback you might have!
<img width="1407" height="1007" alt="image" src="https://github.com/user-attachments/assets/b08beddc-d928-4a59-aead-597f4ca3c1d4" />
<img width="1326" height="940" alt="image" src="https://github.com/user-attachments/assets/3b95a3ad-7c59-4754-86c9-7b88e5a74377" />
