### PR TITLE
chore: Update stoat.js dependency, update ulid dependency

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -143,7 +143,7 @@
     "space-separated-tokens": "^2.0.2",
     "stoat.js": "workspace:^",
     "style-to-object": "^1.0.8",
-    "ulid": "^2.4.0",
+    "ulid": "^3.0.2",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
       ulid:
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^3.0.2
+        version: 3.0.2
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -633,9 +633,12 @@ importers:
         specifier: 0.8.9-4
         version: 0.8.9-4
       ulid:
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^3.0.2
+        version: 3.0.2
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.1
+        version: 9.39.1
       '@mxssfd/typedoc-theme':
         specifier: ^1.1.7
         version: 1.1.7(typedoc@0.27.9(typescript@5.8.3))
@@ -7236,8 +7239,8 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  ulid@2.4.0:
-    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
     hasBin: true
 
   unbox-primitive@1.1.0:
@@ -15140,7 +15143,7 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  ulid@2.4.0: {}
+  ulid@3.0.2: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
Update stoat.js to 7.3.7 for newest fixes and improvements. [Release notes](https://github.com/stoatchat/javascript-client-sdk/releases/tag/7.3.7)

Update ULID to v3