### PR TITLE
feat: add screenshare audio with muting capabilities

### DIFF
--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -44,6 +44,7 @@ export function UserContextMenu(props: {
   member?: ServerMember;
   contextMessage?: Message;
   inVoice?: boolean;
+  isScreenshare?: boolean;
 }) {
   // TODO: if we take serverId instead, we could dynamically fetch server member here
   // same for the floating menu I guess?
@@ -278,7 +279,7 @@ export function UserContextMenu(props: {
   return (
     <ContextMenu class="UserContextMenu">
       {/* Voice controls */}
-      <Show when={props.inVoice && !props.user.self}>
+      <Show when={props.inVoice && !props.user.self && !props.isScreenshare}>
         <ContextMenuButton
           onMouseDown={(e) => e.stopImmediatePropagation()}
           onClick={(e) => e.stopImmediatePropagation()}
@@ -314,6 +315,47 @@ export function UserContextMenu(props: {
         >
           <Trans>Mute</Trans>
         </ContextMenuButton>
+        <ContextMenuDivider />
+      </Show>
+      <Show when={props.isScreenshare && !props.user.self}>
+        <ContextMenuButton
+          onMouseDown={(e) => e.stopImmediatePropagation()}
+          onClick={(e) => e.stopImmediatePropagation()}
+        >
+          <Text class="label">
+            <Trans>Screen Share Volume</Trans>
+          </Text>
+          <Slider
+            min={0}
+            max={3}
+            step={0.1}
+            value={state.voice.getScreenShareVolume(props.user.id)}
+            onInput={(event) =>
+              state.voice.setScreenShareVolume(
+                props.user.id,
+                event.currentTarget.value,
+              )
+            }
+            labelFormatter={(label) => (label * 100).toFixed(0) + "%"}
+          />
+        </ContextMenuButton>
+        <ContextMenuButton
+          icon={MdMicOff}
+          onClick={() =>
+            state.voice.setScreenShareMuted(
+              props.user.id,
+              !state.voice.getScreenShareMuted(props.user.id),
+            )
+          }
+          actionSymbol={
+            state.voice.getScreenShareMuted(props.user.id)
+              ? MdChecked
+              : MdUnchecked
+          }
+        >
+          <Trans>Mute Screen Share</Trans>
+        </ContextMenuButton>
+
         <ContextMenuDivider />
       </Show>
 

--- a/packages/client/components/modal/modals/ScreenSharePicker.tsx
+++ b/packages/client/components/modal/modals/ScreenSharePicker.tsx
@@ -19,6 +19,7 @@ export function ScreenSharePickerModal(
     qualityName: createFormControl<ScreenShareQualityName>(
       voice.screenShareQuality || "low",
     ),
+    audio: createFormControl(voice.screenShareAudio),
     idx: createFormControl([0], { required: true }),
   });
 
@@ -26,6 +27,7 @@ export function ScreenSharePickerModal(
     props.callback(
       group.controls.idx.value[0],
       group.controls.qualityName.value,
+      group.controls.audio.value,
     );
     props.onClose();
   }
@@ -89,6 +91,9 @@ export function ScreenSharePickerModal(
               };
             })}
           />
+          <Form2.Checkbox control={group.controls.audio}>
+            <Trans>Share audio</Trans>
+          </Form2.Checkbox>
         </Column>
       </form>
     </Dialog>

--- a/packages/client/components/modal/modals/ScreenShareSettings.tsx
+++ b/packages/client/components/modal/modals/ScreenShareSettings.tsx
@@ -19,6 +19,7 @@ export function ScreenShareSettingsModal(
       voice.screenShareQuality || "low",
       { required: true },
     ),
+    audio: createFormControl(voice.screenShareAudio),
     dontAsk: createFormControl(false),
   });
 
@@ -26,9 +27,13 @@ export function ScreenShareSettingsModal(
     if (group.controls.dontAsk.value) {
       voice.screenShareQuality = group.controls.qualityName.value;
       voice.screenShareQualityAsk = false;
+      voice.screenShareAudio = group.controls.audio.value;
     }
 
-    props.callback(group.controls.qualityName.value);
+    props.callback(
+      group.controls.qualityName.value,
+      group.controls.audio.value,
+    );
     props.onClose();
   }
 
@@ -74,6 +79,9 @@ export function ScreenShareSettingsModal(
               };
             })}
           />
+          <Form2.Checkbox control={group.controls.audio}>
+            <Trans>Share audio</Trans>
+          </Form2.Checkbox>
           <Form2.Checkbox control={group.controls.dontAsk}>
             <Trans>Don't ask me again</Trans>
           </Form2.Checkbox>

