### PR TITLE
chore: add pnpm and nodejs to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,8 @@ let
 in pkgs.mkShell {
   packages = with pkgs; [
     mise
+    pnpm
+    nodejs_latest
     cargo-binstall
     (writeShellScriptBin "fish" ''
       exec ${pkgs.fish}/bin/fish -C 'mise activate fish | source' "$@"


### PR DESCRIPTION
When using nix, you typically do not install development packages like node system-wide, but instead install them in a devshell. I have added these two packages to make the devshell more complete.