### PR TITLE
fix: Spacing around emoji/link/markdown in reply preview

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
@@ -110,8 +110,11 @@ export function MessageReply(props: Props) {
     if (content.length > 128) {
       content = content.slice(0, 128) + "...";
     }
+    content = content.replace(/\n/g, " ");
 
-    return renderSimpleMarkdown(content.replace(/\n/g, " "));
+    content = content.replace(/ /g, "\u00A0");
+
+    return renderSimpleMarkdown(content);
   };
 
   return (

--- a/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
@@ -96,7 +96,6 @@ const Attachments = styled("em", {
 const Link = styled("a", {
   base: {
     minWidth: 0,
-    display: "flex",
     alignItems: "center",
     gap: "var(--gap-md)",
   },
@@ -110,11 +109,8 @@ export function MessageReply(props: Props) {
     if (content.length > 128) {
       content = content.slice(0, 128) + "...";
     }
-    content = content.replace(/\n/g, " ");
 
-    content = content.replace(/ /g, "\u00A0");
-
-    return renderSimpleMarkdown(content);
+    return renderSimpleMarkdown(content.replace(/\n/g, " "));
   };
 
   return (
@@ -161,7 +157,6 @@ export function MessageReply(props: Props) {
 
 const ReplyContent = styled("div", {
   base: {
-    display: "flex",
     overflow: "hidden",
     alignItems: "center",
     whiteSpace: "nowrap",


### PR DESCRIPTION
Fix reply preview removing spaces around emoji/link/markdown by ~~replacing ASCII space to unicode char to preserve the gap~~ removing the `display: "flex"` on ReplyContent and Link elements thanks to @Pecacheu for pointing it out

![image (1)](https://github.com/user-attachments/assets/2e7237bd-c4b3-42ae-8669-c5bd17127a7a)

***

Fixes: <https://github.com/stoatchat/for-web/issues/1182>

- `main` <!-- branch-stack -->
  - \#1022 :point\_left:
