### PR TITLE
feat: add automatic gain control to voice processing options

### DIFF
--- a/packages/client/components/app/interface/settings/user/voice/VoiceProcessingOptions.tsx
+++ b/packages/client/components/app/interface/settings/user/voice/VoiceProcessingOptions.tsx
@@ -26,6 +26,15 @@ export function VoiceProcessingOptions() {
         >
           <Trans>Browser Echo Cancellation</Trans>
         </CategoryButton>
+        <CategoryButton
+          icon="blank"
+          action={<Checkbox checked={state.voice.autoGainControl} />}
+          onClick={() =>
+            (state.voice.autoGainControl = !state.voice.autoGainControl)
+          }
+        >
+          <Trans>Automatic Gain Control</Trans>
+        </CategoryButton>
       </CategoryButton.Group>
     </Column>
   );

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -92,6 +92,7 @@ class Voice {
         deviceId: this.#settings.preferredAudioInputDevice,
         echoCancellation: this.#settings.echoCancellation,
         noiseSuppression: this.#settings.noiseSupression === "browser",
+        autoGainControl: this.#settings.autoGainControl,
       },
       audioOutput: {
         deviceId: this.#settings.preferredAudioOutputDevice,

--- a/packages/client/components/state/stores/Voice.ts
+++ b/packages/client/components/state/stores/Voice.ts
@@ -19,6 +19,7 @@ export interface TypeVoice {
 
   echoCancellation: boolean;
   noiseSupression: NoiseSuppresionState;
+  autoGainControl: boolean;
 
   inputVolume: number;
   outputVolume: number;
@@ -53,6 +54,7 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
     return {
       echoCancellation: true,
       noiseSupression: "browser",
+      autoGainControl: true,
       inputVolume: 1.0,
       outputVolume: 1.0,
       userVolumes: {},
@@ -88,6 +90,10 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
       NoiseSuppresionStates.includes(input.noiseSupression)
     ) {
       data.noiseSupression = input.noiseSupression;
+    }
+
+    if (typeof input.autoGainControl === "boolean") {
+      data.autoGainControl = input.autoGainControl;
     }
 
     if (typeof input.inputVolume === "number") {
@@ -183,6 +189,13 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
   }
 
   /**
+   * Set auto gain control
+   */
+  set autoGainControl(value: boolean) {
+    this.set("autoGainControl", value);
+  }
+
+  /**
    * Set input volume
    */
   set inputVolume(value: number) {
@@ -222,6 +235,13 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
    */
   get noiseSupression(): NoiseSuppresionState | undefined {
     return this.get().noiseSupression;
+  }
+
+  /**
+   * Get auto gain control
+   */
+  get autoGainControl(): boolean | undefined {
+    return this.get().autoGainControl;
   }
 
   /**


### PR DESCRIPTION
Closes #563 by allowing disabling of automatic gain control.

Many users (myself included) do not like automatic gain control. By default, livekit has it enabled. This PR adds a voice processing option to disable automatic gain control, with the default value being on.