### PR TITLE
fix: Strip HTML from error strings

### DIFF
--- a/packages/client/components/i18n/errors.ts
+++ b/packages/client/components/i18n/errors.ts
@@ -1,6 +1,8 @@
 import { useLingui } from "@lingui-solid/solid/macro";
 import { API } from "stoat.js";
 
+const RE_BREAK = /\s*\n\s*/g;
+
 /**
  * Translate any error
  */
@@ -159,6 +161,13 @@ export function useError() {
     ) {
       const message = (error as { message: string }).message.trim();
       if (message) return message;
+    } else if (typeof error === "string") {
+      //Strip HTML from string
+      const p = document.createElement("html");
+      p.innerHTML = error;
+      p.querySelector("head")?.remove();
+      p.querySelector("[role=contentinfo]")?.remove();
+      error = p.textContent.trim().replace(RE_BREAK, ". ");
     }
 
     return t`Something went wrong! ${error}`;

--- a/packages/client/components/modal/modals/Error2.tsx
+++ b/packages/client/components/modal/modals/Error2.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui-solid/solid/macro";
+import { styled } from "styled-system/jsx";
 
 import { useError } from "@revolt/i18n";
 import { Dialog, DialogProps, iconSize } from "@revolt/ui";
@@ -6,6 +7,12 @@ import { Dialog, DialogProps, iconSize } from "@revolt/ui";
 import MdError from "@material-design-icons/svg/outlined/error.svg?component-solid";
 
 import { Modals } from "../types";
+
+const Error = styled("div", {
+  base: {
+    whiteSpace: "pre-wrap",
+  },
+});
 
 export function Error2Modal(props: DialogProps & Modals & { type: "error2" }) {
   const err = useError();
@@ -18,7 +25,7 @@ export function Error2Modal(props: DialogProps & Modals & { type: "error2" }) {
       title={<Trans>An error occurred.</Trans>}
       actions={[{ text: <Trans>OK</Trans> }]}
     >
-      {err(props.error)}
+      <Error>{err(props.error)}</Error>
     </Dialog>
   );
 }


### PR DESCRIPTION
Now ideally the Stoat backend should just not send API errors in HTML format to begin with (but as raw text or JSON, for instance) because it wastes network bandwidth, but hey, stripping it on the frontend also helps in case any HTML-formatted errors from other sources slip through the cracks. Which- if other people's error report screenshots are anything to go by- happens a lot.

Old:
<img height=200 src="https://github.com/user-attachments/assets/57c70450-8d5a-4f80-a318-df40e62cf4e9" />

New:
<img height=200 src="https://github.com/user-attachments/assets/200984ee-7176-4fe8-a7e3-09209ec7a9a6" />