### PR TITLE
fix: also check if the member is the owner on UserProfileRoles.tsx

### DIFF
--- a/packages/client/components/modal/modals/UserProfileRoles.tsx
+++ b/packages/client/components/modal/modals/UserProfileRoles.tsx
@@ -56,7 +56,8 @@ export function UserProfileRolesModal(
                   disabled={
                     // this needs a better API
                     // not sure if this actually works
-                    (role.rank ?? 0) <
+		    !props.member.server?.owner?.self &&
+		    (role.rank ?? 0) <
                     (props.member.server?.member?.orderedRoles.toReversed()[0]
                       ?.rank ?? 0)
                   }

--- a/packages/client/components/modal/modals/UserProfileRoles.tsx
+++ b/packages/client/components/modal/modals/UserProfileRoles.tsx
@@ -56,10 +56,10 @@ export function UserProfileRolesModal(
                   disabled={
                     // this needs a better API
                     // not sure if this actually works
-		    !props.member.server?.owner?.self &&
-		    (role.rank ?? 0) <
-                    (props.member.server?.member?.orderedRoles.toReversed()[0]
-                      ?.rank ?? 0)
+                    !props.member.server?.owner?.self &&
+                    (role.rank ?? 0) <
+                      (props.member.server?.member?.orderedRoles.toReversed()[0]
+                        ?.rank ?? 0)
                   }
                   onChange={() =>
                     props.member.edit({


### PR DESCRIPTION
This fixes an issue with how role rankings in `UserProfileRoles` were calculated, where it was not checking if the member being targeted was both ourselves **and** the owner of the server.

This seemed to confuse new users who were creating servers and had "owner" roles that were not ordered properly.