### PR TITLE
fix: unify autocomplete scrollbar styling via shared scrollable classes

### DIFF
--- a/packages/client/components/ui/components/features/texteditor/codeMirrorAutoComplete.ts
+++ b/packages/client/components/ui/components/features/texteditor/codeMirrorAutoComplete.ts
@@ -5,6 +5,8 @@ import {
 } from "@codemirror/autocomplete";
 import { EditorView, keymap } from "@codemirror/view";
 import { Accessor } from "solid-js";
+
+import { scrollableStyles } from "../../../directives/scrollable";
 import { AutoCompleteSearchSpace } from "../../utils/autoComplete";
 import { codeMirrorAutoCompleteSource } from "./codeMirrorAutoCompleteSource";
 
@@ -78,6 +80,8 @@ const completionTheme = EditorView.theme({
 export function codeMirrorAutoComplete(
   searchSpace?: Accessor<AutoCompleteSearchSpace>,
 ) {
+  const autocompleteScrollbarClasses = scrollableStyles();
+
   const extension = autocompletion({
     activateOnTyping: true,
     aboveCursor: true,
@@ -87,16 +91,28 @@ export function codeMirrorAutoComplete(
     tooltipClass: (state) => {
       const completions = currentCompletions(state);
       if (completions[0]?.type == "emoji") {
-        return "autocomplete-tooltip autocomplete-tooltip-emoji";
+        return (
+          "autocomplete-tooltip autocomplete-tooltip-emoji " +
+          autocompleteScrollbarClasses
+        );
       } else if (
         completions[0]?.type == "user" ||
         completions[0]?.type == "role"
       ) {
-        return "autocomplete-tooltip autocomplete-tooltip-mention";
+        return (
+          "autocomplete-tooltip autocomplete-tooltip-mention " +
+          autocompleteScrollbarClasses
+        );
       } else if (completions[0]?.type == "channel") {
-        return "autocomplete-tooltip autocomplete-tooltip-channel";
+        return (
+          "autocomplete-tooltip autocomplete-tooltip-channel " +
+          autocompleteScrollbarClasses
+        );
       } else {
-        return "autocomplete-tooltip autocomplete-tooltip-unknown";
+        return (
+          "autocomplete-tooltip autocomplete-tooltip-unknown " +
+          autocompleteScrollbarClasses
+        );
       }
     },
     // optionClass: (completion) => "example-option-class",

--- a/packages/client/components/ui/directives/scrollable.ts
+++ b/packages/client/components/ui/directives/scrollable.ts
@@ -2,7 +2,7 @@ import { type Accessor, type JSX, onCleanup } from "solid-js";
 
 import { cva } from "styled-system/css";
 
-const baseStyles = cva({
+export const scrollableStyles = cva({
   base: {
     willChange: "transform",
     scrollbarColor: "var(--md-sys-color-primary) transparent",
@@ -66,7 +66,7 @@ export function scrollable(
   }
 
   el.classList.add(
-    ...baseStyles({
+    ...scrollableStyles({
       direction: props.direction,
       showOnHover: props.showOnHover,
     }).split(" "),


### PR DESCRIPTION
Applied the app’s shared scrollbar styling to CodeMirror autocomplete tooltips for consistent and maintainable behavior.

`scrollable.ts`  - exported shared scrollableStyles for reuse  
`codeMirrorAutoComplete.ts`  - applied shared scrollable classes to autocomplete tooltip classes (emoji, mention, role, channel...)

---

## Currently we have this:

![chrome_O16XiFOkvv](https://github.com/user-attachments/assets/c6a1cbbf-c3b9-42b7-8439-fa7cbc748ace)

---

## What I made have this:

![chrome_a6C6Lo4Bzj](https://github.com/user-attachments/assets/23b33ec8-c958-4eba-865d-5cbf1bf479f3)
