### PR TITLE
feat: remove background from invite embed and modal

### DIFF
--- a/packages/client/components/auth/src/AuthPage.tsx
+++ b/packages/client/components/auth/src/AuthPage.tsx
@@ -10,7 +10,6 @@ import { IconButton, iconSize } from "@revolt/ui";
 
 import MdDarkMode from "@material-design-icons/svg/filled/dark_mode.svg?component-solid";
 
-import background from "./background.jpg";
 import { FlowBase } from "./flows/Flow";
 import bluesky from "./flows/bluesky.svg";
 
@@ -127,10 +126,7 @@ export function AuthPage(props: { children: JSX.Element }) {
       }}
     >
       <Titlebar />
-      <Base
-        style={{ "--url": `url('${background}')` }}
-        css={{ scrollbar: "hidden" }}
-      >
+      <Base css={{ scrollbar: "hidden" }}>
         <Nav>
           <div />
           <IconButton

--- a/packages/client/components/modal/modals/Invite.tsx
+++ b/packages/client/components/modal/modals/Invite.tsx
@@ -64,11 +64,6 @@ export function InviteModal(props: DialogProps & Modals & { type: "invite" }) {
         },
       ]}
       isDisabled={join.isPending}
-      scrimBackground={
-        props.invite instanceof ServerPublicInvite
-          ? props.invite.serverBanner?.originalUrl
-          : undefined
-      }
     >
       <Switch>
         <Match when={props.invite.type === "Server"}>

--- a/packages/client/components/ui/components/features/messaging/elements/Invite.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Invite.tsx
@@ -104,6 +104,5 @@ const Base = styled("div", {
     borderRadius: "var(--borderRadius-md)",
 
     color: "var(--md-sys-color-on-secondary-container)",
-    background: "var(--md-sys-color-secondary-container)",
   },
 });


### PR DESCRIPTION
*closes #977 if I did it correctly. The feature wasn't detailed well, so I had to figure out something. If need further investigation, please let me know*


-   Removed the background color from the Invite message embed to blend with the chat.
    
-   Removed the server banner backdrop from the Invite modal for a cleaner appearance.
    
-   Cleaned up unused background image references in the Authentication page.

---
## Before

<img width="407" height="186" alt="image" src="https://github.com/user-attachments/assets/5f21dd5f-a5dd-4599-8863-ff7be4ad14a8" />

<img width="421" height="184" alt="image" src="https://github.com/user-attachments/assets/f62d95f6-5678-4ab1-9f14-720b185d4513" />

## After

<img width="405" height="170" alt="image" src="https://github.com/user-attachments/assets/37c126d4-d91e-4418-8cfd-a383c7d15010" />

<img width="410" height="173" alt="image" src="https://github.com/user-attachments/assets/59f19a92-b52d-4fd1-91ad-69a129b3134b" />
