### PR TITLE
feat: PWA hint dialog for mobile devices

### DIFF
--- a/packages/client/components/modal/modals.tsx
+++ b/packages/client/components/modal/modals.tsx
@@ -53,6 +53,7 @@ import { ServerInfoModal } from "./modals/ServerInfo";
 import { SettingsModal } from "./modals/Settings";
 import { SignOutSessionsModal } from "./modals/SignOutSessions";
 import { SignedOutModal } from "./modals/SignedOut";
+import { TryPWAModal } from "./modals/TryPWA";
 import { UserProfileModal } from "./modals/UserProfile";
 import { UserProfileMutualFriendsModal } from "./modals/UserProfileMutualFriends";
 import { UserProfileMutualGroupsModal } from "./modals/UserProfileMutualGroups";
@@ -183,6 +184,8 @@ export function RenderModal(props: ActiveModal & { onClose: () => void }) {
       return <ResetBotTokenModal {...modalProps} />;
     case "edit_category":
       return <EditCategoryModal {...modalProps} />;
+    case "try_pwa":
+      return <TryPWAModal {...modalProps} />;
 
     default:
       console.error(

--- a/packages/client/components/modal/modals/TryPWA.tsx
+++ b/packages/client/components/modal/modals/TryPWA.tsx
@@ -1,0 +1,49 @@
+import { Trans } from "@lingui-solid/solid/macro";
+
+import { Dialog, DialogProps, iconSize } from "@revolt/ui";
+
+import MdInfo from "@material-design-icons/svg/outlined/error.svg?component-solid";
+
+import { t } from "@lingui/core/macro";
+import { useState } from "@revolt/state";
+import { Modals } from "../types";
+
+export function TryPWAModal(props: DialogProps & Modals & { type: "try_pwa" }) {
+  const state = useState();
+
+  return (
+    <Dialog
+      icon={<MdInfo {...iconSize(24)} />}
+      show={props.show}
+      onClose={() => {
+        state.settings.setValue("pwa:shown", true);
+        props.onClose();
+      }}
+      title={<Trans>Did you know?</Trans>}
+      actions={[
+        { text: <Trans>Close</Trans> },
+        {
+          text: <Trans>Install</Trans>,
+          onClick: () => {
+            // @ts-expect-error PWA event not recognized
+            if (state.pwaPrompt) state.pwaPrompt.prompt();
+            else
+              alert(
+                t`Sorry, your device doesn't support auto-install. Check your browser's menu for the 'Add to Home Screen' option.`,
+              );
+          },
+        },
+      ]}
+    >
+      <Trans>
+        You can <b>install</b> this Web App on your devive for conveient access
+        from the Home Screen, just like a real app. It even hides the huge menu
+        bar!
+        <br />
+        <br />
+        To install, tap the button below or open your browser's menu and choose
+        <b> Add to Home Screen</b>.
+      </Trans>
+    </Dialog>
+  );
+}

--- a/packages/client/components/modal/modals/TryPWA.tsx
+++ b/packages/client/components/modal/modals/TryPWA.tsx
@@ -37,12 +37,8 @@ export function TryPWAModal(props: DialogProps & Modals & { type: "try_pwa" }) {
     >
       <Trans>
         You can <b>install</b> this Web App on your devive for conveient access
-        from the Home Screen, just like a real app. It even hides the huge menu
-        bar!
-        <br />
-        <br />
-        To install, tap the button below or open your browser's menu and choose
-        <b> Add to Home Screen</b>.
+        from the Home Screen. Tap the button below or open your browser's menu
+        and choose <b>Add to Home Screen</b>.
       </Trans>
     </Dialog>
   );

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -314,4 +314,7 @@ export type Modals =
       type: "edit_category";
       server: Server;
       category: CategoryData;
+    }
+  | {
+      type: "try_pwa";
     };

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -11,6 +11,7 @@ import { SetStoreFunction, createStore } from "solid-js/store";
 import equal from "fast-deep-equal";
 import localforage from "localforage";
 
+import { isMobileBrowser } from "@livekit/components-core";
 import { AbstractStore, Store } from "./stores";
 import { Auth } from "./stores/Auth";
 import { Draft } from "./stores/Draft";
@@ -46,6 +47,9 @@ export class State {
   private store: Store;
   private setStore: SetStoreFunction<Store>;
   private writeQueue: Record<string, number>;
+
+  isMobile: boolean;
+  pwaPrompt: Event | undefined;
 
   // define all stores
   auth = new Auth(this);
@@ -99,6 +103,7 @@ export class State {
     this.store = store as never;
     this.setStore = setStore;
     this.writeQueue = {};
+    this.isMobile = isMobileBrowser();
   }
 
   /**

--- a/packages/client/components/state/stores/Settings.ts
+++ b/packages/client/components/state/stores/Settings.ts
@@ -68,6 +68,11 @@ interface SettingsDefinition {
    * Last read changelog index
    */
   "changelog:last_index": number;
+
+  /**
+   * Whether the user has seen the TryPWA dialog
+   */
+  "pwa:shown": boolean;
 }
 
 /**
@@ -95,6 +100,7 @@ const EXPECTED_TYPES: { [K in keyof SettingsDefinition]: ValueType<K> } = {
   "advanced:copy_id": "boolean",
   "advanced:admin_panel": "boolean",
   "changelog:last_index": "number",
+  "pwa:shown": "boolean",
 };
 
 /**

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -108,8 +108,12 @@ function BotRedirect() {
   return <PWARedirect />;
 }
 
+let pwaPrompt: Event;
+addEventListener("beforeinstallprompt", (e) => (pwaPrompt = e));
+
 function MountContext(props: { children?: JSX.Element }) {
   const state = useState();
+  state.pwaPrompt = pwaPrompt;
 
   /**
    * Tanstack Query client


### PR DESCRIPTION
Split off from #835

A lot of users, including my testers so far, have _literally no idea_ what the heck a Progressive Web App is, and didn't even know they could install the web page like an app. Unlike on desktop (where Chromium browsers for instance show a little 'install' icon in the URL bar), mobile browsers (Android and iOS) don't really display any hint whatsoever on supported sites.

This dialog should pop up for the user after logging in- but **only once and only on mobile**, with a helpful tip. Once dismissed, it should not appear again.

<img width="400" src="https://github.com/user-attachments/assets/1ea86dcb-5d4d-4cb8-891c-05d46cf35f09" />