### PR TITLE
feat: Embeds allowed directly in messages to enable powerful Markdown formatting

### DIFF
--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -18,7 +18,6 @@ import { styled } from "styled-system/jsx";
 import { decodeTime } from "ulid";
 
 import { useClient } from "@revolt/client";
-import { isGif } from "@revolt/common/lib/gifs";
 import { useTime } from "@revolt/i18n";
 import { Markdown } from "@revolt/markdown";
 import { startsWithPackPUA } from "@revolt/markdown/emoji/UnicodeEmoji";
@@ -46,12 +45,6 @@ import {
 } from "../../../menus/UserContextMenu";
 
 import { EditMessage } from "./EditMessage";
-
-/**
- * Regex for matching URLs
- */
-const RE_URL =
-  /[(http(s)?)://(www.)?a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
 
 interface Props {
   /**
@@ -117,16 +110,6 @@ export function Message(props: Props) {
   const [isHovering, setIsHovering] = createSignal(false);
   const [reactPicker, setReactPicker] = createSignal<MediaPickerProps>();
   let msgRef!: HTMLDivElement;
-
-  /**
-   * Determine whether this message only contains a GIF
-   */
-  const isOnlyGIF = () =>
-    props.message.embeds &&
-    props.message.embeds.length === 1 &&
-    isGif(props.message.embeds[0]) &&
-    props.message.content &&
-    !props.message.content.replace(RE_URL, "").length;
 
   /**
    * React with an emoji
@@ -355,23 +338,30 @@ export function Message(props: Props) {
             return <></>;
           }}
         </CompositionMediaPicker>
-        <Switch>
+        <Switch
+          fallback={
+            <For each={props.message.embeds}>
+              {(em) => <Embed embed={em} />}
+            </For>
+          }
+        >
           <Match when={props.editing}>
             <EditMessage message={props.message} />
           </Match>
-          <Match when={props.message.content && !isOnlyGIF()}>
-            <BreakText>
-              <Markdown content={props.message.content!} />
-            </BreakText>
+          <Match when={props.message.content}>
+            <Markdown
+              content={props.message.content}
+              message={props.message}
+              container={(md) => (
+                <BreakText class="message_body">{md}</BreakText>
+              )}
+            />
           </Match>
         </Switch>
         <For each={props.message.attachments}>
           {(attachment) => (
             <Attachment message={props.message} file={attachment} />
           )}
-        </For>
-        <For each={props.message.embeds}>
-          {(embed) => <Embed embed={embed} />}
         </For>
         <Reactions
           reactions={

--- a/packages/client/components/markdown/index.tsx
+++ b/packages/client/components/markdown/index.tsx
@@ -13,6 +13,7 @@ import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 import { VFile } from "vfile";
 
+import { Message } from "stoat.js";
 import * as elements from "./elements";
 import { injectEmojiSize } from "./emoji/util";
 import { RenderCodeblock } from "./plugins/Codeblock";
@@ -46,7 +47,7 @@ import {
   unicodeEmojiHandler,
 } from "./plugins/unicodeEmoji";
 import { remarkInsertBreaks, sanitise } from "./sanitise";
-import { childrenToSolid } from "./solid-markdown/ast-to-solid";
+import { Container, childrenToSolid } from "./solid-markdown/ast-to-solid";
 import { defaults } from "./solid-markdown/defaults";
 
 /**
@@ -298,6 +299,17 @@ export interface MarkdownProps {
   content?: string;
 
   /**
+   * Container to wrap render in
+   */
+  container?: Container;
+
+  /**
+   * Parent message (**DO NOT** use this for any Markdown other than the
+   * root-level content of a message, else it will cause infinite recursion)
+   */
+  message?: Message;
+
+  /**
    * Whether to prevent big emoji from rendering
    */
   disallowBigEmoji?: boolean;
@@ -324,7 +336,6 @@ export function renderSimpleMarkdown(content: string) {
         components: replyComponents(),
       },
       schema: html,
-      listDepth: 0,
     },
     hastNode,
   );
@@ -380,9 +391,10 @@ export function Markdown(props: MarkdownProps) {
           ...defaults,
           // @ts-expect-error it doesn't like the td component
           components: components(),
+          container: props.container,
+          message: props.message,
         },
         schema: html,
