### PR TITLE
feat: add recently used emojis to picker and autocomplete

### DIFF
--- a/packages/client/components/state/stores/Settings.ts
+++ b/packages/client/components/state/stores/Settings.ts
@@ -68,6 +68,11 @@ interface SettingsDefinition {
    * Last read changelog index
    */
   "changelog:last_index": number;
+
+  /**
+   * Recently used emojis (LRU)
+   */
+  "recent_emojis": string[];
 }
 
 /**
@@ -95,6 +100,11 @@ const EXPECTED_TYPES: { [K in keyof SettingsDefinition]: ValueType<K> } = {
   "advanced:copy_id": "boolean",
   "advanced:admin_panel": "boolean",
   "changelog:last_index": "number",
+  "recent_emojis": (v) => {
+    if (!Array.isArray(v)) return undefined;
+
+    return [...new Set(v.filter((x): x is string => typeof x === "string"))].slice(0, 50);
+  },
 };
 
 /**
@@ -136,6 +146,7 @@ export class Settings extends AbstractStore<"settings", TypeSettings> {
       "appearance:compact_mode": false,
       "advanced:copy_id": false,
       "advanced:admin_panel": false,
+      "recent_emojis": [],
     };
   }
 
@@ -183,5 +194,24 @@ export class Settings extends AbstractStore<"settings", TypeSettings> {
    */
   getValue<T extends keyof TypeSettings>(key: T) {
     return this.get()[key] ?? DEFAULT_VALUES[key];
+  }
+
+  /**
+   * Push a recently used emoji to the top of the list
+   * @param emoji Emoji ID or Unicode character
+   */
+  pushRecentEmoji(emoji: string) {
+    const current = this.getValue("recent_emojis") ?? [];
+    const updated = [emoji, ...current.filter((e) => e !== emoji)].slice(0, 50);
+    this.set("recent_emojis", updated);
+  }
+
+  /**
+   * Remove an emoji from the recent list
+   * @param emoji Emoji ID or Unicode character
+   */
+  removeRecentEmoji(emoji: string) {
+    const current = this.getValue("recent_emojis") ?? [];
+    this.set("recent_emojis", current.filter((value) => value !== emoji));
   }
 }

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -26,6 +26,10 @@ import {
   compositionContent,
 } from "./CompositionMediaPicker";
 