--- a/packages/client/components/modal/modals/ScreenShareSettings.tsx
+++ b/packages/client/components/modal/modals/ScreenShareSettings.tsx
@@ -20,7 +20,9 @@ export function ScreenShareSettingsModal(
       voice.screenShareQuality || "low",
       { required: true },
     ),
-    audio: createFormControl(voice.screenShareAudio),
+    audio: createFormControl(props.audio && voice.screenShareAudio, {
+      disabled: !props.audio,
+    }),
     dontAsk: createFormControl(false),
   });
 
@@ -88,6 +90,11 @@ export function ScreenShareSettingsModal(
           <Form2.Checkbox control={group.controls.dontAsk}>
             <Trans>Don't ask me again</Trans>
           </Form2.Checkbox>
+          <Show when={!props.audio}>
+            <small>
+              <Trans>Audio disabled by browser</Trans>
+            </small>
+          </Show>
         </Column>
       </form>
     </Dialog>

--- a/packages/client/components/modal/modals/ScreenShareSettings.tsx
+++ b/packages/client/components/modal/modals/ScreenShareSettings.tsx
@@ -6,6 +6,7 @@ import { ScreenShareQualityName } from "@revolt/state/stores/Voice";
 import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
 import { VideoTrack } from "solid-livekit-components";
 
+import { Show } from "solid-js";
 import { Modals } from "../types";
 
 export function ScreenShareSettingsModal(
@@ -32,7 +33,7 @@ export function ScreenShareSettingsModal(
 
     props.callback(
       group.controls.qualityName.value,
-      group.controls.audio.value,
+      group.controls.audio.value && props.audio,
     );
     props.onClose();
   }
@@ -79,9 +80,11 @@ export function ScreenShareSettingsModal(
               };
             })}
           />
-          <Form2.Checkbox control={group.controls.audio}>
-            <Trans>Share audio</Trans>
-          </Form2.Checkbox>
+          <Show when={props.audio}>
+            <Form2.Checkbox control={group.controls.audio}>
+              <Trans>Share audio</Trans>
+            </Form2.Checkbox>
+          </Show>
           <Form2.Checkbox control={group.controls.dontAsk}>
             <Trans>Don't ask me again</Trans>
           </Form2.Checkbox>

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -321,12 +321,16 @@ export type Modals =
       type: "screen_share_settings";
       trackReference: TrackReference;
       qualities: { name: string; fullName: string }[];
