### PR TITLE
fix: Change underlined element for username click-to-copy

### DIFF
--- a/packages/client/components/ui/components/features/profiles/ProfileBanner.tsx
+++ b/packages/client/components/ui/components/features/profiles/ProfileBanner.tsx
@@ -74,12 +74,12 @@ export function ProfileBanner(props: {
             content={isCopied() ? t`Copied!` : t`Click to copy username`}
             placement="top"
           >
-            <span onClick={onUsernameClick}>
+            <Username onClick={onUsernameClick}>
               {props.user.username}
               <span class={css({ fontWeight: 200 })}>
                 #{props.user.discriminator}
               </span>
-            </span>
+            </Username>
           </Tooltip>
         </UserShort>
       </Row>
@@ -133,6 +133,11 @@ const UserShort = styled("div", {
     lineHeight: "1em",
     gap: "var(--gap-xs)",
     flexDirection: "column",
+  },
+});
+
+const Username = styled("span", {
+  base: {
     _hover: {
       textDecoration: "underline",
     },


### PR DESCRIPTION
Tiny fix for the username copy feature in #1044. Now it only underlines the clickable part- the username itself- instead of highlighting both that and the display name but only responding to clicks to the username, which is slightly confusing since the user would expect anything that turns underlined on hover is directly interactable.