### PR TITLE
fix: chat input custom scrollbar

### DIFF
--- a/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
+++ b/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
@@ -6,6 +6,7 @@ import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { css } from "styled-system/css";
 
+import { scrollableStyles } from "../../../directives/scrollable";
 import { AutoCompleteSearchSpace } from "../../utils/autoComplete";
 
 import { codeMirrorAutoComplete } from "./codeMirrorAutoComplete";
@@ -70,6 +71,8 @@ const placeholderCompartment = new Compartment();
  * Text editor powered by CodeMirror
  */
 export function TextEditor2(props: Props) {
+  const editorScrollbarClasses = scrollableStyles();
+
   const codeMirror = document.createElement("div");
   codeMirror.className = editor;
 
@@ -162,6 +165,12 @@ export function TextEditor2(props: Props) {
       ],
     }),
   });
+
+  // Apply shared scrollbar styles from the exported scrollable style classes.
+  const scroller = codeMirror.querySelector<HTMLDivElement>(".cm-scroller");
+  if (scroller) {
+    scroller.classList.add(...editorScrollbarClasses.split(" "));
+  }
 
   // connect signals to extensions
   createEffect(


### PR DESCRIPTION
*I edited this message since I no longer change anything on the chat, but the scrollbar!*

`TextEditor2.tsx` - chat editor scrollbar now uses app scrollbar style

## Currently we have this:

![chrome_AtQKYStZtz](https://github.com/user-attachments/assets/8d875048-c7fd-40ab-8da6-9cdaf08d670c)

---

## What I made have this:

![chrome_NPHxi6E1eU](https://github.com/user-attachments/assets/08d799bd-a8e5-4ef1-93a7-3d139872fd50)