-      callback: (qualityName: ScreenShareQualityName) => void;
+      callback: (qualityName: ScreenShareQualityName, audio: boolean) => void;
       onCancel: () => void;
     }
   | {
       type: "screen_share_picker";
-      callback: (idx: number, qualityName: ScreenShareQualityName) => void;
+      callback: (
+        idx: number,
+        qualityName: ScreenShareQualityName,
+        audio: boolean,
+      ) => void;
       qualities: { name: string; fullName: string }[];
       sources: {
         idx: number;

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -321,6 +321,7 @@ export type Modals =
       type: "screen_share_settings";
       trackReference: TrackReference;
       qualities: { name: string; fullName: string }[];
+      audio: boolean;
       callback: (qualityName: ScreenShareQualityName, audio: boolean) => void;
       onCancel: () => void;
     }

--- a/packages/client/components/rtc/components/RoomAudioManager.tsx
+++ b/packages/client/components/rtc/components/RoomAudioManager.tsx
@@ -50,10 +50,14 @@ export function RoomAudioManager() {
             trackRef={track()}
             volume={
               state.voice.outputVolume *
-              state.voice.getUserVolume(track().participant.identity)
+              (track().source === Track.Source.ScreenShareAudio
+                ? state.voice.getScreenShareVolume(track().participant.identity)
+                : state.voice.getUserVolume(track().participant.identity))
             }
             muted={
-              state.voice.getUserMuted(track().participant.identity) ||
+              (track().source === Track.Source.ScreenShareAudio
+                ? state.voice.getScreenShareMuted(track().participant.identity)
+                : state.voice.getUserMuted(track().participant.identity)) ||
               voice.deafen()
             }
             enableBoosting

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -438,6 +438,7 @@ class Voice {
                   const v = qualities[k as ScreenShareQualityName]!;
                   return { name: k, fullName: v.fullName };
                 }),
+                audio: !!screenAudioTrack,
                 callback: async (qualityName, audio) => {
                   callback(qualityName, audio);
                   localTrack.resumeUpstream();

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -326,6 +326,7 @@ class Voice {
     } else {
       const qualities = this.getEnabledScreenShareQualities();
       let screenPickerQualityName: ScreenShareQualityName | undefined;
+      let screenPickerAudio: boolean | undefined;
 
       // Register the modal on screen picker handler if it exists
       if (window.native && window.native.onceScreenPicker) {
@@ -335,10 +336,14 @@ class Voice {
             onCancel: () => {
               window.native.screenPickerCallback(-1, false);
             },
-            callback: (idx: number, qualityName: ScreenShareQualityName) => {
-              // TODO: Change this to true when enabling screen share audio.
-              window.native.screenPickerCallback(idx, false);
+            callback: (
+              idx: number,
+              qualityName: ScreenShareQualityName,
+              audio: boolean,
+            ) => {
+              window.native.screenPickerCallback(idx, audio);
               screenPickerQualityName = qualityName;
+              screenPickerAudio = audio;
             },
             sources: sources,
             qualities: Object.keys(qualities).map((k) => {
@@ -357,15 +362,21 @@ class Voice {
               this.getEnabledScreenShareQualities()[
                 this.#settings.screenShareQuality || "low"
               ]?.resolution,
-            // TODO: Change this to true when enabling screen share audio.
-            audio: false,
+            audio: true,
           },
+        );
+
+        const screenAudioTrack = room.localParticipant.getTrackPublication(
+          Track.Source.ScreenShareAudio,
         );
 
         this.#setScreenshare(room.localParticipant.isScreenShareEnabled);
 
         if (localTrack) {
-          const callback = async (qualityName: ScreenShareQualityName) => {
+          const callback = async (
+            qualityName: ScreenShareQualityName,
+            audio: boolean,
+          ) => {
             const quality = qualities[qualityName] || qualities.low!;
 
             if (localTrack.videoTrack) {
@@ -382,14 +393,21 @@ class Voice {
               });
               localTrack.videoTrack.mediaStreamTrack.contentHint =
                 quality.contentHint;
+              if (!audio && screenAudioTrack?.track) {
+                room.localParticipant.unpublishTrack(screenAudioTrack.track);
+              }
             }
           };
 
           if (screenPickerQualityName) {
-            callback(screenPickerQualityName || "low");
+            callback(
+              screenPickerQualityName || "low",
+              screenPickerAudio || false,
+            );
           } else if (this.#settings.screenShareQualityAsk) {
             if (Object.keys(qualities).length > 1) {
               localTrack.pauseUpstream();
+              screenAudioTrack?.pauseUpstream();
               this.openModal({
                 onCancel: async () => {
                   await room.localParticipant.setScreenShareEnabled(false);
@@ -407,13 +425,19 @@ class Voice {
                   const v = qualities[k as ScreenShareQualityName]!;
                   return { name: k, fullName: v.fullName };
                 }),
-                callback: async (qualityName) => {
-                  callback(qualityName);
+                callback: async (qualityName, audio) => {
+                  callback(qualityName, audio);
                   localTrack.resumeUpstream();
+                  if (audio) {
+                    screenAudioTrack?.resumeUpstream();
+                  }
                 },
               });
             } else {
-              callback(this.#settings.screenShareQuality || "low");
+              callback(
+                this.#settings.screenShareQuality || "low",
+                this.#settings.screenShareAudio,
+              );
             }
           }
         }

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -373,6 +373,19 @@ class Voice {
         this.#setScreenshare(room.localParticipant.isScreenShareEnabled);
 
         if (localTrack) {
+          // This event is only fired if the screen share is ended by closing the window being streamed.
+          // This catches the ending and disables screen sharing on our side. If this weren't here,
+          // livekit would still share stream audio after closing the window being streamed.
+          localTrack.on("ended", () => {
+            this.toggleScreenshare();
+            const oldAudioTrack = room.localParticipant.getTrackPublication(
+              Track.Source.ScreenShareAudio,
+            );
+            if (oldAudioTrack && oldAudioTrack.track) {
+              room.localParticipant.unpublishTrack(oldAudioTrack.track);
+            }
+          });
+
           const callback = async (
             qualityName: ScreenShareQualityName,
             audio: boolean,

--- a/packages/client/components/state/stores/Voice.ts
+++ b/packages/client/components/state/stores/Voice.ts
@@ -37,6 +37,7 @@ export interface TypeVoice {
 
   screenShareQuality: ScreenShareQualityName;
   screenShareQualityAsk: boolean;
+  screenShareAudio: boolean;
 
   inputVolume: number;
   outputVolume: number;
@@ -45,6 +46,9 @@ export interface TypeVoice {
 
   userVolumes: Record<string, number>;
   userMutes: Record<string, boolean>;
+
+  screenShareVolumes: Record<string, number>;
+  screenShareMutes: Record<string, boolean>;
 }
 
 /**
@@ -76,12 +80,15 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
       autoGainControl: true,
       screenShareQuality: "low",
       screenShareQualityAsk: true,
+      screenShareAudio: true,
       inputVolume: 1.0,
       outputVolume: 1.0,
       deafen: false,
       micOn: true,
       userVolumes: {},
       userMutes: {},
+      screenShareVolumes: {},
+      screenShareMutes: {},
     };
   }
 
@@ -130,6 +137,10 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
       data.screenShareQualityAsk = input.screenShareQualityAsk;
     }
 
+    if (typeof input.screenShareAudio === "boolean") {
+      data.screenShareAudio = input.screenShareAudio;
+    }
+
     if (typeof input.inputVolume === "number") {
       data.inputVolume = input.inputVolume;
     }
@@ -157,6 +168,23 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
 
     if (typeof input.userMutes === "object") {
       Object.entries(input.userMutes)
+        .filter(
+          ([userId, muted]) => typeof userId === "string" && muted === true,
+        )
+        .forEach(([k, v]) => (data.userMutes[k] = v));
+    }
+
+    if (typeof input.screenShareVolumes === "object") {
+      Object.entries(input.screenShareVolumes)
+        .filter(
+          ([userId, volume]) =>
+            typeof userId === "string" && typeof volume === "number",
+        )
+        .forEach(([k, v]) => (data.userVolumes[k] = v));
+    }
+
+    if (typeof input.screenShareMutes === "object") {
+      Object.entries(input.screenShareMutes)
         .filter(
           ([userId, muted]) => typeof userId === "string" && muted === true,
         )
@@ -200,6 +228,42 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
    */
   getUserMuted(userId: string): boolean {
     return this.get().userMutes[userId] || false;
+  }
+
+  /**
+   * Set a user's screen share volume
+   * @param userId User ID
+   * @param volume Volume
+   */
+  setScreenShareVolume(userId: string, volume: number) {
+    this.set("screenShareVolumes", userId, volume);
+  }
+
+  /**
+   * Get a user's screen share volume
+   * @param userId User ID
+   * @returns Volume or default
+   */
+  getScreenShareVolume(userId: string): number {
+    return this.get().screenShareVolumes[userId] || 1.0;
+  }
+
+  /**
+   * Set whether a user's screen share is muted
+   * @param userId User ID
+   * @param muted Whether they should be muted
+   */
+  setScreenShareMuted(userId: string, muted: boolean) {
+    this.set("screenShareMutes", userId, muted);
+  }
+
+  /**
+   * Get whether a user's screen share is muted
+   * @param userId User ID
+   * @returns Whether muted
+   */
+  getScreenShareMuted(userId: string): boolean {
+    return this.get().screenShareMutes[userId] ?? true;
   }
 
   /**
@@ -249,6 +313,13 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
    */
   set screenShareQualityAsk(value: boolean) {
     this.set("screenShareQualityAsk", value);
+  }
+
+  /**
+   * Set screen share audio
+   */
+  set screenShareAudio(value: boolean) {
+    this.set("screenShareAudio", value);
   }
 
   /**
@@ -326,6 +397,13 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
    */
   get screenShareQualityAsk(): boolean {
     return this.get().screenShareQualityAsk;
+  }
+
+  /**
+   * Get screen share audio
+   */
+  get screenShareAudio(): boolean {
+    return this.get().screenShareAudio;
   }
 
   /**

--- a/packages/client/components/state/stores/Voice.ts
+++ b/packages/client/components/state/stores/Voice.ts
@@ -180,7 +180,7 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
           ([userId, volume]) =>
             typeof userId === "string" && typeof volume === "number",
         )
-        .forEach(([k, v]) => (data.userVolumes[k] = v));
+        .forEach(([k, v]) => (data.screenShareVolumes[k] = v));
     }
 
     if (typeof input.screenShareMutes === "object") {
@@ -188,7 +188,7 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
         .filter(
           ([userId, muted]) => typeof userId === "string" && muted === true,
         )
-        .forEach(([k, v]) => (data.userMutes[k] = v));
+        .forEach(([k, v]) => (data.screenShareMutes[k] = v));
     }
 
     return data;

--- a/packages/client/components/ui/components/features/voice/callCard/ParticipantTile.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/ParticipantTile.tsx
@@ -15,6 +15,7 @@ import { styled } from "styled-system/jsx";
 import { UserContextMenu } from "@revolt/app";
 import { useUser } from "@revolt/markdown/users";
 import { useVoice } from "@revolt/rtc";
+import { useState } from "@revolt/state";
 import { Avatar } from "@revolt/ui/components/design";
 import { Row } from "@revolt/ui/components/layout";
 import { OverflowingText } from "@revolt/ui/components/utils";
@@ -31,6 +32,7 @@ type TileProps = {
  */
 export function ParticipantTile(props: TileProps) {
   const voice = useVoice();
+  const state = useState();
   const participant = useEnsureParticipant();
   const track = useTrackRefContext();
   const user = useUser(participant.identity);
@@ -56,6 +58,11 @@ export function ParticipantTile(props: TileProps) {
     participant,
     source: Track.Source.ScreenShare,
   });
+
+  const isScreenShareAudioUserMuted = () =>
+    state.voice.getScreenShareMuted(user().user!.id)
+      ? "by-user"
+      : isScreenShareAudioMuted() || false;
 
   const isVideoMuted = useIsMuted({
     participant,
@@ -88,24 +95,21 @@ export function ParticipantTile(props: TileProps) {
           }) + (isScreenShare() ? " vc_tile group" : " vc_tile")
         }
         onClick={() => voice.toggleFocus(track)}
-        use:floating={
-          isScreenShare()
-            ? undefined
-            : {
-                // TODO: Conflicts with focusing, maybe only show if clicking name itself
-                //   userCard: {
-                //     user: user().user!,
-                //     member: user().member,
-                //   },
-                contextMenu: () => (
-                  <UserContextMenu
-                    user={user().user!}
-                    member={user().member}
-                    inVoice
-                  />
-                ),
-              }
-        }
+        use:floating={{
+          // TODO: Conflicts with focusing, maybe only show if clicking name itself
+          //   userCard: {
+          //     user: user().user!,
+          //     member: user().member,
+          //   },
+          contextMenu: () => (
+            <UserContextMenu
+              user={user().user!}
+              member={user().member}
+              inVoice={!isScreenShare()}
+              isScreenshare={isScreenShare()}
+            />
+          ),
+        }}
         style={{ ...getHeight() }}
       >
         <Show
@@ -145,8 +149,17 @@ export function ParticipantTile(props: TileProps) {
             <OverflowingText>{user().username}</OverflowingText>
             <Row gap="md">
               {isScreenShare() ? (
-                <Show when={isScreenShareAudioMuted()}>
-                  <Symbol size={18}>no_sound</Symbol>
+                <Show when={isScreenShareAudioUserMuted()}>
+                  <Symbol
+                    size={18}
+                    color={
+                      isScreenShareAudioUserMuted() === "by-user"
+                        ? "var(--md-sys-color-error)"
+                        : undefined
+                    }
+                  >
+                    no_sound
+                  </Symbol>
                 </Show>
               ) : (
                 <VoiceStatefulUserIcons


### PR DESCRIPTION
This PR adds audio to the screenshare functionality of Stoat. It also adds the ability to mute and change volume of streams. Audio is defaultly muted on screen shares to prevent surprises.

Audio does not work on Wayland Linux desktop. This is an Electron limitation.

Closes #1070

## How was this PR tested?
Screen sharing was initiated with audio and without audio.
Screen sharing was muted by user, and then unmuted.
Screen sharing volume was adjusted up and down by user.
Screen sharing was cancelled by clicking button and by closing window.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Screen share settings modal with new "Share Audio" checkbox
<img width="582" height="599" alt="image" src="https://github.com/user-attachments/assets/46eccba0-0bd3-4968-b168-973b53fbfce4" />

Screen share with audio
<img width="661" height="399" alt="image" src="https://github.com/user-attachments/assets/606354a6-b6e3-4b70-b9f9-ffc511e8cfb1" />

Screen share without audio
<img width="661" height="399" alt="image" src="https://github.com/user-attachments/assets/a250997a-0cf7-4e90-a31e-767a68a9ea31" />

Screen share muted by user
<img width="661" height="399" alt="image" src="https://github.com/user-attachments/assets/5ff4bd13-b697-4e08-9fe2-b4ba0ca62a9d" />

Screen share context menu
<img width="658" height="533" alt="image" src="https://github.com/user-attachments/assets/928fc55d-1b24-4cda-aa6d-f1f987bcf681" />

Screen share audio checkbox also appears on the screen picker modal, but I am not on Windows and that's a pain for me to showcase. Just trust me bro :+1:

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Generative AI was not used in the writing of this PR.