### PR TITLE
fix: Make the sync store only update if remote is different than local

### DIFF
--- a/packages/client/components/state/stores/NotificationOptions.ts
+++ b/packages/client/components/state/stores/NotificationOptions.ts
@@ -86,6 +86,15 @@ export class NotificationOptions extends AbstractStore<
   }
 
   /**
+   * Get this store's value
+   *
+   * Reexported to allow equals checking for syncing
+   */
+  get() {
+    return super.get();
+  }
+
+  /**
    * Hydrate external context
    */
   hydrate(): void {

--- a/packages/client/components/state/stores/Ordering.ts
+++ b/packages/client/components/state/stores/Ordering.ts
@@ -25,6 +25,15 @@ export class Ordering extends AbstractStore<"ordering", TypeOrdering> {
   }
 
   /**
+   * Get this store's value
+   *
+   * Reexported to allow equals checking for syncing
+   */
+  get() {
+    return super.get();
+  }
+
+  /**
    * Hydrate external context
    */
   hydrate(): void {

--- a/packages/client/components/state/stores/Sync.ts
+++ b/packages/client/components/state/stores/Sync.ts
@@ -1,3 +1,4 @@
+import isEqual from "lodash.isequal";
 import { batch } from "solid-js";
 
 import { ReactiveSet } from "@solid-primitives/set";
@@ -6,6 +7,8 @@ import { Client } from "stoat.js";
 import { State } from "..";
 
 import { AbstractStore } from ".";
+import { TypeNotificationOptions } from "./NotificationOptions";
+import { TypeOrdering } from "./Ordering";
 
 type SynchronisedStores = "ordering" | "notifications";
 
@@ -163,15 +166,22 @@ export class Sync extends AbstractStore<"sync", TypeSynchronisation> {
     if (import.meta.env.DEV)
       console.info(`[sync] merge ${key} at ${ts} with`, data);
 
+    const parsed = this.state[key].clean(JSON.parse(data));
     if (ts > this.ts(key)) {
       // if ts is newer, hydrate the store with it
-      const parsed = this.state[key].clean(JSON.parse(data));
       this.set("revision", key, ts);
       this.#blockSync.add(key);
       this.state.set(key, parsed);
     } else if (ts !== this.ts(key)) {
-      // if ts is old, trigger write to synchronise to remote
-      this.touch(key);
+      // if ts is old, trigger write to synchronise to remote, but only if the data has been updated
+      if (
+        !isEqual(
+          this.state[key].get(),
+          parsed as TypeOrdering & TypeNotificationOptions,
+        )
+      ) {
+        this.touch(key);
+      }
     }
   }
 


### PR DESCRIPTION
Adds a deep equal function to Ordering and NotificationOptions stores. The sync store will not attempt to update the server if the incoming data is equal to the existing data.

Closes #1009
