### PR TITLE
feat: update GIF embed detection from Tenor to Giphy URLs

### DIFF
--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -85,7 +85,7 @@ export function Message(props: Props) {
     props.message.embeds[0].type === "Website" &&
     ((props.message.embeds[0] as WebsiteEmbed).specialContent?.type === "GIF" ||
       (props.message.embeds[0] as WebsiteEmbed).originalUrl?.startsWith(
-        "https://tenor.com",
+        "https://giphy.com",
       )) &&
     props.message.content &&
     !props.message.content.replace(RE_URL, "").length;

--- a/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
@@ -27,7 +27,7 @@ export function Embed(props: { embed: MessageEmbed }) {
     props.embed.type === "Website" &&
     ((props.embed as WebsiteEmbed).specialContent?.type === "GIF" ||
       (props.embed as WebsiteEmbed).originalUrl?.startsWith(
-        "https://tenor.com",
+        "https://giphy.com",
       ));
 
   /**


### PR DESCRIPTION
Updates GIF embed detection to match Giphy URLs instead of Tenor URLs, since the gifbox backend is migrating from Tenor to Giphy.

Changes `https://tenor.com` → `https://giphy.com` in:
- `Embed.tsx` (embed component GIF detection)
- `Message.tsx` (inline GIF message detection)

Related: stoatchat/stoatchat#661, stoatchat/for-android#94

Tested and live on https://chat.sanhost.net