### PR TITLE
feat(auth): skip email check flow when verification is disabled

### DIFF
--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -1,9 +1,10 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
-import { useApi, useClient } from "@revolt/client";
+import { useApi, useClient, useClientLifecycle } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
 import { useNavigate, useParams } from "@revolt/routing";
 import { Button, Row, iconSize } from "@revolt/ui";
+import { useModals } from "@revolt/modal";
 
 import MdArrowBack from "@material-design-icons/svg/filled/arrow_back.svg?component-solid";
 
@@ -20,6 +21,8 @@ export default function FlowCreate() {
   const getClient = useClient();
   const navigate = useNavigate();
   const { code } = useParams();
+  const { login } = useClientLifecycle();
+  const modals = useModals();
 
   /**
    * Create an account
@@ -38,13 +41,29 @@ export default function FlowCreate() {
       ...(invite ? { invite } : {}),
     });
 
-    // FIXME: should tell client if email was sent
-    //        or if email even needs to be confirmed
+    if (needsEmailVerification()) {
+      redirectToEmailVerification(email);
+    } else {
+      await loginDirectly(email, password);
+    }
+  }
 
-    // TODO: log straight in if no email confirmation?
+  function needsEmailVerification() {
+    const client = getClient();
+    if (client.configured()) {
+      return client.configuration?.features.email; 
+    }
+    return true;
+  }
 
+  function redirectToEmailVerification(email: string) {
     setFlowCheckEmail(email);
     navigate("/login/check", { replace: true });
+  }
+
+  async function loginDirectly(email: string, password: string) {
+    await login({ email, password }, modals);
+    navigate("/login/auth", { replace: true });
   }
 
   const isInviteOnly = () => {


### PR DESCRIPTION
Hey i tumbled in here from the Self-Host community! The Readme stated that with email verification disabled the Page still prompts the user to check his mail, a message that i have to forward to every user during onboarding. So i set out to fix that!

It simply checks the client config, analog to "isInviteOnly", and then either routes the old way or directly executes login for the user with the readily available credentials and then forwards him to the username selection.

I tested it by adding and removing an [api.smtp] connection to the toml for a local mailpit instance.

UI flow without email verification:
![stoat_no_mail](https://github.com/user-attachments/assets/ad871b17-1629-44f2-8bf6-1676165034aa)

UI flow with email verification:
![stoat_with_mail](https://github.com/user-attachments/assets/dafee362-ce45-442e-924d-3ff6c2ae9530)
