### PR TITLE
experiment: hide the names of blocked users that reacted to a message

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/Reactions.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Reactions.tsx
@@ -176,9 +176,12 @@ function Reaction(props: {
    */
   const peopleList = () => {
     const all = users();
-    const list = all.filter((user) => user);
+    const list = all.filter(
+      (user) => user && user.user?.relationship !== "Blocked",
+    );
     const unknown =
-      all.filter((user) => !user).length + Math.max(0, list.length - 3);
+      all.filter((user) => user?.user?.relationship === "Blocked" || !user)
+        .length + Math.max(0, list.length - 3);
 
     const usernames = list
       .slice(0, 2)


### PR DESCRIPTION
This is an experimental feature that hides the name of blocked users inside reactions.

Originally, this feature was supposed to hide the reaction itself, instead of just hiding the name of the person who reacted, however, I don't really know what would the best approach to do this would be. Since using the difference of a set seems to completely break solid.js reactivity, even when wrapping the set in a deferred or memorized signal.

I am open to any other ideas to fix this problem, as well as feedback regarding the feature (ie. whether it should be a toggle in settings).