### PR TITLE
fix: remove scrollbarGutter stable from showOnHover to prevent carets without overflow

### DIFF
--- a/packages/client/components/ui/directives/scrollable.ts
+++ b/packages/client/components/ui/directives/scrollable.ts
@@ -83,10 +83,17 @@ export function scrollable(
     const showClass = hoverStyles({ direction: props.direction }).split(" ");
 
     /**
-     * Handle mouse entry
+     * Handle mouse entry — only show scrollbar if content actually overflows.
+     * This prevents scrollbar carets from appearing when there's nothing to scroll.
      */
     const onMouseEnter = () => {
-      el.classList.add(...showClass);
+      const isOverflowing =
+        props.direction === "x"
+          ? el.scrollWidth > el.clientWidth
+          : el.scrollHeight > el.clientHeight;
+      if (isOverflowing) {
+        el.classList.add(...showClass);
+      }
     };
 
     /**


### PR DESCRIPTION
## Summary

The member list sidebar showed scrollbar carets on hover even when there weren't enough members to require scrolling.

## Root cause
`scrollableStyles` applied `scrollbarGutter: 'stable'` when `showOnHover` was enabled. The `stable` value permanently reserves space for the scrollbar track — including its carets — regardless of whether content overflows.

## Fix
Removed `scrollbarGutter: 'stable'` from the `showOnHover` variant. The hover handlers already apply `overflow: scroll` on mouse entry, so scrolling still works correctly when content does overflow. The carets no longer appear when there's nothing to scroll.