### PR TITLE
feat(client): improve permissions editor readability

### DIFF
--- a/packages/client/components/app/interface/settings/channel/permissions/ChannelPermissionsEditor.tsx
+++ b/packages/client/components/app/interface/settings/channel/permissions/ChannelPermissionsEditor.tsx
@@ -421,7 +421,13 @@ export function ChannelPermissionsEditor(props: Props) {
   }
 
   return (
-    <div class={css({ display: "flex", flexDirection: "column" })}>
+    <div
+      class={css({
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--gap-md)",
+      })}
+    >
       <For each={Permissions}>
         {(entry) => (
           <Show when={description(entry)}>
@@ -534,10 +540,22 @@ function ChannelPermissionToggle(props: {
           marginStart: "var(--gap-md)",
           display: "flex",
           flexDirection: "column",
+          gap: "2px",
+          minWidth: 0,
+          paddingBlock: "var(--gap-sm)",
         })}
       >
         <Text size="large">{props.title}</Text>
-        <Text>{props.description}</Text>
+        <Text class="body" size="small">
+          <span
+            class={css({
+              color: "var(--md-sys-color-outline)",
+              lineHeight: 1.2,
+            })}
+          >
+            {props.description}
+          </span>
+        </Text>
       </div>
     </Checkbox2>
   );
@@ -558,6 +576,7 @@ function ChannelPermissionOverride(props: {
       class={css({
         gap: "var(--gap-md)",
         display: "flex",
+        paddingBlock: "var(--gap-sm)",
       })}
     >
       <div
@@ -565,10 +584,21 @@ function ChannelPermissionOverride(props: {
           flexGrow: 1,
           display: "flex",
           flexDirection: "column",
+          gap: "2px",
+          minWidth: 0,
         })}
       >
         <Text size="large">{props.title}</Text>
-        <Text>{props.description}</Text>
+        <Text class="body" size="small">
+          <span
+            class={css({
+              color: "var(--md-sys-color-outline)",
+              lineHeight: 1.2,
+            })}
+          >
+            {props.description}
+          </span>
+        </Text>
       </div>
       <OverrideSwitch
         disabled={!props.havePermission}


### PR DESCRIPTION
## Summary

Improves the readability of the channel permissions editor by adding spacing and clearer typography for permission descriptions.

## Changes

- Added consistent vertical spacing between permission rows and sections.
- Rendered permission descriptions as a smaller, muted secondary line under the title.
- Added vertical padding to checkbox-based permission rows for better scanability.

## Files Touched

- `packages/client/components/app/interface/settings/channel/permissions/ChannelPermissionsEditor.tsx`

## Testing

1. Open **Permissions > Default Permissions**.
2. Verify each permission row has proper vertical spacing.
3. Confirm the description appears on a second line under the title.
4. Ensure checkbox rows have improved vertical padding and better visual clarity.

Before :

<img width="1173" height="842" alt="image" src="https://github.com/user-attachments/assets/f459fe1b-0257-4ee1-96a1-cefe18000bdf" />


After :

<img width="911" height="821" alt="image" src="https://github.com/user-attachments/assets/36349a77-888a-4cae-a841-d83bf7dfa4a8" />
