### PR TITLE
fix: add missing jest-mocks package.json COPY in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/stoat.js/package.json packages/stoat.js/
 COPY packages/solid-livekit-components/package.json packages/solid-livekit-components/
 COPY packages/js-lingui-solid/packages/babel-plugin-lingui-macro/package.json packages/js-lingui-solid/packages/babel-plugin-lingui-macro/
 COPY packages/js-lingui-solid/packages/babel-plugin-extract-messages/package.json packages/js-lingui-solid/packages/babel-plugin-extract-messages/
+COPY packages/js-lingui-solid/packages/jest-mocks/package.json packages/js-lingui-solid/packages/jest-mocks/
 COPY packages/client/package.json packages/client/
 
 # Copy panda config needed by client's "prepare" lifecycle script (panda codegen)


### PR DESCRIPTION
The `jest-mocks` workspace package is listed in `pnpm-workspace.yaml` but its `package.json` is not copied during the dependency resolution stage of the Docker build. This causes `pnpm install --frozen-lockfile` to fail when the lockfile references this workspace package.