+const EMOJI_REVERSE_MAPPING = Object.fromEntries(
+  Object.entries(emojiMapping).map(([k, v]) => [v, k])
+);
+
 type Item =
   | {
       /**
@@ -93,16 +97,40 @@ export function EmojiPicker() {
     }
 
     const items: Item[] = [];
+    const recentEmojis = state.settings.getValue("recent_emojis") || [];
+
+    if (recentEmojis.length > 0) {
+      items.push({ t: 3, title: "Recently Used" });
+
+      while (items.length % COLUMNS) {
+        items.push({ t: 1 });
+      }
+
+      for (const recent of recentEmojis) {
+        const emoji = client().emojis.get(recent);
+
+        if (emoji) {
+          items.push({ t: 2, emoji });
+          continue;
+        }
+
+        const name = EMOJI_REVERSE_MAPPING[recent];
+        if (name) {
+          items.push({ t: 4, name, text: recent });
+        }
+      }
+
+      while (items.length % COLUMNS) {
+        items.push({ t: 1 });
+      }
+    }
 
     for (const server of state.ordering.orderedServers(client())) {
       const emojis = server.emojis;
 
       if (emojis.length === 0) continue;
 
-      items.push({
-        t: 0,
-        server,
-      });
+      items.push({ t: 0, server });
 
       while (items.length % COLUMNS) {
         items.push({ t: 1 });
@@ -117,21 +145,14 @@ export function EmojiPicker() {
       }
     }
 
-    items.push({
-      t: 3,
-      title: "Default",
-    });
+    items.push({ t: 3, title: "Default" });
 
     while (items.length % COLUMNS) {
       items.push({ t: 1 });
     }
 
     for (const emoji of Object.entries(emojiMapping)) {
-      items.push({
-        t: 4,
-        name: emoji[0],
-        text: emoji[1] as string,
-      });
+      items.push({ t: 4, name: emoji[0], text: emoji[1] as string });
     }
 
     return items;
@@ -235,6 +256,7 @@ const ServerOption = styled("div", {
 });
 
 const EmojiItem = (props: { style: unknown; tabIndex: number; item: Item }) => {
+  const client = useClient();
   const state = useState();
   const { onTextReplacement } = useContext(CompositionMediaPickerContext);
 
@@ -246,10 +268,19 @@ const EmojiItem = (props: { style: unknown; tabIndex: number; item: Item }) => {
       role="listitem"
       onClick={() => {
         if (props.item.t === 2) {
-          onTextReplacement(`:${props.item.emoji.id}:`);
+          const emoji = client().emojis.get(props.item.emoji.id);
+
+          if (!emoji) {
+            state.settings.removeRecentEmoji(props.item.emoji.id);
+            return;
+          }
+
+          state.settings.pushRecentEmoji(emoji.id);
+          onTextReplacement(`:${emoji.id}:`);
         }
 
         if (props.item.t === 4) {
+          state.settings.pushRecentEmoji(props.item.text);
           onTextReplacement(
             `${UNICODE_EMOJI_PACK_PUA[state.settings.getValue("appearance:unicode_emoji")!] ?? ""}${props.item.text}`,
           );

--- a/packages/client/components/ui/components/features/texteditor/codeMirrorAutoCompleteSource.ts
+++ b/packages/client/components/ui/components/features/texteditor/codeMirrorAutoCompleteSource.ts
@@ -42,19 +42,48 @@ export function codeMirrorAutoCompleteSource(
   const client = useClient();
 
   const emoji = createMemo(() => {
+    const recentEmojis = state.settings.getValue("recent_emojis") ?? [];
+
+    /**
+     * Calculate boost score based on recency.
+     * Index 0 (most recent) gets score 100.
+     * Items not in list get score 0.
+     */
+    const getBoost = (key: string) => {
+      const index = recentEmojis.indexOf(key);
+      return index === -1 ? 0 : 100 - index;
+    };
+
     return ([] as Completion[]).concat(
-      MAPPED_EMOJI_KEYS.map((emoji) => ({
-        ...emoji,
-        apply: `${UNICODE_EMOJI_PACK_PUA[state.settings.getValue("appearance:unicode_emoji")!] ?? ""}${emoji.apply as string}`,
-        url: unicodeEmojiUrl(
-          state.settings.getValue("appearance:unicode_emoji"),
-          emoji.apply as string,
-        ),
-      })),
+      MAPPED_EMOJI_KEYS.map((emoji) => {
+        const emojiValue = emoji.apply as string;
+
+        return {
+          ...emoji,
+          boost: getBoost(emojiValue),
+          apply: (view, _completion, from, to) => {
+            const text = `${UNICODE_EMOJI_PACK_PUA[state.settings.getValue("appearance:unicode_emoji")!] ?? ""}${emojiValue}`;
+            state.settings.pushRecentEmoji(emojiValue);
+            view.dispatch({
+              changes: { from, to, insert: text },
+            });
+          },
+          url: unicodeEmojiUrl(
+            state.settings.getValue("appearance:unicode_emoji"),
+            emojiValue,
+          ),
+        };
+      }),
       client().emojis.map((emoji) => ({
         type: "emoji",
         label: `:${emoji.name}:`,
-        apply: `:${emoji.id}: `,
+        apply: (view, _completion, from, to) => {
+          state.settings.pushRecentEmoji(emoji.id);
+          view.dispatch({
+            changes: { from, to, insert: `:${emoji.id}: ` },
+          });
+        },
+        boost: getBoost(emoji.id),
         url: emoji.url,
       })),
     );


### PR DESCRIPTION
*Closed the other PR and created a clean one. The other one was a mess because of the BOT.*

I believe this closes #758

## Changelog
- Added `recent_emojis` to `Settings.ts` with LRU behavior (max 50), persistence, and cleanup helpers.
- Added a **Recently Used** section in `EmojiPicker.tsx`.
- Updated picker emoji handling in `EmojiPicker.tsx`:
  - recent clicks move emojis to the top,
  - stale custom recent entries are removed when clicked.
- Updated `codeMirrorAutoCompleteSource.ts`:
  - recent usage now affects emoji suggestion ranking (`boost`),
  - selecting an emoji from autocomplete also updates recently used emojis.

---

![chrome_8txWhQFZaY](https://github.com/user-attachments/assets/8252736c-1aec-4c6c-822e-d9ddfe5afbab)

*For this test I set the limit to 3 items, but for the PR I changed it back to store 50 recently used emojis*