### PR TITLE
chore: Added CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @stoatchat/for-web-maintainers
 
 # UI/UX related code
-/packages/client @infi
+/packages/client @stoatchat/ui-ux


### PR DESCRIPTION
A CODEOWNERS file will allow for maintainers to be automatically assigned to PRs for review.

A few tasks should be completed on the repo for this to be effective:

- [ ] The "Require review from Code Owners" branch protection needs to be enabled
- [ ] A (recommended) requirement of 2 reviewers should be required for each PR

Additionally, @infi is required for UI/UX PRs. At this time I've included them under the entire `packages/client` folder. This runs the risk of having them added to PRs that are not UI/UX related. I need an idea of which files are under @infi's purview. I don't know enough about a frontend project's structure to confidently make this call.

