### PR TITLE
fix: client.configured reference in signup flow

### DIFF
--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -49,7 +49,7 @@ export default function FlowCreate() {
 
   const isInviteOnly = () => {
     const client = getClient();
-    if (client.configured()) {
+    if (client.configured) {
       return client.configuration?.features.invite_only;
     }
     return false;


### PR DESCRIPTION
Broken reference caused an error when clicking sign up.