### PR TITLE
fix: Add button action timeout to solve click-through issue on touch devices

### DIFF
--- a/packages/client/components/ui/components/design/Button.tsx
+++ b/packages/client/components/ui/components/design/Button.tsx
@@ -122,6 +122,7 @@ export function Button(props: Props) {
 
   const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
 
+  //Eslint being silly, this is reactive
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
   const onPress = debounce((e: any) => btn.onPress?.(e), 100),
     btnRest = mergeProps(noBtnRest, { onPress });

--- a/packages/client/components/ui/components/design/Button.tsx
+++ b/packages/client/components/ui/components/design/Button.tsx
@@ -5,6 +5,7 @@ import { AriaButtonProps, createButton } from "@solid-aria/button";
 import { cva } from "styled-system/css/cva";
 
 import { debounce } from "@revolt/common";
+
 import { Ripple } from "./Ripple";
 import { typography } from "./Text";
 
@@ -90,7 +91,7 @@ export function Button(props: Props) {
     "role",
   ]);
 
-  const [style, noSty] = splitProps(propsRest, [
+  const [style, rest] = splitProps(propsRest, [
     "bg",
     "size",
     "shape",
@@ -119,17 +120,18 @@ export function Button(props: Props) {
     ),
   );
 
-  const [btn, noBtnRest] = splitProps(noSty, ["onPress"]);
+  const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
   const onPress = debounce((e: any) => btn.onPress?.(e), 100),
-    rest = mergeProps(noBtnRest, { onPress });
+    btnRest = mergeProps(noBtnRest, { onPress });
 
-  const { buttonProps } = createButton(rest, () => ref);
+  const { buttonProps } = createButton(btnRest, () => ref);
   return (
     <button
       {...passthrough}
       {...buttonProps}
+      onTouchEnd={onPress}
       ref={ref}
       class={button({
         shape: shape(),

--- a/packages/client/components/ui/components/design/Button.tsx
+++ b/packages/client/components/ui/components/design/Button.tsx
@@ -1,9 +1,10 @@
-import { Show, createRenderEffect, on, splitProps } from "solid-js";
+import { Show, createRenderEffect, mergeProps, on, splitProps } from "solid-js";
 import { JSX } from "solid-js/jsx-runtime";
 
 import { AriaButtonProps, createButton } from "@solid-aria/button";
 import { cva } from "styled-system/css/cva";
 
+import { debounce } from "@revolt/common";
 import { Ripple } from "./Ripple";
 import { typography } from "./Text";
 
@@ -89,7 +90,7 @@ export function Button(props: Props) {
     "role",
   ]);
 
-  const [style, rest] = splitProps(propsRest, [
+  const [style, noSty] = splitProps(propsRest, [
     "bg",
     "size",
     "shape",
@@ -117,6 +118,12 @@ export function Button(props: Props) {
       { defer: true },
     ),
   );
+
+  const [btn, noBtnRest] = splitProps(noSty, ["onPress"]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
+  const onPress = debounce((e: any) => btn.onPress?.(e), 100),
+    rest = mergeProps(noBtnRest, { onPress });
 
   const { buttonProps } = createButton(rest, () => ref);
   return (

--- a/packages/client/components/ui/components/design/Button.tsx
+++ b/packages/client/components/ui/components/design/Button.tsx
@@ -4,8 +4,6 @@ import { JSX } from "solid-js/jsx-runtime";
 import { AriaButtonProps, createButton } from "@solid-aria/button";
 import { cva } from "styled-system/css/cva";
 
-import { debounce } from "@revolt/common";
-
 import { Ripple } from "./Ripple";
 import { typography } from "./Text";
 
@@ -122,9 +120,9 @@ export function Button(props: Props) {
 
   const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
 
-  //Eslint being silly, this is reactive
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
-  const onPress = debounce((e: any) => btn.onPress?.(e), 100),
+  //Emulate delay of native onClick (solves click-through issue)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onPress = (e: any) => setTimeout(() => btn.onPress?.(e), 1),
     btnRest = mergeProps(noBtnRest, { onPress, preventFocusOnPress: true });
 
   const { buttonProps } = createButton(btnRest, () => ref);

--- a/packages/client/components/ui/components/design/Button.tsx
+++ b/packages/client/components/ui/components/design/Button.tsx
@@ -120,9 +120,11 @@ export function Button(props: Props) {
 
   const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
 
-  //Emulate delay of native onClick (solves click-through issue)
+  //Emulate delay of native onClick
+  // See issue https://github.com/solidjs-community/solid-aria/issues/84
+  // Delay must be at least 32ms for Safari
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const onPress = (e: any) => setTimeout(() => btn.onPress?.(e), 1),
+  const onPress = (e: any) => setTimeout(() => btn.onPress?.(e), 32),
     btnRest = mergeProps(noBtnRest, { onPress, preventFocusOnPress: true });
 
   const { buttonProps } = createButton(btnRest, () => ref);

--- a/packages/client/components/ui/components/design/Button.tsx
+++ b/packages/client/components/ui/components/design/Button.tsx
@@ -125,14 +125,13 @@ export function Button(props: Props) {
   //Eslint being silly, this is reactive
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
   const onPress = debounce((e: any) => btn.onPress?.(e), 100),
-    btnRest = mergeProps(noBtnRest, { onPress });
+    btnRest = mergeProps(noBtnRest, { onPress, preventFocusOnPress: true });
 
   const { buttonProps } = createButton(btnRest, () => ref);
   return (
     <button
       {...passthrough}
       {...buttonProps}
-      onTouchEnd={onPress}
       ref={ref}
       class={button({
         shape: shape(),

--- a/packages/client/components/ui/components/design/IconButton.tsx
+++ b/packages/client/components/ui/components/design/IconButton.tsx
@@ -1,8 +1,10 @@
-import { Show, splitProps } from "solid-js";
+import { mergeProps, Show, splitProps } from "solid-js";
 import { JSX } from "solid-js/jsx-runtime";
 
 import { AriaButtonProps, createButton } from "@solid-aria/button";
 import { cva } from "styled-system/css/cva";
+
+import { debounce } from "@revolt/common";
 
 import { Ripple } from "./Ripple";
 import { typography } from "./Text";
@@ -39,11 +41,18 @@ export function IconButton(props: Props) {
   ]);
   let ref: HTMLButtonElement | undefined;
 
-  const { buttonProps } = createButton(rest, () => ref);
+  const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
+  const onPress = debounce((e: any) => btn.onPress?.(e), 100),
+    restBtn = mergeProps(noBtnRest, { onPress });
+
+  const { buttonProps } = createButton(restBtn, () => ref);
   return (
     <button
       {...passthrough}
       {...buttonProps}
+      onTouchEnd={onPress}
       ref={ref}
       class={iconButton2({
         ...style,

--- a/packages/client/components/ui/components/design/IconButton.tsx
+++ b/packages/client/components/ui/components/design/IconButton.tsx
@@ -43,6 +43,7 @@ export function IconButton(props: Props) {
 
   const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
 
+  //Eslint being silly, this is reactive
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
   const onPress = debounce((e: any) => btn.onPress?.(e), 100),
     restBtn = mergeProps(noBtnRest, { onPress });

--- a/packages/client/components/ui/components/design/IconButton.tsx
+++ b/packages/client/components/ui/components/design/IconButton.tsx
@@ -41,9 +41,11 @@ export function IconButton(props: Props) {
 
   const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
 
-  //Emulate delay of native onClick (solves click-through issue)
+  //Emulate delay of native onClick
+  // See issue https://github.com/solidjs-community/solid-aria/issues/84
+  // Delay must be at least 32ms for Safari
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const onPress = (e: any) => setTimeout(() => btn.onPress?.(e), 1),
+  const onPress = (e: any) => setTimeout(() => btn.onPress?.(e), 32),
     btnRest = mergeProps(noBtnRest, { onPress, preventFocusOnPress: true });
 
   const { buttonProps } = createButton(btnRest, () => ref);

--- a/packages/client/components/ui/components/design/IconButton.tsx
+++ b/packages/client/components/ui/components/design/IconButton.tsx
@@ -4,8 +4,6 @@ import { JSX } from "solid-js/jsx-runtime";
 import { AriaButtonProps, createButton } from "@solid-aria/button";
 import { cva } from "styled-system/css/cva";
 
-import { debounce } from "@revolt/common";
-
 import { Ripple } from "./Ripple";
 import { typography } from "./Text";
 
@@ -43,12 +41,12 @@ export function IconButton(props: Props) {
 
   const [btn, noBtnRest] = splitProps(rest, ["onPress"]);
 
-  //Eslint being silly, this is reactive
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
-  const onPress = debounce((e: any) => btn.onPress?.(e), 100),
-    restBtn = mergeProps(noBtnRest, { onPress, preventFocusOnPress: true });
+  //Emulate delay of native onClick (solves click-through issue)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onPress = (e: any) => setTimeout(() => btn.onPress?.(e), 1),
+    btnRest = mergeProps(noBtnRest, { onPress, preventFocusOnPress: true });
 
-  const { buttonProps } = createButton(restBtn, () => ref);
+  const { buttonProps } = createButton(btnRest, () => ref);
   return (
     <button
       {...passthrough}

--- a/packages/client/components/ui/components/design/IconButton.tsx
+++ b/packages/client/components/ui/components/design/IconButton.tsx
@@ -46,14 +46,13 @@ export function IconButton(props: Props) {
   //Eslint being silly, this is reactive
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, solid/reactivity
   const onPress = debounce((e: any) => btn.onPress?.(e), 100),
-    restBtn = mergeProps(noBtnRest, { onPress });
+    restBtn = mergeProps(noBtnRest, { onPress, preventFocusOnPress: true });
 
   const { buttonProps } = createButton(restBtn, () => ref);
   return (
     <button
       {...passthrough}
       {...buttonProps}
-      onTouchEnd={onPress}
       ref={ref}
       class={iconButton2({
         ...style,


### PR DESCRIPTION
Fixes #798

At long last, I found a simple fix that works on Chrome mobile without breaking it on Firefox mobile!

This also fixes another button bug on mobile where when the virtual keyboard is open, pressing a button does not fire as it closes. This is likely a Solid Aria bug, but adding `onTouchEnd` fixes it for now, and the debounce prevents multiple event firings.