### PR TITLE
refactor: place instance-specific config into dedicated context

### DIFF
--- a/packages/client/components/app/interface/settings/channel/Overview.tsx
+++ b/packages/client/components/app/interface/settings/channel/Overview.tsx
@@ -5,10 +5,10 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import type { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useModals } from "@revolt/modal";
 import { Button, CircularProgress, Column, Form2, Row, Text } from "@revolt/ui";
 
+import { useInstance } from "@revolt/instance";
 import { ChannelSettingsProps } from "../ChannelSettings";
 
 /**
@@ -18,6 +18,7 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
   const { t } = useLingui();
   const client = useClient();
   const { openModal } = useModals();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   // we want to take the initial value only
@@ -64,7 +65,7 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
 
         const [key, value] = client().authenticationHeader;
         const data: { id: string } = await fetch(
-          `${CONFIGURATION.DEFAULT_MEDIA_URL}/icons`,
+          `${instance.mediaUrl}/icons`,
           {
             method: "POST",
             body,

--- a/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
+++ b/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
@@ -6,7 +6,6 @@ import { useMutation } from "@tanstack/solid-query";
 import { API, ChannelWebhook } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useModals } from "@revolt/modal";
 import {
   CategoryButton,
@@ -65,7 +64,7 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
 
         const [key, value] = client().authenticationHeader;
         const data: { id: string } = await fetch(
-          `${CONFIGURATION.DEFAULT_MEDIA_URL}/avatars`,
+          `${instance.mediaUrl}/avatars`,
           {
             method: "POST",
             body,

--- a/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
+++ b/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
@@ -19,6 +19,7 @@ import {
 import MdContentCopy from "@material-design-icons/svg/outlined/content_copy.svg?component-solid";
 import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
 
+import { useInstance } from "@revolt/instance";
 import { useSettingsNavigation } from "../../Settings";
 
 /**
@@ -29,6 +30,7 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
   const client = useClient();
   const { showError } = useModals();
   const { navigate } = useSettingsNavigation();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   const editGroup = createFormGroup({
@@ -120,7 +122,7 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
           icon={<MdContentCopy />}
           onClick={() =>
             navigator.clipboard.writeText(
-              `${CONFIGURATION.DEFAULT_API_URL}/webhooks/${props.webhook.id}/${props.webhook.token}`,
+              `${instance.apiUrl}/webhooks/${props.webhook.id}/${props.webhook.token}`,
             )
           }
         >

--- a/packages/client/components/app/interface/settings/server/Overview.tsx
+++ b/packages/client/components/app/interface/settings/server/Overview.tsx
@@ -5,7 +5,6 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import type { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import {
   CircularProgress,
   Column,
@@ -15,6 +14,7 @@ import {
   Text,
 } from "@revolt/ui";
 
+import { useInstance } from "@revolt/instance";
 import { ServerSettingsProps } from "../ServerSettings";
 
 /**
@@ -23,6 +23,7 @@ import { ServerSettingsProps } from "../ServerSettings";
 export default function ServerOverview(props: ServerSettingsProps) {
   const { t } = useLingui();
   const client = useClient();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   const editGroup = createFormGroup({
@@ -144,7 +145,7 @@ export default function ServerOverview(props: ServerSettingsProps) {
         changes.icon = await client().uploadFile(
           "icons",
           editGroup.controls.icon.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
       }
     }
@@ -156,7 +157,7 @@ export default function ServerOverview(props: ServerSettingsProps) {
         changes.banner = await client().uploadFile(
           "banners",
           editGroup.controls.banner.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
       }
     }

--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -8,6 +8,7 @@ import { css } from "styled-system/css";
 import { useClient } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
 import { useError } from "@revolt/i18n";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import {
   Avatar,
@@ -27,6 +28,7 @@ export function EmojiList(props: { server: Server }) {
   const { t } = useLingui();
   const client = useClient();
   const { openModal } = useModals();
+  const instance = useInstance();
 
   function isDisabled() {
     return props.server.emojis.length >= CONFIGURATION.MAX_EMOJI;
@@ -50,7 +52,7 @@ export function EmojiList(props: { server: Server }) {
 
     const [key, value] = client().authenticationHeader;
     const data: { id: string } = await fetch(
-      `${CONFIGURATION.DEFAULT_MEDIA_URL}/emojis`,
+      `${instance.mediaUrl}/emojis`,
       {
         method: "POST",
         body,

--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -6,7 +6,6 @@ import { Server } from "stoat.js";
 import { css } from "styled-system/css";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useError } from "@revolt/i18n";
 import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
@@ -31,7 +30,7 @@ export function EmojiList(props: { server: Server }) {
   const instance = useInstance();
 
   function isDisabled() {
-    return props.server.emojis.length >= CONFIGURATION.MAX_EMOJI;
+    return props.server.emojis.length >= instance.maxEmoji;
   }
 
   const editGroup = createFormGroup(
@@ -101,7 +100,7 @@ export function EmojiList(props: { server: Server }) {
                 <Switch
                   fallback={
                     <Trans>
-                      {CONFIGURATION.MAX_EMOJI - props.server.emojis.length}{" "}
+                      {instance.maxEmoji - props.server.emojis.length}{" "}
                       emoji slots remaining
                     </Trans>
                   }

--- a/packages/client/components/app/interface/settings/user/Feedback.tsx
+++ b/packages/client/components/app/interface/settings/user/Feedback.tsx
@@ -13,7 +13,7 @@ import MdBugReport from "@material-design-icons/svg/outlined/bug_report.svg?comp
 import MdFormatListNumbered from "@material-design-icons/svg/outlined/format_list_numbered.svg?component-solid";
 import MdStar from "@material-design-icons/svg/outlined/star_outline.svg?component-solid";
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { useNavigate } from "@solidjs/router";
 import { Match, Switch } from "solid-js";
@@ -26,8 +26,9 @@ export function Feedback() {
   const { openModal, pop } = useModals();
   const navigate = useNavigate();
   const client = useClient();
+  const instance = useInstance();
 
-  const showLoungeButton = CONFIGURATION.IS_STOAT;
+  const showLoungeButton = instance.isStoat;
   const isInLounge =
     client()!.servers.get("01F7ZSBSFHQ8TA81725KQCSDDP") !== undefined;
 

--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -6,7 +6,6 @@ import { useQuery, useQueryClient } from "@tanstack/solid-query";
 import { API, User } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import {
   CategoryButton,
   CircularProgress,
@@ -18,6 +17,7 @@ import {
 
 import MdBadge from "@material-design-icons/svg/filled/badge.svg?component-solid";
 
+import { useInstance } from "@revolt/instance";
 import { useSettingsNavigation } from "../../Settings";
 
 interface Props {
@@ -28,6 +28,7 @@ export function UserProfileEditor(props: Props) {
   const { t } = useLingui();
   const client = useClient();
   const queryClient = useQueryClient();
+  const instance = useInstance();
 
   const profile = useQuery(() => ({
     queryKey: ["profile", props.user.id],
@@ -102,7 +103,7 @@ export function UserProfileEditor(props: Props) {
         changes.avatar = await client().uploadFile(
           "avatars",
           editGroup.controls.avatar.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
       }
     }
@@ -126,10 +127,10 @@ export function UserProfileEditor(props: Props) {
         changes.profile.background = await client().uploadFile(
           "backgrounds",
           editGroup.controls.banner.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
 
-        newBannerUrl = `${CONFIGURATION.DEFAULT_MEDIA_URL}/backgrounds/${changes.profile.background}`;
+        newBannerUrl = `${instance.mediaUrl}/backgrounds/${changes.profile.background}`;
       } else {
         newBannerUrl = editGroup.controls.banner.value;
       }

--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -1,6 +1,6 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useNavigate } from "@revolt/routing";
 import { Button, Row, iconSize } from "@revolt/ui";
 
@@ -18,6 +18,7 @@ import { Fields, Form } from "./Form";
 export default function FlowCreate() {
   const api = useApi();
   const navigate = useNavigate();
+  const instance = useInstance();
 
   /**
    * Create an account
@@ -48,7 +49,7 @@ export default function FlowCreate() {
       <FlowTitle subtitle={<Trans>Create an account</Trans>} emoji="wave">
         <Trans>Hello!</Trans>
       </FlowTitle>
-      <Form onSubmit={create} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
+      <Form onSubmit={create} captcha={instance.hcaptcha_sitekey}>
         <Fields fields={["email", "password"]} />
         <Row justify>
           <a href="..">

--- a/packages/client/components/auth/src/flows/FlowResend.tsx
+++ b/packages/client/components/auth/src/flows/FlowResend.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
 import { useApi } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useNavigate } from "@revolt/routing";
 import { Button } from "@revolt/ui";
 
@@ -15,6 +15,7 @@ import { Fields, Form } from "./Form";
 export default function FlowResend() {
   const api = useApi();
   const navigate = useNavigate();
+  const instance = useInstance();
 
   /**
    * Resend email verification
@@ -38,7 +39,7 @@ export default function FlowResend() {
       <FlowTitle>
         <Trans>Resend verification</Trans>
       </FlowTitle>
-      <Form onSubmit={resend} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
+      <Form onSubmit={resend} captcha={instance.hcaptcha_sitekey}>
         <Fields fields={["email"]} />
         <Button type="submit">
           <Trans>Resend</Trans>

--- a/packages/client/components/auth/src/flows/FlowReset.tsx
+++ b/packages/client/components/auth/src/flows/FlowReset.tsx
@@ -1,7 +1,6 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
 import { useApi } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useNavigate } from "@revolt/routing";
 import { Button } from "@revolt/ui";
 

--- a/packages/client/components/auth/src/flows/FlowReset.tsx
+++ b/packages/client/components/auth/src/flows/FlowReset.tsx
@@ -8,6 +8,7 @@ import { Button } from "@revolt/ui";
 import { FlowTitle } from "./Flow";
 import { setFlowCheckEmail } from "./FlowCheck";
 import { Fields, Form } from "./Form";
+import { useInstance } from "@revolt/instance";
 
 /**
  * Flow for sending password reset
@@ -15,6 +16,7 @@ import { Fields, Form } from "./Form";
 export default function FlowReset() {
   const api = useApi();
   const navigate = useNavigate();
+  const instance = useInstance();
 
   /**
    * Send password reset
@@ -38,7 +40,7 @@ export default function FlowReset() {
       <FlowTitle>
         <Trans>Reset password</Trans>
       </FlowTitle>
-      <Form onSubmit={reset} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
+      <Form onSubmit={reset} captcha={instance.hcaptcha_sitekey}>
         <Fields fields={["email"]} />
         <Button type="submit">
           <Trans>Reset</Trans>

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -8,6 +8,7 @@ import { CONFIGURATION } from "@revolt/common";
 import { ModalControllerExtended } from "@revolt/modal";
 import type { State as ApplicationState } from "@revolt/state";
 import type { Session } from "@revolt/state/stores/Auth";
+import Instance from "../instance/Instance";
 
 export enum State {
   Ready = "Ready",
@@ -126,7 +127,7 @@ class Lifecycle {
     }
 
     this.client = new Client({
-      baseURL: CONFIGURATION.DEFAULT_API_URL,
+      baseURL: this.#controller.instance.apiUrl,
       autoReconnect: false,
       syncUnreads: true,
       debug: import.meta.env.DEV,
@@ -446,12 +447,18 @@ export default class ClientController {
   readonly state: ApplicationState;
 
   /**
+   * Reference to the instance the client connects to
+   */
+  readonly instance: Instance;
+
+  /**
    * Construct new client controller
    */
