### PR TITLE
fix: drag indicator using wrong colour on dark mode

### DIFF
--- a/packages/client/components/app/interface/settings/server/roles/ServerRoleOverview.tsx
+++ b/packages/client/components/app/interface/settings/server/roles/ServerRoleOverview.tsx
@@ -74,6 +74,7 @@ export function ServerRoleOverview(props: { context: Server }) {
           {(entry) => (
             <ItemContainer>
               <MdDragIndicator
+                fill="var(--md-sys-color-on-surface)"
                 {...createDragHandle(entry.dragDisabled, entry.setDragDisabled)}
               />
 


### PR DESCRIPTION
Before:
<img width="368" height="534" alt="image" src="https://github.com/user-attachments/assets/6df292bb-1883-4418-a2e5-8574f69ccafb" />

After:
<img width="217" height="310" alt="image" src="https://github.com/user-attachments/assets/978fc6bc-bb43-42fc-8c66-182ab7d9bd01" />
