### PR TITLE
fix: nested textfield labels in Form

### DIFF
--- a/packages/client/components/auth/src/flows/Form.tsx
+++ b/packages/client/components/auth/src/flows/Form.tsx
@@ -66,11 +66,12 @@ export function Fields(props: FieldProps) {
   return (
     <For each={props.fields}>
       {(field) => (
-        <label>
-          {field === "log-out" ? (
-            <Checkbox2 name="log-out">
-              {fieldConfiguration["log-out"].name()}
-            </Checkbox2>
+          field === "log-out" ? (
+            <label>
+              <Checkbox2 name="log-out">
+                {fieldConfiguration["log-out"].name()}
+              </Checkbox2>
+            </label>
           ) : (
             <TextField
               required
@@ -79,8 +80,7 @@ export function Fields(props: FieldProps) {
               label={fieldConfiguration[field].name()}
               placeholder={fieldConfiguration[field].placeholder()}
             />
-          )}
-        </label>
+          )
       )}
     </For>
   );


### PR DESCRIPTION
`mdui` text fields already contains a `label` so, they shouldn't be put in another. This nested label had the effect of breaking the cursor change when hovering the component.
https://github.com/stoatchat/for-web/blob/addb6b7c84bf3852691f3311470e714bbe9b5522/packages/client/components/auth/src/flows/Form.tsx#L69-L83

Before :
<img width="369" height="488" alt="image" src="https://github.com/user-attachments/assets/53716681-431f-4283-b25f-54e93fd7e680" />
After :
<img width="370" height="489" alt="image" src="https://github.com/user-attachments/assets/46f1120d-f891-4a84-aae7-e018a4163ee0" />

Let me know if this was intentional or if there is something else to change.