### PR TITLE
feat: set 60% opacity for read-only channels

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/MessageBox.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/MessageBox.tsx
@@ -139,6 +139,7 @@ const Blocked = styled(Row, {
     fontSize: "14px",
     userSelect: "none",
     padding: "var(--gap-md)",
+    opacity: 0.6,
   },
 });
 


### PR DESCRIPTION
closes #926

The `Blocked` styled component has been updated with an `opacity: 0.6` style rule. As a result, in channels where the user lacks messaging permissions, the entire message input field (including icons) will now appear with 60% opacity. This provides stronger **visual feedback** to the user regarding their current interaction state, aligning with the project's requirement that all nodes/states should have corresponding visual indicators.

---

<img width="587" height="199" alt="image" src="https://github.com/user-attachments/assets/47289ea9-3c5a-46e8-9ecb-bfb1a8c2e5b3" />

---

<img width="588" height="200" alt="image" src="https://github.com/user-attachments/assets/27849396-4b6d-43b0-85ea-1bb4d756e7f0" />
