### PR TITLE
feat: Add invite_only support, add invite code field

### DIFF
--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -1,13 +1,13 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
+import { useApi, useClient } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
-import { useNavigate } from "@revolt/routing";
+import { useNavigate, useParams } from "@revolt/routing";
 import { Button, Row, iconSize } from "@revolt/ui";
 
 import MdArrowBack from "@material-design-icons/svg/filled/arrow_back.svg?component-solid";
 
-import { useApi } from "../../../client";
-
+import { Show } from "solid-js";
 import { FlowTitle } from "./Flow";
 import { setFlowCheckEmail } from "./FlowCheck";
 import { Fields, Form } from "./Form";
@@ -17,7 +17,9 @@ import { Fields, Form } from "./Form";
  */
 export default function FlowCreate() {
   const api = useApi();
+  const getClient = useClient();
   const navigate = useNavigate();
+  const { code } = useParams();
 
   /**
    * Create an account
@@ -27,11 +29,13 @@ export default function FlowCreate() {
     const email = data.get("email") as string;
     const password = data.get("password") as string;
     const captcha = data.get("captcha") as string;
+    const invite = data.get("invite") as string;
 
     await api.post("/auth/account/create", {
       email,
       password,
       captcha,
+      ...(invite ? { invite } : {}),
     });
 
     // FIXME: should tell client if email was sent
@@ -43,6 +47,14 @@ export default function FlowCreate() {
     navigate("/login/check", { replace: true });
   }
 
+  const isInviteOnly = () => {
+    const client = getClient();
+    if (client.configured()) {
+      return client.configuration?.features.invite_only;
+    }
+    return false;
+  };
+
   return (
     <>
       <FlowTitle subtitle={<Trans>Create an account</Trans>} emoji="wave">
@@ -50,6 +62,13 @@ export default function FlowCreate() {
       </FlowTitle>
       <Form onSubmit={create} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
         <Fields fields={["email", "password"]} />
+        <Show when={isInviteOnly()}>
+          <Fields
+            fields={[
+              { field: "invite", value: code, disabled: code?.length > 0 },
+            ]}
+          />
+        </Show>
         <Row justify>
           <a href="..">
             <Button variant="text">

--- a/packages/client/components/auth/src/flows/Form.tsx
+++ b/packages/client/components/auth/src/flows/Form.tsx
@@ -9,7 +9,13 @@ import { Checkbox2, Column, Text, TextField } from "@revolt/ui";
 /**
  * Available field types
  */
-type Field = "email" | "password" | "new-password" | "log-out" | "username";
+type Field =
+  | "email"
+  | "password"
+  | "new-password"
+  | "log-out"
+  | "username"
+  | "invite";
 
 /**
  * Properties to apply to fields
@@ -47,6 +53,13 @@ const useFieldConfiguration = () => {
       name: () => t`Username`,
       placeholder: () => t`Enter your preferred username.`,
     },
+    invite: {
+      minLength: 1,
+      type: "text" as const,
+      autocomplete: "none",
+      name: () => t`Invite Code`,
+      placeholder: () => t`Enter your invite code.`,
+    },
   };
 };
 
@@ -54,7 +67,14 @@ interface FieldProps {
   /**
    * Fields to gather
    */
-  fields: Field[];
+  fields: (Field | FieldPreset)[];
+}
+
+interface FieldPreset {
+  field: Field;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value?: any;
+  disabled?: boolean;
 }
 
 /**
@@ -65,23 +85,31 @@ export function Fields(props: FieldProps) {
 
   return (
     <For each={props.fields}>
-      {(field) => (
-        <label>
-          {field === "log-out" ? (
-            <Checkbox2 name="log-out">
-              {fieldConfiguration["log-out"].name()}
-            </Checkbox2>
-          ) : (
-            <TextField
-              required
-              {...fieldConfiguration[field]}
-              name={field}
-              label={fieldConfiguration[field].name()}
-              placeholder={fieldConfiguration[field].placeholder()}
-            />
-          )}
-        </label>
-      )}
+      {(field) => {
+        // If field is just a Field value, convert it to a FieldPreset
+        if (typeof field === "string") {
+          field = { field: field };
+        }
+        return (
+          <label>
+            {field.field === "log-out" ? (
+              <Checkbox2 name={field.field}>
+                {fieldConfiguration[field.field].name()}
+              </Checkbox2>
+            ) : (
+              <TextField
+                required
+                {...fieldConfiguration[field.field]}
+                name={field.field}
+                label={fieldConfiguration[field.field].name()}
+                placeholder={fieldConfiguration[field.field].placeholder()}
+                disabled={field.disabled}
+                value={field.value}
+              />
+            )}
+          </label>
+        );
+      }}
     </For>
   );
 }

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -144,6 +144,7 @@ render(
           <Route path="/delete/:token" component={FlowDeleteAccount} />
           <Route path="/check" component={FlowCheck} />
           <Route path="/create" component={FlowCreate} />
+          <Route path="/create/:code" component={FlowCreate} />
           <Route path="/auth" component={FlowLogin} />
           <Route path="/resend" component={FlowResend} />
           <Route path="/reset" component={FlowReset} />


### PR DESCRIPTION
Adds support for invite_only. Reads the invite_only configuration field from the configuration object. Supports sending an invite code in the url like `/login/create/invite_code_here`. This functionality rhymes with existing functionality in other systems.

This PR also adds the ability to pass default values and disabling login form elements. Might be useful in some other cases.

Closes #639

Supersedes #769
Supersedes #957 