-  constructor(state: ApplicationState) {
+  constructor(state: ApplicationState, instance: Instance) {
     this.state = state;
+    this.instance = instance;
     this.api = new API.API({
-      baseURL: CONFIGURATION.DEFAULT_API_URL,
+      baseURL: instance.apiUrl,
     });
 
     this.lifecycle = new Lifecycle(this);

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -159,7 +159,7 @@ class Lifecycle {
         },
       },
       vapid: String(),
-      ws: CONFIGURATION.DEFAULT_WS_URL,
+      ws: this.#controller.instance.wsUrl,
     };
 
     this.client.events.on("state", this.onState);

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -144,7 +144,7 @@ class Lifecycle {
       features: {
         autumn: {
           enabled: true,
-          url: CONFIGURATION.DEFAULT_MEDIA_URL,
+          url: this.#controller.instance.mediaUrl,
         },
         january: {
           enabled: true,

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -4,7 +4,6 @@ import { detect } from "detect-browser";
 import { API, Client, ConnectionState } from "stoat.js";
 import { ProtocolV1 } from "stoat.js/lib/events/v1";
 
-import { CONFIGURATION } from "@revolt/common";
 import { ModalControllerExtended } from "@revolt/modal";
 import type { State as ApplicationState } from "@revolt/state";
 import type { Session } from "@revolt/state/stores/Auth";
@@ -148,7 +147,7 @@ class Lifecycle {
         },
         january: {
           enabled: true,
-          url: CONFIGURATION.DEFAULT_PROXY_URL,
+          url: this.#controller.instance.proxyUrl,
         },
         captcha: {} as never,
         email: true,

--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -15,6 +15,7 @@ import { State } from "@revolt/state";
 
 import { State as LifecycleState } from "./Controller";
 
+import { useInstance } from "@revolt/instance";
 import { CHANGELOG_MODAL_CONST } from "@revolt/modal/modals/Changelog";
 import ClientController from "./Controller";
 
@@ -27,9 +28,10 @@ const clientContext = createContext(null! as ClientController);
  */
 export function ClientContext(props: { state: State; children: JSXElement }) {
   const { openModal } = useModals();
+  const instance = useInstance();
 
   // eslint-disable-next-line solid/reactivity
-  const controller = new ClientController(props.state);
+  const controller = new ClientController(props.state, instance);
   onCleanup(() => controller.dispose());
 
   createEffect(() => {

--- a/packages/client/components/i18n/catalogs/ar/messages.po
+++ b/packages/client/components/i18n/catalogs/ar/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/as/messages.po
+++ b/packages/client/components/i18n/catalogs/as/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/az/messages.po
+++ b/packages/client/components/i18n/catalogs/az/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/be/messages.po
+++ b/packages/client/components/i18n/catalogs/be/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/bg/messages.po
+++ b/packages/client/components/i18n/catalogs/bg/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/bn/messages.po
+++ b/packages/client/components/i18n/catalogs/bn/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/bottom/messages.po
+++ b/packages/client/components/i18n/catalogs/bottom/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/br/messages.po
+++ b/packages/client/components/i18n/catalogs/br/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ca/messages.po
+++ b/packages/client/components/i18n/catalogs/ca/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ceb/messages.po
+++ b/packages/client/components/i18n/catalogs/ceb/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ckb/messages.po
+++ b/packages/client/components/i18n/catalogs/ckb/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/cs/messages.po
+++ b/packages/client/components/i18n/catalogs/cs/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/da/messages.po
+++ b/packages/client/components/i18n/catalogs/da/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/de/messages.po
+++ b/packages/client/components/i18n/catalogs/de/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/dev/messages.po
+++ b/packages/client/components/i18n/catalogs/dev/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/el/messages.po
+++ b/packages/client/components/i18n/catalogs/el/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/en-US/messages.po
+++ b/packages/client/components/i18n/catalogs/en-US/messages.po
@@ -68,7 +68,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/en/messages.po
+++ b/packages/client/components/i18n/catalogs/en/messages.po
@@ -72,7 +72,7 @@ msgstr "{0} changed the channel description"
 msgid "{0} changed the channel icon"
 msgstr "{0} changed the channel icon"
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr "{0} emoji slots remaining"

--- a/packages/client/components/i18n/catalogs/enchantment/messages.po
+++ b/packages/client/components/i18n/catalogs/enchantment/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/eo/messages.po
+++ b/packages/client/components/i18n/catalogs/eo/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/es-419/messages.po
+++ b/packages/client/components/i18n/catalogs/es-419/messages.po
@@ -68,7 +68,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/es/messages.po
+++ b/packages/client/components/i18n/catalogs/es/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/et/messages.po
+++ b/packages/client/components/i18n/catalogs/et/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/fa/messages.po
+++ b/packages/client/components/i18n/catalogs/fa/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/fi/messages.po
+++ b/packages/client/components/i18n/catalogs/fi/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/fil/messages.po
+++ b/packages/client/components/i18n/catalogs/fil/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/fr/messages.po
+++ b/packages/client/components/i18n/catalogs/fr/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ga/messages.po
+++ b/packages/client/components/i18n/catalogs/ga/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/hi/messages.po
+++ b/packages/client/components/i18n/catalogs/hi/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/hr/messages.po
+++ b/packages/client/components/i18n/catalogs/hr/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/hu/messages.po
+++ b/packages/client/components/i18n/catalogs/hu/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/hy/messages.po
+++ b/packages/client/components/i18n/catalogs/hy/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/id/messages.po
+++ b/packages/client/components/i18n/catalogs/id/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/is/messages.po
+++ b/packages/client/components/i18n/catalogs/is/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/it/messages.po
+++ b/packages/client/components/i18n/catalogs/it/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ja/messages.po
+++ b/packages/client/components/i18n/catalogs/ja/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ko/messages.po
+++ b/packages/client/components/i18n/catalogs/ko/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/lb/messages.po
+++ b/packages/client/components/i18n/catalogs/lb/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/leet/messages.po
+++ b/packages/client/components/i18n/catalogs/leet/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/lt/messages.po
+++ b/packages/client/components/i18n/catalogs/lt/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/lv/messages.po
+++ b/packages/client/components/i18n/catalogs/lv/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/mk/messages.po
+++ b/packages/client/components/i18n/catalogs/mk/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ms/messages.po
+++ b/packages/client/components/i18n/catalogs/ms/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/nb-NO/messages.po
+++ b/packages/client/components/i18n/catalogs/nb-NO/messages.po
@@ -68,7 +68,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/nl/messages.po
+++ b/packages/client/components/i18n/catalogs/nl/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/owo/messages.po
+++ b/packages/client/components/i18n/catalogs/owo/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/piglatin/messages.po
+++ b/packages/client/components/i18n/catalogs/piglatin/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/pl/messages.po
+++ b/packages/client/components/i18n/catalogs/pl/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/pr/messages.po
+++ b/packages/client/components/i18n/catalogs/pr/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/pt-BR/messages.po
+++ b/packages/client/components/i18n/catalogs/pt-BR/messages.po
@@ -68,7 +68,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/pt-PT/messages.po
+++ b/packages/client/components/i18n/catalogs/pt-PT/messages.po
@@ -68,7 +68,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ro/messages.po
+++ b/packages/client/components/i18n/catalogs/ro/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ru/messages.po
+++ b/packages/client/components/i18n/catalogs/ru/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/si/messages.po
+++ b/packages/client/components/i18n/catalogs/si/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/sk/messages.po
+++ b/packages/client/components/i18n/catalogs/sk/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/sl/messages.po
+++ b/packages/client/components/i18n/catalogs/sl/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/sq/messages.po
+++ b/packages/client/components/i18n/catalogs/sq/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/sr/messages.po
+++ b/packages/client/components/i18n/catalogs/sr/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/sv/messages.po
+++ b/packages/client/components/i18n/catalogs/sv/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ta/messages.po
+++ b/packages/client/components/i18n/catalogs/ta/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/th/messages.po
+++ b/packages/client/components/i18n/catalogs/th/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/tokipona/messages.po
+++ b/packages/client/components/i18n/catalogs/tokipona/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/tr/messages.po
+++ b/packages/client/components/i18n/catalogs/tr/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/uk/messages.po
+++ b/packages/client/components/i18n/catalogs/uk/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/ur/messages.po
+++ b/packages/client/components/i18n/catalogs/ur/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/vec/messages.po
+++ b/packages/client/components/i18n/catalogs/vec/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/vi/messages.po
+++ b/packages/client/components/i18n/catalogs/vi/messages.po
@@ -72,7 +72,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/zh-Hans/messages.po
+++ b/packages/client/components/i18n/catalogs/zh-Hans/messages.po
@@ -68,7 +68,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/i18n/catalogs/zh-Hant/messages.po
+++ b/packages/client/components/i18n/catalogs/zh-Hant/messages.po
@@ -68,7 +68,7 @@ msgstr ""
 msgid "{0} changed the channel icon"
 msgstr ""
 
-#. placeholder {0}: CONFIGURATION.MAX_EMOJI - props.server.emojis.length
+#. placeholder {0}: instance.maxEmoji - props.server.emojis.length
 #: components/app/interface/settings/server/emojis/EmojiList.tsx
 msgid "{0} emoji slots remaining"
 msgstr ""

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -1,0 +1,7 @@
+export default class Instance {
+  readonly apiUrl: string;
+
+  constructor(apiUrl: string) {
+    this.apiUrl = apiUrl;
+  }
+}

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -1,9 +1,11 @@
 export default class Instance {
   readonly apiUrl: string;
   readonly wsUrl: string;
+  readonly mediaUrl: string;
 
-  constructor(apiUrl: string, wsUrl: string) {
+  constructor(apiUrl: string, wsUrl: string, mediaUrl: string) {
     this.apiUrl = apiUrl;
     this.wsUrl = wsUrl;
+    this.mediaUrl = mediaUrl;
   }
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -1,4 +1,5 @@
 export default class Instance {
+  readonly isStoat: boolean;
   readonly apiUrl: string;
   readonly wsUrl: string;
   readonly mediaUrl: string;
@@ -12,6 +13,14 @@ export default class Instance {
     proxyUrl: string,
     gifboxUrl: string,
   ) {
+    this.isStoat = [
+      // historically...
+      "https://api.revolt.chat",
+      "https://beta.revolt.chat/api",
+      "https://revolt.chat/api",
+      // ... and now:
+      "https://stoat.chat/api",
+    ].includes(apiUrl);
     this.apiUrl = apiUrl;
     this.wsUrl = wsUrl;
     this.mediaUrl = mediaUrl;

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -6,6 +6,10 @@ export default class Instance {
   readonly proxyUrl: string;
   readonly gifboxUrl: string;
   readonly hcaptcha_sitekey: string;
+  // Not implemented, but shouldn't be too bad for now
+  // readonly maxReplies: number;
+  // readonly maxAttachments: number;
+  readonly maxEmoji: number;
 
   constructor(
     apiUrl: string,
@@ -14,6 +18,7 @@ export default class Instance {
     proxyUrl: string,
     gifboxUrl: string,
     hcaptcha_sitekey: string,
+    maxEmoji: number,
   ) {
     this.isStoat = [
       // historically...
@@ -29,5 +34,6 @@ export default class Instance {
     this.proxyUrl = proxyUrl;
     this.gifboxUrl = gifboxUrl;
     this.hcaptcha_sitekey = hcaptcha_sitekey;
+    this.maxEmoji = maxEmoji;
   }
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -2,10 +2,17 @@ export default class Instance {
   readonly apiUrl: string;
   readonly wsUrl: string;
   readonly mediaUrl: string;
+  readonly proxyUrl: string;
 
-  constructor(apiUrl: string, wsUrl: string, mediaUrl: string) {
+  constructor(
+    apiUrl: string,
+    wsUrl: string,
+    mediaUrl: string,
+    proxyUrl: string,
+  ) {
     this.apiUrl = apiUrl;
     this.wsUrl = wsUrl;
     this.mediaUrl = mediaUrl;
+    this.proxyUrl = proxyUrl;
   }
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -9,10 +9,13 @@ export default class Instance {
   readonly maxEmoji: number;
   readonly enableVideo: boolean;
 
-  // Not implemented, but shouldn't be too bad for now
+  // Not implemented, but should be fine for now
   // readonly maxReplies: number;
   // readonly maxAttachments: number;
   // readonly maxFileSize: number;
+  // DEVELOPMENT_SESSION_ID
+  // DEVELOPMENT_TOKEN
+  // DEVELOPMENT_USER_ID
 
   constructor(
     apiUrl: string,

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -5,6 +5,7 @@ export default class Instance {
   readonly mediaUrl: string;
   readonly proxyUrl: string;
   readonly gifboxUrl: string;
+  readonly hcaptcha_sitekey: string;
 
   constructor(
     apiUrl: string,
@@ -12,6 +13,7 @@ export default class Instance {
     mediaUrl: string,
     proxyUrl: string,
     gifboxUrl: string,
+    hcaptcha_sitekey: string,
   ) {
     this.isStoat = [
       // historically...
@@ -26,5 +28,6 @@ export default class Instance {
     this.mediaUrl = mediaUrl;
     this.proxyUrl = proxyUrl;
     this.gifboxUrl = gifboxUrl;
+    this.hcaptcha_sitekey = hcaptcha_sitekey;
   }
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -1,7 +1,9 @@
 export default class Instance {
   readonly apiUrl: string;
+  readonly wsUrl: string;
 
-  constructor(apiUrl: string) {
+  constructor(apiUrl: string, wsUrl: string) {
     this.apiUrl = apiUrl;
+    this.wsUrl = wsUrl;
   }
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -3,16 +3,19 @@ export default class Instance {
   readonly wsUrl: string;
   readonly mediaUrl: string;
   readonly proxyUrl: string;
+  readonly gifboxUrl: string;
 
   constructor(
     apiUrl: string,
     wsUrl: string,
     mediaUrl: string,
     proxyUrl: string,
+    gifboxUrl: string,
   ) {
     this.apiUrl = apiUrl;
     this.wsUrl = wsUrl;
     this.mediaUrl = mediaUrl;
     this.proxyUrl = proxyUrl;
+    this.gifboxUrl = gifboxUrl;
   }
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -6,10 +6,13 @@ export default class Instance {
   readonly proxyUrl: string;
   readonly gifboxUrl: string;
   readonly hcaptcha_sitekey: string;
+  readonly maxEmoji: number;
+  readonly enableVideo: boolean;
+
   // Not implemented, but shouldn't be too bad for now
   // readonly maxReplies: number;
   // readonly maxAttachments: number;
-  readonly maxEmoji: number;
+  // readonly maxFileSize: number;
 
   constructor(
     apiUrl: string,
@@ -19,6 +22,7 @@ export default class Instance {
     gifboxUrl: string,
     hcaptcha_sitekey: string,
     maxEmoji: number,
+    enableVideo: boolean,
   ) {
     this.isStoat = [
       // historically...
@@ -35,5 +39,6 @@ export default class Instance {
     this.gifboxUrl = gifboxUrl;
     this.hcaptcha_sitekey = hcaptcha_sitekey;
     this.maxEmoji = maxEmoji;
+    this.enableVideo = enableVideo;
   }
 }

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -16,6 +16,7 @@ export function InstanceContext(props: { children: JSXElement }) {
           CONFIGURATION.DEFAULT_GIFBOX_URL,
           CONFIGURATION.HCAPTCHA_SITEKEY,
           CONFIGURATION.MAX_EMOJI,
+          CONFIGURATION.ENABLE_VIDEO,
         )
       }
     >

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -14,6 +14,7 @@ export function InstanceContext(props: { children: JSXElement }) {
           CONFIGURATION.DEFAULT_MEDIA_URL,
           CONFIGURATION.DEFAULT_PROXY_URL,
           CONFIGURATION.DEFAULT_GIFBOX_URL,
+          CONFIGURATION.HCAPTCHA_SITEKEY,
         )
       }
     >

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -1,0 +1,25 @@
+import { CONFIGURATION } from "@revolt/common";
+import { createContext, JSXElement, useContext } from "solid-js";
+import Instance from "./Instance";
+
+const instanceContext = createContext<Instance>();
+
+export function InstanceContext(props: { children: JSXElement }) {
+  return (
+    <instanceContext.Provider
+      value={new Instance(CONFIGURATION.DEFAULT_API_URL)}
+    >
+      {props.children}
+    </instanceContext.Provider>
+  );
+}
+
+export function useInstance() {
+  const instance = useContext(instanceContext);
+
+  if (!instance) {
+    throw new Error("useInstance must be called inside InstanceProvider");
+  }
+
+  return instance;
+}

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -11,6 +11,7 @@ export function InstanceContext(props: { children: JSXElement }) {
         new Instance(
           CONFIGURATION.DEFAULT_API_URL,
           CONFIGURATION.DEFAULT_WS_URL,
+          CONFIGURATION.DEFAULT_MEDIA_URL,
         )
       }
     >

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -15,6 +15,7 @@ export function InstanceContext(props: { children: JSXElement }) {
           CONFIGURATION.DEFAULT_PROXY_URL,
           CONFIGURATION.DEFAULT_GIFBOX_URL,
           CONFIGURATION.HCAPTCHA_SITEKEY,
+          CONFIGURATION.MAX_EMOJI,
         )
       }
     >

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -13,6 +13,7 @@ export function InstanceContext(props: { children: JSXElement }) {
           CONFIGURATION.DEFAULT_WS_URL,
           CONFIGURATION.DEFAULT_MEDIA_URL,
           CONFIGURATION.DEFAULT_PROXY_URL,
+          CONFIGURATION.DEFAULT_GIFBOX_URL,
         )
       }
     >

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -12,6 +12,7 @@ export function InstanceContext(props: { children: JSXElement }) {
           CONFIGURATION.DEFAULT_API_URL,
           CONFIGURATION.DEFAULT_WS_URL,
           CONFIGURATION.DEFAULT_MEDIA_URL,
+          CONFIGURATION.DEFAULT_PROXY_URL,
         )
       }
     >

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -7,7 +7,12 @@ const instanceContext = createContext<Instance>();
 export function InstanceContext(props: { children: JSXElement }) {
   return (
     <instanceContext.Provider
-      value={new Instance(CONFIGURATION.DEFAULT_API_URL)}
+      value={
+        new Instance(
+          CONFIGURATION.DEFAULT_API_URL,
+          CONFIGURATION.DEFAULT_WS_URL,
+        )
+      }
     >
       {props.children}
     </instanceContext.Provider>

--- a/packages/client/components/modal/modals/CreateInvite.tsx
+++ b/packages/client/components/modal/modals/CreateInvite.tsx
@@ -4,7 +4,6 @@ import { Trans } from "@lingui-solid/solid/macro";
 import { useMutation } from "@tanstack/solid-query";
 import { styled } from "styled-system/jsx";
 
-import { CONFIGURATION } from "@revolt/common";
 import { Dialog, DialogProps } from "@revolt/ui";
 
 import { useModals } from "..";

--- a/packages/client/components/modal/modals/CreateInvite.tsx
+++ b/packages/client/components/modal/modals/CreateInvite.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogProps } from "@revolt/ui";
 
 import { useModals } from "..";
 import { Modals } from "../types";
+import { useInstance } from "@revolt/instance";
 
 /**
  * Code block which displays invite
@@ -36,6 +37,7 @@ export function CreateInviteModal(
 ) {
   const { showError } = useModals();
   const [link, setLink] = createSignal("...");
+  const instance = useInstance();
 
   const fetchInvite = useMutation(() => ({
     mutationFn: () =>
@@ -43,7 +45,7 @@ export function CreateInviteModal(
         .createInvite()
         .then(({ _id }) =>
           setLink(
-            CONFIGURATION.IS_STOAT
+            instance.isStoat
               ? `https://stt.gg/${_id}`
               : `${window.location.protocol}//${window.location.host}/invite/${_id}`,
           ),

--- a/packages/client/components/modal/modals/ServerIdentity.tsx
+++ b/packages/client/components/modal/modals/ServerIdentity.tsx
@@ -4,9 +4,9 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
 
+import { useInstance } from "@revolt/instance";
 import { useModals } from "..";
 import { Modals } from "../types";
 
@@ -19,6 +19,7 @@ export function ServerIdentityModal(
   const { t } = useLingui();
   const client = useClient();
   const { showError } = useModals();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   const group = createFormGroup({
@@ -51,7 +52,7 @@ export function ServerIdentityModal(
           changes.avatar = await client().uploadFile(
             "avatars",
             group.controls.avatar.value[0],
-            CONFIGURATION.DEFAULT_MEDIA_URL,
+            instance.mediaUrl,
           );
         }
       }

--- a/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
@@ -14,7 +14,6 @@ import { useQuery } from "@tanstack/solid-query";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
-import env from "@revolt/common/lib/env";
 import { useInstance } from "@revolt/instance";
 import {
   CircularProgress,

--- a/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
@@ -15,6 +15,7 @@ import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
 import env from "@revolt/common/lib/env";
+import { useInstance } from "@revolt/instance";
 import {
   CircularProgress,
   TextField,
@@ -96,13 +97,14 @@ function Categories() {
   let targetElement!: HTMLDivElement;
 
   const client = useClient();
+  const instance = useInstance();
 
   const trendingCategories = useQuery<GifCategory[]>(() => ({
     queryKey: ["trendingGifCategories"],
     queryFn: () => {
       const [authHeader, authHeaderValue] = client()!.authenticationHeader;
 
-      return fetch(`${env.DEFAULT_GIFBOX_URL}/categories?locale=en_US`, {
+      return fetch(`${instance.gifboxUrl}/categories?locale=en_US`, {
         headers: {
           [authHeader]: authHeaderValue,
         },
@@ -117,7 +119,7 @@ function Categories() {
     queryFn: () => {
       const [authHeader, authHeaderValue] = client()!.authenticationHeader;
 
-      return fetch(`${env.DEFAULT_GIFBOX_URL}/trending?locale=en_US&limit=1`, {
+      return fetch(`${instance.gifboxUrl}/trending?locale=en_US&limit=1`, {
         headers: {
           [authHeader]: authHeaderValue,
         },
@@ -214,6 +216,7 @@ function GifSearch(props: { query: string }) {
   let targetElement!: HTMLDivElement;
 
   const client = useClient();
+  const instance = useInstance();
 
   const search = useQuery<GifResult[]>(() => ({
     queryKey: ["gifs", props.query],
@@ -221,7 +224,7 @@ function GifSearch(props: { query: string }) {
       const [authHeader, authHeaderValue] = client()!.authenticationHeader;
 
       return fetch(
-        `${env.DEFAULT_GIFBOX_URL}/` +
+        `${instance.gifboxUrl}/` +
           (props.query === "trending"
             ? `trending?locale=en_US`
             : `search?locale=en_US&query=${encodeURIComponent(props.query)}`),

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -3,7 +3,7 @@ import { Show } from "solid-js";
 import { useLingui } from "@lingui-solid/solid/macro";
 import { styled } from "styled-system/jsx";
 
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useVoice } from "@revolt/rtc";
 import { Button, IconButton } from "@revolt/ui/components/design";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
@@ -11,9 +11,10 @@ import { Symbol } from "@revolt/ui/components/utils/Symbol";
 export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
   const voice = useVoice();
   const { t } = useLingui();
+  const instance = useInstance();
 
   function isVideoEnabled() {
-    return CONFIGURATION.ENABLE_VIDEO;
+    return instance.enableVideo;
   }
 
   return (

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -33,6 +33,7 @@ import { FloatingManager, LoadTheme } from "@revolt/ui";
 /* @refresh reload */
 import "@revolt/ui/styles";
 
+import { InstanceContext } from "@revolt/instance";
 import AuthPage from "./Auth";
 import Interface from "./Interface";
 import "./index.css";
@@ -117,22 +118,24 @@ function MountContext(props: { children?: JSX.Element }) {
   const client = new QueryClient();
 
   return (
-    <KeybindContext>
-      <ModalContext>
-        <ClientContext state={state}>
-          <I18nProvider>
-            <VoiceContext>
-              <QueryClientProvider client={client}>
-                {props.children}
-                <ModalRenderer />
-                <FloatingManager />
-              </QueryClientProvider>
-            </VoiceContext>
-          </I18nProvider>
-          <SyncWorker />
-        </ClientContext>
-      </ModalContext>
-    </KeybindContext>
+    <InstanceContext>
+      <KeybindContext>
+        <ModalContext>
+          <ClientContext state={state}>
+            <I18nProvider>
+              <VoiceContext>
+                <QueryClientProvider client={client}>
+                  {props.children}
+                  <ModalRenderer />
+                  <FloatingManager />
+                </QueryClientProvider>
+              </VoiceContext>
+            </I18nProvider>
+            <SyncWorker />
+          </ClientContext>
+        </ModalContext>
+      </KeybindContext>
+    </InstanceContext>
   );
 }
 

--- a/packages/client/src/interface/Home.tsx
+++ b/packages/client/src/interface/Home.tsx
@@ -6,7 +6,6 @@ import { css, cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { IS_DEV, useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { useNavigate } from "@revolt/routing";

--- a/packages/client/src/interface/Home.tsx
+++ b/packages/client/src/interface/Home.tsx
@@ -7,6 +7,7 @@ import { styled } from "styled-system/jsx";
 
 import { IS_DEV, useClient } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { useNavigate } from "@revolt/routing";
 import {
@@ -94,9 +95,10 @@ export function HomePage() {
   const { openModal } = useModals();
   const navigate = useNavigate();
   const client = useClient();
+  const instance = useInstance();
 
   // check if we're stoat.chat; if so, check if the user is in the Lounge
-  const showLoungeButton = CONFIGURATION.IS_STOAT;
+  const showLoungeButton = instance.isStoat;
   const isInLounge =
     client()!.servers.get("01F7ZSBSFHQ8TA81725KQCSDDP") !== undefined;
 
@@ -189,7 +191,7 @@ export function HomePage() {
             </CategoryButton>
           </SeparatedColumn>
           <SeparatedColumn>
-            <Show when={CONFIGURATION.IS_STOAT}>
+            <Show when={instance.isStoat}>
               <CategoryButton
                 onClick={() => navigate("/discover")}
                 description={

--- a/packages/client/src/interface/navigation/servers/ServerList.tsx
+++ b/packages/client/src/interface/navigation/servers/ServerList.tsx
@@ -6,7 +6,6 @@ import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { KeybindAction, createKeybind } from "@revolt/keybinds";
 import { useModals } from "@revolt/modal";
 import { useNavigate } from "@revolt/routing";
@@ -17,13 +16,13 @@ import MdAdd from "@material-design-icons/svg/filled/add.svg?component-solid";
 import MdExplore from "@material-design-icons/svg/filled/explore.svg?component-solid";
 import MdHome from "@material-design-icons/svg/filled/home.svg?component-solid";
 import MdSettings from "@material-design-icons/svg/filled/settings.svg?component-solid";
+import { useInstance } from "@revolt/instance";
 
 import { Tooltip } from "../../../../components/ui/components/floating";
 import { Draggable } from "../../../../components/ui/components/utils/Draggable";
 
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 import { UserMenu } from "./UserMenu";
-import { useInstance } from "@revolt/instance";
 
 interface Props {
   /**

--- a/packages/client/src/interface/navigation/servers/ServerList.tsx
+++ b/packages/client/src/interface/navigation/servers/ServerList.tsx
@@ -23,6 +23,7 @@ import { Draggable } from "../../../../components/ui/components/utils/Draggable"
 
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 import { UserMenu } from "./UserMenu";
+import { useInstance } from "@revolt/instance";
 
 interface Props {
   /**
@@ -70,6 +71,7 @@ export const ServerList = (props: Props) => {
   const client = useClient();
   const navigate = useNavigate();
   const { openModal } = useModals();
+  const instance = useInstance();
 
   const navigateServer = (byOffset: number) => {
     const serverId = props.selectedServer();
@@ -302,7 +304,7 @@ export const ServerList = (props: Props) => {
             <Avatar size={42} fallback={<MdAdd />} />
           </a>
         </Tooltip>
-        <Show when={CONFIGURATION.IS_STOAT}>
+        <Show when={instance.isStoat}>
           <Tooltip placement="right" content={"Find new servers to join"}>
             <a
               href={state.layout.getLastActiveDiscoverPath()}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -29,6 +29,8 @@
       "@revolt/client/*": ["components/client/*"],
       "@revolt/common": ["components/common"],
       "@revolt/common/*": ["components/common/*"],
+      "@revolt/instance": ["components/instance"],
+      "@revolt/instance/*": ["components/instance/*"],
       "@revolt/i18n": ["components/i18n"],
       "@revolt/i18n/*": ["components/i18n/*"],
       "@revolt/keybinds": ["components/keybinds"],


### PR DESCRIPTION
In order to implement token federation (as per https://github.com/orgs/stoatchat/discussions/1073#discussioncomment-15814999), the client must be refactored to not use global configuration for values that are dependent on a specific instance.
This is fairly easy for most of them, since they are accessed in components and can thus use solid's context feature, but some values are also accessed in stores. I'm not sure how to best make those access the config, and I would appreciate suggestions, but I believe they will lead to a few client errors at worst, so it should be fine to deal with them later.