### PR TITLE
feat(registration): allow registration with invitation code 

### DIFF
--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -27,11 +27,13 @@ export default function FlowCreate() {
     const email = data.get("email") as string;
     const password = data.get("password") as string;
     const captcha = data.get("captcha") as string;
+    const invite = new URLSearchParams(window.location.search).get("invite") || undefined;
 
     await api.post("/auth/account/create", {
       email,
       password,
       captcha,
+      ...(invite ? { invite } : {}),
     });
 
     // FIXME: should tell client if email was sent

--- a/packages/client/e2e/invite-registration.spec.ts
+++ b/packages/client/e2e/invite-registration.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import type { Route } from "@playwright/test";
+
+/**
+ * Set value on an mdui-text-field and its associated form field
+ */
+async function fillField(page: import("@playwright/test").Page, name: string, value: string) {
+  await page.locator(`mdui-text-field[name="${name}"]`).evaluate((el, val) => {
+    const field = el as HTMLElement & { value: string; name: string };
+    field.value = val;
+    // Ensure the web component participates in FormData by setting a hidden input fallback
+    const form = field.closest("form");
+    if (form) {
+      let hidden = form.querySelector(`input[data-wc-name="${field.name}"]`) as HTMLInputElement | null;
+      if (!hidden) {
+        hidden = document.createElement("input");
+        hidden.type = "hidden";
+        hidden.name = field.name;
+        hidden.dataset.wcName = field.name;
+        form.appendChild(hidden);
+      }
+      hidden.value = val;
+    }
+  }, value);
+}
+
+test.describe("invite code registration", () => {
+  test("includes invite code in account creation request when present in URL", async ({
+    page,
+  }) => {
+    const inviteCode = "TESTINVITECODE";
+
+    // Intercept the account creation request and capture its body
+    const requestPromise = new Promise<Record<string, unknown>>((resolve) => {
+      page.route(/\/auth\/account\/create/, async (route: Route) => {
+        resolve(route.request().postDataJSON());
+        await route.fulfill({ status: 200, body: JSON.stringify({}) });
+      });
+    });
+
+    await page.goto(`/login/create?invite=${inviteCode}`);
+    await page.locator("mdui-text-field[name='email']").waitFor();
+
+    await fillField(page, "email", "test@example.com");
+    await fillField(page, "password", "password123");
+
+    await page.evaluate(() =>
+      document.querySelector("form")!.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+    );
+
+    const body = await requestPromise;
+    expect(body.invite).toBe(inviteCode);
+  });
+
+  test("does not include invite code in account creation request when absent from URL", async ({
+    page,
+  }) => {
+    const requestPromise = new Promise<Record<string, unknown>>((resolve) => {
+      page.route(/\/auth\/account\/create/, async (route: Route) => {
+        resolve(route.request().postDataJSON());
+        await route.fulfill({ status: 200, body: JSON.stringify({}) });
+      });
+    });
+
+    await page.goto("/login/create");
+    await page.locator("mdui-text-field[name='email']").waitFor();
+
+    await fillField(page, "email", "test@example.com");
+    await fillField(page, "password", "password123");
+
+    await page.evaluate(() =>
+      document.querySelector("form")!.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+    );
+
+    const body = await requestPromise;
+    expect(body.invite).toBeUndefined();
+  });
+});


### PR DESCRIPTION
when the admin create the invitation code as and create a link with it : 
https://${DOMAIN}/login/create?invite=${INVITE_REGISTRATION_CODE}

the user will copy in a browser enter his mail and password : 

<img width="406" height="587" alt="Capture d&#39;écran 2026-02-28 222202" src="https://github.com/user-attachments/assets/52d6ffbe-25d9-4adb-93e4-13a501c0d441" />

validate we can see in the console that the code is passed: 
<img width="374" height="431" alt="Capture d&#39;écran 2026-02-28 221640" src="https://github.com/user-attachments/assets/77691230-ccd1-4971-9493-94563e70472c" />
<img width="682" height="58" alt="Capture d&#39;écran 2026-02-28 221606" src="https://github.com/user-attachments/assets/932997d3-d9c9-4852-882e-84680ed1fbf8" />

if we use a bad code (not in mongo) it will tell that the code is invalid and the account will not be created: 


<img width="415" height="556" alt="Capture d&#39;écran 2026-02-28 222415" src="https://github.com/user-attachments/assets/d137f7e8-a234-4bc2-bb88-3a702d32fce1" />
<img width="372" height="399" alt="image" src="https://github.com/user-attachments/assets/aa615979-0e24-44d1-8b75-3e31a304f6ff" />

tests : 

<img width="1014" height="291" alt="image" src="https://github.com/user-attachments/assets/4768385d-670e-4165-8fca-3915da1c5f7a" />