-        listDepth: 0,
       },
       hastNode,
     );
@@ -395,8 +407,8 @@ export function Markdown(props: MarkdownProps) {
   // If it ever updates, re-render the whole tree:
   createEffect(
     on(
-      () => props.content,
-      (content) => setChildren(render(content)),
+      [() => props.content, () => props.message?.embeds],
+      (data) => setChildren(render(data[0])),
       { defer: true },
     ),
   );

--- a/packages/client/components/markdown/plugins/anchors.tsx
+++ b/packages/client/components/markdown/plugins/anchors.tsx
@@ -1,6 +1,7 @@
 import { JSX, Show, splitProps } from "solid-js";
 
 import { Trans } from "@lingui/solid/macro";
+import { MessageEmbed } from "stoat.js";
 import { cva } from "styled-system/css";
 
 import { MessageContextMenu, useMessage } from "@revolt/app";
@@ -8,9 +9,10 @@ import { useClient } from "@revolt/client";
 import { STOAT_HOST } from "@revolt/common/lib/env";
 import { DefaultHost, useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
+import { trimURL } from "@revolt/modal/modals/LinkWarning";
 import { paramsFromPathname } from "@revolt/routing";
 import { useState } from "@revolt/state";
-import { Avatar, iconSize } from "@revolt/ui";
+import { Avatar, Embed, iconSize } from "@revolt/ui";
 import { Invite } from "@revolt/ui/components/features/messaging/elements/Invite";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
@@ -62,25 +64,34 @@ function inAppScope(link: URL, root: string): boolean {
 }
 
 export function RenderAnchor(
-  props: { disabled?: boolean } & JSX.AnchorHTMLAttributes<HTMLAnchorElement>,
+  props: {
+    disabled?: boolean;
+    embeds?: MessageEmbed[];
+    node?: Element;
+  } & JSX.AnchorHTMLAttributes<HTMLAnchorElement>,
 ) {
   /* eslint-disable solid/reactivity */
   /* eslint-disable solid/components-return-once */
 
-  const [localProps, remoteProps] = splitProps(props, [
-    "href",
-    "target",
-    "disabled",
-  ]);
+  const text = Array.isArray(props.children) && props.children[0]?.toString(),
+    plainLink = text === props.href && !props.disabled;
 
   const instance = useInstance();
 
   // Handle empty link
-  if (!localProps.href) return <span>{remoteProps.children}</span>;
+  if (
+    !props.href ||
+    (props.node &&
+      !text &&
+      // Nested anchor, continue down the stack
+      [...props.node.children].find((el) => el.tagName === "a"))
+  )
+    return props.children;
 
   // Test internal link
   try {
-    let url = new URL(localProps.href);
+    let url = new URL(props.href),
+      internal = false;
 
     // Only allow http, https, mailto, and tel protocols
     if (
@@ -88,9 +99,8 @@ export function RenderAnchor(
       url.protocol !== "https:" &&
       url.protocol !== "mailto:" &&
       url.protocol !== "tel:"
-    ) {
-      return <span>{remoteProps.children}</span>;
-    }
+    )
+      return props.children;
 
     // Remap discover links to native links
     if (url.origin === "https://rvlt.gg" || url.origin === "https://stt.gg") {
@@ -185,26 +195,22 @@ export function RenderAnchor(
             </LinkComponent>
           </Show>
         );
-      } else if (
-        params.inviteId &&
-        // only display invites if it is just the plain link:
-        Array.isArray(remoteProps.children) &&
-        remoteProps.children[0] === localProps.href &&
-        !localProps.disabled
-      ) {
+      } else if (params.inviteId && plainLink) {
         return <Invite code={params.inviteId} />;
-      } else {
-        const internalUrl = () =>
-          new URL(url.pathname, location.origin).toString();
+      }
+      internal = true;
+    }
 
-        return (
-          <LinkComponent
-            {...remoteProps}
-            class={link()}
-            disabled={localProps.disabled}
-            href={internalUrl()}
-          />
-        );
+    //Inline link embed
+    if (plainLink && props.embeds) {
+      const href = trimURL(url, true);
+      for (let i = 0, l = props.embeds.length, em; i < l; ++i) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        em = props.embeds[i] as any;
+        if (trimURL(em.originalUrl || em.url, true) === href) {
+          props.embeds.splice(i, 1);
+          return <Embed embed={em} link={url} />;
+        }
       }
     }
 
@@ -222,31 +228,37 @@ export function RenderAnchor(
         openModal({
           type: "link_warning",
           url,
-          display: event.currentTarget!.innerText,
+          display: text || url.href,
         });
       }
     }
 
+    const destUrl = trimURL(url);
+
+    //Override internal URL
+    if (internal)
+      url = new URL(url.pathname + url.search + url.hash, location.origin);
+
     return (
       <Show
-        when={state.linkSafety.isTrusted(url)}
+        when={internal || state.linkSafety.isTrusted(url)}
         fallback={
           <LinkComponent
-            {...remoteProps}
+            children={props.node ? text : props.children}
             class={link()}
-            dest={localProps.href}
-            disabled={localProps.disabled}
+            dest={destUrl}
+            disabled={props.disabled}
             onClick={onHandleWarning}
             onAuxClick={onHandleWarning}
           />
         }
       >
         <LinkComponent
-          {...remoteProps}
+          children={props.node ? text : props.children}
           class={link()}
-          disabled={localProps.disabled}
-          dest={localProps.href}
-          href={localProps.href}
+          disabled={props.disabled}
+          dest={destUrl}
+          href={internal ? trimURL(url) : destUrl}
           target={"_blank"}
           rel="noreferrer"
         />
@@ -256,7 +268,7 @@ export function RenderAnchor(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (_) {
     // invalid URL
-    return <span>{props.children}</span>;
+    return props.children;
   }
 }
 

--- a/packages/client/components/markdown/solid-markdown/ast-to-solid.tsx
+++ b/packages/client/components/markdown/solid-markdown/ast-to-solid.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * This file is provided under the MIT License
  * Copyright (c) 2015 Espen Hovlandsdal
@@ -11,7 +10,7 @@ import { Dynamic } from "solid-js/web";
 import { stringify as commas } from "comma-separated-tokens";
 import type {
   Comment,
-  DocType,
+  Doctype,
   Element,
   ElementContent,
   Root,
@@ -22,6 +21,8 @@ import { find, hastToReact, svg } from "property-information";
 import { stringify as spaces } from "space-separated-tokens";
 import style from "style-to-object";
 
+import { Embed } from "@revolt/ui";
+import { Message, MessageEmbed } from "stoat.js";
 import type { NormalComponents, SolidMarkdownProps } from "./complex-types";
 
 export type Position = {
@@ -36,7 +37,8 @@ type Raw = {
 type Context = {
   options: Options;
   schema: Schema;
-  listDepth: number;
+  _listDepth?: number;
+  _embeds?: MessageEmbed[];
 };
 type TransformLink = (
   href: string,
@@ -108,6 +110,8 @@ type SpecialComponents = {
 type Components = Partial<Omit<NormalComponents, keyof SpecialComponents>> &
   Partial<SpecialComponents>;
 
+export type Container = (md: JSX.Element[]) => JSX.Element;
+
 export type Options = {
   sourcePos: boolean;
   rawSourcePos: boolean;
@@ -117,6 +121,9 @@ export type Options = {
   transformImageUri?: TransformImage;
   linkTarget: TransformLinkTargetType | TransformLinkTarget;
   components: Components;
+  container?: Container;
+  message?: Message;
+  embeds?: MessageEmbed[];
 };
 
 const own = {}.hasOwnProperty;
@@ -129,15 +136,20 @@ export function childrenToSolid(
   context: Context,
   node: Element | Root,
 ): JSX.Element[] {
-  const children: JSX.Element[] = [];
-  let childIndex = -1;
+  const isRoot = node.type === "root";
+  let children: JSX.Element[] = [],
+    childIndex = -1;
 
-  // let child: Comment | DocType | Element | Raw | Text;
+  if (isRoot) context._listDepth = 0;
+
+  //Copy embeds to track use
+  const msgRoot = isRoot ? context.options.message : undefined;
+  if (msgRoot?.embeds) context._embeds = msgRoot.embeds.slice();
 
   while (++childIndex < node.children.length) {
     const child = node.children[childIndex] as
       | Comment
-      | DocType
+      | Doctype
       | Element
       | Raw
       | Text;
@@ -159,6 +171,14 @@ export function childrenToSolid(
       children.push(child.value);
     }
   }
+
+  //Apply container
+  if (isRoot && context.options.container)
+    children = [context.options.container(children)];
+
+  //Append unused embeds
+  if (isRoot && context._embeds)
+    for (const em of context._embeds) children.push(<Embed embed={em} />);
 
   return children;
 }
@@ -190,22 +210,18 @@ function toSolid(
     }
   }
 
-  if (name === "ol" || name === "ul") {
-    context.listDepth++;
-  }
+  if (name === "ol" || name === "ul") ++context._listDepth!;
 
   const children = childrenToSolid(context, node);
 
-  if (name === "ol" || name === "ul") {
-    context.listDepth--;
-  }
+  if (name === "ol" || name === "ul") --context._listDepth!;
 
   // Restore parent schema.
   context.schema = parentSchema;
 
   // Nodes created by plugins do not have positional info, in which case we use
   // an object that matches the position interface.
-  const position = node.position || {
+  const position = (node.position as Position) || {
     start: { line: null, column: null, offset: null },
     end: { line: null, column: null, offset: null },
   };
@@ -287,7 +303,7 @@ function toSolid(
 
   if (!basic && (name === "ol" || name === "ul")) {
     properties.ordered = name === "ol";
-    properties.depth = context.listDepth;
+    properties.depth = context._listDepth;
   }
 
   if (name === "td" || name === "th") {
@@ -324,6 +340,7 @@ function toSolid(
 
   if (!basic) {
     properties.node = node;
+    properties.embeds = context._embeds;
   }
 
   return (

--- a/packages/client/components/modal/modals/LinkWarning.tsx
+++ b/packages/client/components/modal/modals/LinkWarning.tsx
@@ -8,33 +8,56 @@ import { Checkbox, Column, Dialog, DialogProps, Text } from "@revolt/ui";
 
 import { Modals } from "../types";
 
-/**
- * Modal to warn the user about a potentially unsafe link
- */
+const URL_TRIM = /\/+$/;
+
+/** Trim trailing slash from URL
+@param noHash Remove #hash before trimming
+*/
+export function trimURL(url: string | URL, noHash?: boolean) {
+  if (!(url instanceof URL)) {
+    try {
+      url = new URL(url);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_) {
+      return url as string;
+    }
+  }
+
+  let base = url.protocol + "//";
+  if (url.username || url.password)
+    base += `${url.username}${url.password ? ":" + url.password : ""}@`;
+
+  return (
+    base +
+    url.host +
+    url.pathname.replace(URL_TRIM, "") +
+    url.search +
+    (noHash ? "" : url.hash)
+  );
+}
+
+/** Modal to warn the user about a potentially unsafe link */
 export function LinkWarningModal(
   props: DialogProps & Modals & { type: "link_warning" },
 ) {
   const state = useState();
   const [value, setValue] = createSignal(false);
 
-  const scrutiny = createMemo(() => {
-    const destUrlString = props.url.toString();
-    if (destUrlString !== props.display) {
-      try {
-        const displayUrl = new URL(props.display);
-        if (destUrlString !== displayUrl.toString()) {
-          return 2;
-        } else {
-          return 1;
-        }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (_) {
-        // URL parsing failed; the link is likely not intentionally misleading.
-        return 1;
-      }
-    }
+  // eslint-disable-next-line solid/reactivity
+  const urlStr = trimURL(props.url),
+    // eslint-disable-next-line solid/reactivity
+    dispStr = trimURL(props.display);
 
-    return 0;
+  const scrutiny = createMemo(() => {
+    if (dispStr === urlStr) return 0;
+
+    try {
+      return dispStr === trimURL(new URL(dispStr)) ? 1 : 2;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_) {
+      // URL parsing failed; the link is likely not intentionally misleading.
+      return 1;
+    }
   });
 
   return (
@@ -47,11 +70,8 @@ export function LinkWarningModal(
         {
           text: <Trans>Continue</Trans>,
           onClick: () => {
-            window.open(props.url, "_blank", "noopener");
-
-            if (value() && scrutiny() === 0) {
-              state.linkSafety.trust(props.url);
-            }
+            open(urlStr, "_blank", "noopener");
+            if (value() && scrutiny() === 0) state.linkSafety.trust(props.url);
           },
           isDisabled: scrutiny() === 2 && !value(),
         },
@@ -60,7 +80,7 @@ export function LinkWarningModal(
       <Column>
         <span>
           <Trans>Are you sure you want to go to </Trans>
-          <Link>{props.url.toString()}</Link>?
+          <Link>{urlStr}</Link>?
         </span>
         <Switch
           fallback={
@@ -73,7 +93,7 @@ export function LinkWarningModal(
           }
         >
           <Match when={scrutiny() === 1}>
-            <Trans>You clicked on "{props.display}"</Trans>
+            <Trans>You clicked on "{dispStr}"</Trans>
           </Match>
           <Match when={scrutiny() === 2}>
             <Scrutinise>
@@ -84,7 +104,7 @@ export function LinkWarningModal(
                   This is not the same as the link that was displayed:
                 </Trans>
               </Text>
-              <Link>{props.display}</Link>
+              <Link>{dispStr}</Link>
               <Checkbox checked={value()} onChange={() => setValue((v) => !v)}>
                 <Trans>I understand the consequences</Trans>
               </Checkbox>

--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -213,7 +213,7 @@ const Info = styled("div", {
     display: "flex",
     flexShrink: 0,
     justifyContent: "end",
-    padding: "2px var(--gap-sm)",
+    padding: "2px 5px",
   },
   variants: {
     tail: {
@@ -338,7 +338,7 @@ export function MessageContainer(props: Props) {
       onMouseEnter={() => props.onHover && props.onHover(true)}
       onMouseLeave={() => props.onHover && props.onHover(false)}
       class={
-        "group " +
+        "message group " +
         base({
           tail: props.tail,
           mentioned: props.mentioned,

--- a/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
@@ -1,4 +1,4 @@
-import { Match, Switch } from "solid-js";
+import { createMemo, Match, Switch } from "solid-js";
 
 import {
   ImageEmbed,
@@ -18,13 +18,13 @@ import { TextEmbed } from "./TextEmbed";
 /**
  * Render a given embed
  */
-export function Embed(props: { embed: MessageEmbed }) {
+export function Embed(props: { embed: MessageEmbed; link?: URL }) {
   const { openModal } = useModals();
 
   /**
    * Whether the embed is a GIF
    */
-  const isGIF = () => isGifLib(props.embed);
+  const isGIF = createMemo(() => isGifLib(props.embed));
 
   /**
    * Whether there is a video
@@ -45,7 +45,11 @@ export function Embed(props: { embed: MessageEmbed }) {
   return (
     <Switch fallback={`Could not render ${props.embed.type}!`}>
       <Match when={image()}>
-        <SizedContent width={image()!.width} height={image()!.height}>
+        <SizedContent
+          class={"img_embed embed"}
+          width={image()!.width}
+          height={image()!.height}
+        >
           <img
             // bypass proxy for known GIF providers
             // TODO: Remove the Gifbox check here once gifbox embeds are fixed
@@ -66,7 +70,11 @@ export function Embed(props: { embed: MessageEmbed }) {
         </SizedContent>
       </Match>
       <Match when={video()}>
-        <SizedContent width={video()!.width} height={video()!.height}>
+        <SizedContent
+          class={"video_embed embed"}
+          width={video()!.width}
+          height={video()!.height}
+        >
           <video
             playsinline
             loop={isGIF()}
@@ -95,7 +103,10 @@ export function Embed(props: { embed: MessageEmbed }) {
       <Match
         when={props.embed.type === "Website" || props.embed.type === "Text"}
       >
-        <TextEmbed embed={props.embed as WebsiteEmbed | TextEmbedClass} />
+        <TextEmbed
+          embed={props.embed as WebsiteEmbed | TextEmbedClass}
+          link={props.link}
+        />
       </Match>
       <Match when={props.embed.type === "None"}> </Match>
     </Switch>

--- a/packages/client/components/ui/components/features/messaging/elements/FileInfo.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/FileInfo.tsx
@@ -15,11 +15,15 @@ import { Column, Row } from "@revolt/ui/components/layout";
 import { humanFileSize } from "@revolt/ui/components/utils";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
-/**
- * Base container
- */
-const Base = styled(Row, {
-  base: {},
+const InfoColumn = styled(Column, {
+  base: {
+    overflow: "hidden",
+
+    "& > *": {
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    },
+  },
 });
 
 interface Props {
@@ -38,8 +42,15 @@ interface Props {
  * Information about a given attachment or embed
  */
 export function FileInfo(props: Props) {
+  function download(url: string, name?: string) {
+    const link = document.createElement("a");
+    link.href = url;
+    if (name) link.download = name;
+    link.click();
+  }
+
   return (
-    <Base align>
+    <Row align>
       <Switch fallback={<BiSolidFile size={24} />}>
         <Match
           when={
@@ -64,25 +75,23 @@ export function FileInfo(props: Props) {
           <BiSolidFileTxt size={24} />
         </Match>
       </Switch>
-      <Column grow>
+      <InfoColumn grow>
         <span>{props.file?.filename}</span>
         <Show when={props.file?.size}>
           <Text class="label" size="small">
             {humanFileSize(props.file!.size!)}
           </Text>
         </Show>
-      </Column>
+      </InfoColumn>
       <Show when={props.file}>
-        <a
-          target="_blank"
-          href={props.file?.originalUrl}
-          download={props.file?.filename}
+        <IconButton
+          onPress={() =>
+            download(props.file!.originalUrl, props.file?.filename)
+          }
         >
-          <IconButton>
-            <Symbol>download</Symbol>
-          </IconButton>
-        </a>
+          <Symbol>download</Symbol>
+        </IconButton>
       </Show>
-    </Base>
+    </Row>
   );
 }

--- a/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
@@ -90,28 +90,39 @@ const Attachments = styled("em", {
   },
 });
 
-/**
- * Link styling
- */
 const Link = styled("a", {
   base: {
     display: "flex",
     minWidth: 0,
-    alignItems: "center",
     gap: "var(--gap-md)",
+    marginInlineEnd: "var(--gap-lg)",
   },
 });
+
+const ReplyMax = 128,
+  URLClip = ReplyMax + 8,
+  R_Trim = /\s+/g,
+  R_LastURL = /(?:^|\s)https?:\/\/[\w_.~!*''();:@&=+$,/?#[%-]+([\s\S]{0,7})$/,
+  R_URLEnd = /^[\w_.~!*''();:@&=+$,/?#[%-]+/;
 
 /**
  * Message being replied to
  */
 export function MessageReply(props: Props) {
   const renderReplyContent = (content: string) => {
-    if (content.length > 128) {
-      content = content.slice(0, 128) + "...";
+    if (content.length > ReplyMax) {
+      const cut = content.slice(0, URLClip);
+      let match, len;
+
+      //Clip without interrupting links
+      content =
+        (match = cut.match(R_LastURL)) && //Has URL at end
+        (match[1] || (len = content.slice(URLClip).match(R_URLEnd)?.[0].length)) //Remaining length
+          ? content.slice(0, URLClip + (len || -match[1].length)) + " ..." //Ensure full link
+          : cut.slice(0, ReplyMax) + "..."; //No link
     }
 
-    return renderSimpleMarkdown(content.replace(/\n/g, " "));
+    return renderSimpleMarkdown(content.replace(R_Trim, " "));
   };
 
   return (

--- a/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
@@ -34,7 +34,6 @@ const InformationRow = styled("div", {
   base: {
     display: "flex",
     flexDirection: "row",
-    width: "100%",
     alignItems: "center",
     gap: "var(--gap-md)",
   },
@@ -56,14 +55,9 @@ const PreviewImage = styled("img", {
   },
 });
 
-const Title = styled("span", {
-  base: {
-    minWidth: 0,
-    flexShrink: 1,
-
-    fontSize: "16px",
-    color: "var(--md-sys-color-primary) !important",
-  },
+const titleCss = css({
+  fontSize: "16px",
+  color: "var(--md-sys-color-primary)",
 });
 
 const Content = styled(Column, {
@@ -83,11 +77,26 @@ const Description = styled("div", {
 /**
  * Text Embed
  */
-export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
+export function TextEmbed(props: {
+  embed: TextEmbedClass | WebsiteEmbed;
+  link?: URL;
+}) {
   const { openModal } = useModals();
 
+  function nameFromURL() {
+    let name;
+    try {
+      name = new URL(props.embed.url!).hostname;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-empty
+    } catch (_) {}
+    return name || "Website";
+  }
+
   return (
-    <Base style={{ "border-color": props.embed.colour }}>
+    <Base
+      class="text_embed embed"
+      style={{ "border-color": props.embed.colour }}
+    >
       <Content gap="md" grow>
         <Show
           when={
@@ -112,9 +121,9 @@ export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
           </InformationRow>
         </Show>
 
-        <Show when={props.embed.title}>
+        <Show when={props.embed.url}>
           <InformationRow>
-            <Show when={props.embed.iconUrl && props.embed.type !== "Website"}>
+            <Show when={props.embed.iconUrl}>
               <Favicon
                 loading="lazy"
                 draggable={false}
@@ -122,11 +131,17 @@ export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
                 onError={(e) => (e.currentTarget.style.display = "none")}
               />
             </Show>
-            <Title>
-              <RenderAnchor href={props.embed.url}>
-                <OverflowingText>{props.embed.title}</OverflowingText>
+            <OverflowingText class={titleCss}>
+              <RenderAnchor
+                href={
+                  props.link?.toString() ||
+                  (props.embed as WebsiteEmbed).originalUrl ||
+                  props.embed.url
+                }
+              >
+                {props.embed.title ?? nameFromURL()}
               </RenderAnchor>
-            </Title>
+            </OverflowingText>
           </InformationRow>
         </Show>
 

--- a/packages/client/components/ui/components/utils/SizedContent.tsx
+++ b/packages/client/components/ui/components/utils/SizedContent.tsx
@@ -6,82 +6,47 @@ interface Props {
   /**
    * Pixel width of the content
    */
-  width: number;
+  width?: number;
 
   /**
    * Pixel height of the content
    */
-  height: number;
+  height?: number;
 
   /**
    * The content itself
    */
   children: JSX.Element;
+
+  class?: string;
 }
 
-const MIN_W = 160;
-const MIN_H = 120;
-const MAX_S = 420;
+const MIN_W = 160,
+  MIN_H = 120,
+  MAX_S = 420;
 
 /**
  * Automatic message content sizing for images, videos and embeds
  */
 export function SizedContent(props: Props) {
-  // const tall = () => props.width > props.height;
+  const style = createMemo(() => {
+    const width = props.width!,
+      height = props.height!;
 
-  // const desiredWidth = "max(var(--width), var(--layout-attachments-min-width))";
-  // const desiredHeight =
-  //   "max(var(--height), var(--layout-attachments-min-height))";
+    const setW =
+      (height > width
+        ? Math.floor(
+            (width * Math.min(Math.max(height, MIN_H), MAX_S)) / height,
+          ) //Set from height
+        : Math.min(Math.max(width, MIN_W), MAX_S)) || MAX_S; //Set from width
 
-  // const constrainedWidth = `calc(min(${desiredWidth}, (var(--width)/var(--height)) * min(${desiredHeight}, var(--layout-attachments-max-height))))`;
-  // const constrainedHeight = `calc(min(${desiredHeight}, (var(--height)/var(--width)) * min(${desiredWidth}, var(--layout-attachments-max-width))))`;
-
-  const size = createMemo(() => {
-    let width = props.width,
-      height = props.height;
-
-    // console.info("1", width, height);
-
-    // ensure min. size
-    if (width < MIN_W) {
-      height *= MIN_W / width;
-      width = MIN_W;
-    }
-    // console.info("2", width, height);
-
-    if (height < MIN_H) {
-      width *= MIN_H / height;
-      height = MIN_H;
-    }
-    // console.info("3", width, height);
-
-    // scale down to required size
-    if (width > MAX_S) {
-      height /= width / MAX_S;
-      width = MAX_S;
-    }
-    // console.info("4", width, height);
-
-    if (height > MAX_S) {
-      width /= height / MAX_S;
-      height = MAX_S;
-    }
-    // console.info("5", width, height);
-
-    return {
-      width,
-      height,
-    };
+    const sty: JSX.CSSProperties = { width: `min(${setW}px, 100%)` };
+    if (width && height) sty["aspect-ratio"] = `${width}/${height}`;
+    return sty;
   });
 
   return (
-    <Container
-      style={{
-        width: size().width + "px",
-        // height: size().height + "px",
-        "aspect-ratio": `${size().width} / ${size().height}`,
-      }}
-    >
+    <Container class={props.class} style={style()}>
       {props.children}
     </Container>
   );
@@ -90,34 +55,14 @@ export function SizedContent(props: Props) {
 const Container = styled("div", {
   base: {
     display: "grid",
-
     height: "auto",
-    maxWidth: "100%",
-
-    // // min. render size or chat width, whichever is smaller
-    // // minWidth: "calc(min(100%, var(--layout-attachments-min-width)))",
-    // minWidth: "var(--layout-attachments-min-width)",
-    // // max. render size or chat width, whichever is smaller
-    // // maxWidth: "calc(min(100%, var(--layout-attachments-max-width)))",
-    // maxWidth: "var(--layout-attachments-max-width)",
-    // // min. render size, whichever is smaller
-    // minHeight: "var(--layout-attachments-min-height)",
-    // // max. render size
-    // maxHeight: "calc(min(70vh, var(--layout-attachments-max-height)))",
-
-    // width: "auto",
-    // height: "var(--height)",
-    // aspectRatio: "var(--width) / var(--height)",
-
     overflow: "hidden",
     borderRadius: "var(--borderRadius-md)",
-
     gridTemplateColumns: "1fr",
     gridTemplateRows: "1fr",
 
     // scale to size of container
     "& > *": {
-      // gridArea: "1/1",
       // top-left corner to bottom-right corner
       gridArea: "1 / 1 / 2 / 2",
       width: "100%",
@@ -125,23 +70,7 @@ const Container = styled("div", {
 
       // special case for images
       minHeight: 0,
-
-      // testing:
       objectFit: "contain",
     },
-    // "& .Spoiler": {
-    //   width: "100%",
-    //   height: "100%",
-    // },
   },
-  // variants: {
-  //   tall: {
-  //     true: {
-  //       // // special case for image sizing:
-  //       // "& img": {
-  //       //   width: "unset",
-  //       // },
-  //     },
-  //   },
-  // },
 });

--- a/packages/client/components/ui/styles.css
+++ b/packages/client/components/ui/styles.css
@@ -25,6 +25,10 @@ body {
   background: #191919;
 }
 
+/* Consistent gap between embeds */
+.message_body .embed:not(:last-child) { margin-bottom: var(--gap-md) }
+.message_body .embed + br { display: none }
+
 /* HighlightJs */
 /*!
   Theme: GitHub Dark


### PR DESCRIPTION
_Split off from #835_

The old style of placing all embeds at **end** of the message can lead to confusion, for instance the embeds are often out of order from the links themselves, such as the example below.

This alternative approach places the embeds directly into the message content like a more traditional Markdown style, allowing for much clearer communication, with relevant images/links placed right where they're needed! To prevent an embed from appearing, you can use a Markdown link with custom text.

<img height="700" src="https://github.com/user-attachments/assets/ba657c5e-daef-4d4b-87c4-59b2e56876b2" />
<img height="700" src="https://github.com/user-attachments/assets/750568ce-07df-4c37-996d-c8177d44a73f" />

This fails safe in both directions: Embeds that the client can't find a matching link for still appear at the end as normal, and links that don't have a matching embed appear as a normal anchor link.

Also fixes this erroneous warning when clicking embed links.
<img height="300" src="https://github.com/user-attachments/assets/78c7aeca-f779-4bf7-afb8-ee2070748fe7" />

Fixes #998