### PR TITLE
fix: use server config for custom emoji URLs instead of hardcoded CDN

### DIFF
--- a/packages/client/components/markdown/prosemirror/to-model.ts
+++ b/packages/client/components/markdown/prosemirror/to-model.ts
@@ -147,7 +147,7 @@ function map(
     case "customEmoji":
       return schema.nodes.rfm_custom_emoji.createAndFill({
         id: node.id,
-        src: `https://cdn.revoltusercontent.com/emojis/${node.id}`,
+        src: `${client.configuration?.features.autumn.url}/emojis/${node.id}`,
       })!;
     case "unicodeEmoji":
       return schema.nodes.rfm_unicode_emoji.createAndFill({

--- a/packages/client/components/ui/components/design/TextEditor.tsx
+++ b/packages/client/components/ui/components/design/TextEditor.tsx
@@ -474,7 +474,7 @@ export function TextEditor(props: Props) {
                       action.range.from,
                       schema.nodes.rfm_custom_emoji.createAndFill({
                         id: match.id,
-                        src: `https://cdn.revoltusercontent.com/emojis/${match.id}`,
+                        src: `${client()?.configuration?.features.autumn.url}/emojis/${match.id}`,
                       })!,
                     );
                   }


### PR DESCRIPTION
Custom emoji URLs are hardcoded to `cdn.revoltusercontent.com/emojis/` in the ProseMirror model builder and TextEditor component. This breaks on any instance using a different Autumn CDN URL.

Uses `client.configuration.features.autumn.url` from server config instead.

Fixes #561 (emoji part), partially addresses #939 (custom emoji cross-origin)

Tested and live on https://chat.sanhost.net