### PR TITLE
feat: Add create channel/category opts to respective context menus

### DIFF
--- a/packages/client/components/app/menus/CategoryContextMenu.tsx
+++ b/packages/client/components/app/menus/CategoryContextMenu.tsx
@@ -43,6 +43,17 @@ export function CategoryContextMenu(props: {
   }
 
   /**
+   * Create a new channel
+   */
+  function createChannel() {
+    openModal({
+      type: "create_channel",
+      server: props.server,
+      categoryId: props.category.id,
+    });
+  }
+
+  /**
    * Create a new category
    */
   function createCategory() {
@@ -95,19 +106,18 @@ export function CategoryContextMenu(props: {
       </Show>
 
       <Show when={props.server.havePermission("ManageChannel")}>
+        <ContextMenuButton icon={MdLibraryAdd} onClick={createChannel}>
+          <Trans>Create channel</Trans>
+        </ContextMenuButton>
         <ContextMenuButton icon={MdLibraryAdd} onClick={createCategory}>
           <Trans>Create category</Trans>
         </ContextMenuButton>
-      </Show>
-      <Show when={props.server.havePermission("ManageChannel")}>
         <ContextMenuButton
           icon={<Symbol size={16}>edit</Symbol>}
           onClick={editCategoryName}
         >
           <Trans>Rename category</Trans>
         </ContextMenuButton>
-      </Show>
-      <Show when={props.server.havePermission("ManageChannel")}>
         <ContextMenuButton icon={MdDelete} onClick={deleteCategory} destructive>
           <Trans>Delete category</Trans>
         </ContextMenuButton>

--- a/packages/client/components/app/menus/ChannelContextMenu.tsx
+++ b/packages/client/components/app/menus/ChannelContextMenu.tsx
@@ -47,12 +47,30 @@ export function ChannelContextMenu(props: { channel: Channel }) {
     });
   }
 
+  function getCategory(channel: Channel) {
+    const cats = channel.server!.orderedChannels;
+    let cat, ch;
+    for (cat of cats)
+      for (ch of cat.channels) if (ch.id === channel.id) return cat.id;
+  }
+
   /**
    * Create a new channel
    */
   function createChannel() {
     openModal({
       type: "create_channel",
+      server: props.channel.server!,
+      categoryId: getCategory(props.channel),
+    });
+  }
+
+  /**
+   * Create a new category
+   */
+  function createCategory() {
+    openModal({
+      type: "create_category",
       server: props.channel.server!,
     });
   }
@@ -133,6 +151,9 @@ export function ChannelContextMenu(props: { channel: Channel }) {
       <Show when={props.channel.server?.havePermission("ManageChannel")}>
         <ContextMenuButton icon={MdLibraryAdd} onClick={createChannel}>
           <Trans>Create channel</Trans>
+        </ContextMenuButton>
+        <ContextMenuButton icon={MdLibraryAdd} onClick={createCategory}>
+          <Trans>Create category</Trans>
         </ContextMenuButton>
       </Show>
       <Show when={props.channel.havePermission("ManageChannel")}>

--- a/packages/client/components/modal/modals/CreateChannel.tsx
+++ b/packages/client/components/modal/modals/CreateChannel.tsx
@@ -30,10 +30,25 @@ export function CreateChannelModal(
         name: group.controls.name.value,
       });
 
+      //Reorder categories
+      const newChId = channel.id,
+        catId = props.categoryId;
+      if (catId && catId !== "default") {
+        let ch, chIds;
+        props.server.edit({
+          categories: props.server.orderedChannels.map((cat) => {
+            chIds = [];
+            for (ch of cat.channels) if (ch.id !== newChId) chIds.push(ch.id);
+            if (cat.id === catId) chIds.push(newChId);
+            return { ...cat, channels: chIds };
+          }),
+        });
+      }
+
       if (props.cb) {
         props.cb(channel);
       } else {
-        navigate(`/server/${props.server.id}/channel/${channel.id}`);
+        navigate(`/server/${props.server.id}/channel/${newChId}`);
       }
 
       props.onClose();

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -70,6 +70,7 @@ export type Modals =
   | {
       type: "create_channel";
       server: Server;
+      categoryId?: string;
       cb?: (channel: Channel) => void;
     }
   | {


### PR DESCRIPTION
Adds the "create channel" button to the category context menu and the "create category" to the channel context menu.

This makes it easier to add new ones on small screens or when the the channel sidebar is full, because there's no "blank space" to right-click on. I also made it so that adding a channel by right-clicking a category adds the new channel to _that_ category instead of the default at the top, since that makes more intuitive sense.

Before:
<img height=200 src="https://github.com/user-attachments/assets/de968964-a5f1-4982-88e8-3fc0bcf21341" />

After:
<img height=200 src="https://github.com/user-attachments/assets/8fa16976-fe09-4cad-8c6a-859ffd1154aa" />