### PR TITLE
refactor: Voice Call PIP Card

### DIFF
--- a/packages/client/components/ui/components/design/Avatar.tsx
+++ b/packages/client/components/ui/components/design/Avatar.tsx
@@ -16,7 +16,7 @@ export type Props = {
   /**
    * Avatar shape
    */
-  shape?: "circle" | "rounded-square";
+  shape?: "circle" | "square" | "rounded-square";
 
   /**
    * Image source
@@ -205,6 +205,7 @@ const Shape = styled("div", {
       circle: {
         borderRadius: "var(--borderRadius-circle)",
       },
+      square: {},
       "rounded-square": {
         borderRadius: "var(--borderRadius-md)",
       },

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -1,13 +1,9 @@
 import {
   JSX,
-  Match,
   Show,
-  Switch,
-  batch,
   createContext,
   createEffect,
   createSignal,
-  on,
   onCleanup,
   onMount,
   useContext,
@@ -16,7 +12,6 @@ import { Portal } from "solid-js/web";
 
 import { AutoSizer } from "@dschz/solid-auto-sizer";
 import { Channel } from "stoat.js";
-import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { InRoom, useVoice } from "@revolt/rtc";
@@ -25,241 +20,213 @@ import { VoiceCallCardActiveRoom } from "./VoiceCallCardActiveRoom";
 import { VoiceCallCardPiP } from "./VoiceCallCardPiP";
 import { VoiceCallCardPreview } from "./VoiceCallCardPreview";
 
+type FloatMode = "tl" | "tr" | "bl" | "br";
+
 type State =
   | {
-      type: "floating";
-      corner: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+      mode: "floating";
+      float: FloatMode;
     }
   | {
-      type: "fixed";
-      x: number;
-      y: number;
-      width: number;
-      channel: Channel;
+      mode?: "fixed" | "moving";
     };
 
-type NewState = { channel: Channel; x: number; y: number; width: number };
+type Info = {
+  pos: DOMRect;
+  channel: Channel;
+};
 
-const callCardContext = createContext<(state?: NewState) => void>(null!);
+const PAD = 16,
+  PAD_X = `${PAD}px`,
+  PAD_Y = `${PAD + 56}px`;
 
-/**
- * Voice call card context
- */
+const callCardContext = createContext<(info?: Info) => void>();
+
+function getTouch(id: number, tl: TouchList) {
+  for (const t of tl) if (t.identifier === id) return t;
+}
+
+/** Voice call card context */
 export function VoiceCallCardContext(props: { children: JSX.Element }) {
   const voice = useVoice();
 
-  const [state, setState] = createSignal<State>({
-    type: "floating",
-    corner: "bottom-right",
-  });
+  const [state, setState] = createSignal<State>({});
+  let ref: HTMLDivElement, channel: Channel | null;
 
-  const [moving, setMoving] = createSignal<boolean>();
-  const [offset, setOffset] = createSignal({ x: 0, y: 0 });
+  let events: AbortController | null,
+    tid = 0,
+    ofsX = 0,
+    ofsY = 0;
 
-  function position() {
-    const position = state();
+  function touchToMouse(e: MouseEvent | TouchEvent, down = false) {
+    if (e instanceof TouchEvent) {
+      const t = down ? e.touches[0] : getTouch(tid, e.changedTouches);
+      if (down) tid = t!.identifier;
+      else if (!t) return false;
+      //@ts-expect-error prop
+      e.clientX = t.clientX;
+      //@ts-expect-error prop
+      e.clientY = t.clientY;
+    }
+    return true;
+  }
 
-    switch (position.type) {
-      case "fixed":
-        return {
-          transform: `translate(${position.x}px, ${position.y}px)`,
-          // top: position.y + "px",
-          // left: position.x + "px",
-          width: position.width + "px",
-          height: "40vh",
-        };
-      case "floating":
-        return {
-          "--width": "280px",
-          "--height": "158px",
-          "--padding-x": "32px",
-          "--padding-y": "96px",
-          transform: `translate(${
-            position.corner === "top-left" || position.corner === "bottom-left"
-              ? "calc(var(--padding-x) + var(--offset-x))"
-              : "calc(100vw - var(--padding-x) - var(--width) + var(--offset-x))"
-          }, ${
-            position.corner === "top-left" || position.corner === "top-right"
-              ? "calc(var(--padding-y) + var(--offset-y))"
-              : "calc(100vh - var(--padding-y) - var(--height) + var(--offset-y))"
-          })`,
-          width: "var(--width)",
-          height: "var(--height)",
-        };
+  function mouseDown(e: MouseEvent | TouchEvent) {
+    touchToMouse(e, true);
+    if (state().mode === "floating") {
+      const pos = ref!.getBoundingClientRect();
+      ofsX = (e as MouseEvent).clientX - pos.x;
+      ofsY = (e as MouseEvent).clientY - pos.y;
+      setState({ mode: "moving" });
+      addEvents();
     }
   }
 
-  createEffect(
-    on(moving, (moving) => {
-      if (moving) {
-        const controller = new AbortController();
+  function mouseMove(e: MouseEvent | TouchEvent) {
+    if (!touchToMouse(e)) return;
+    e.preventDefault();
+    ref!.style.left = `${(e as MouseEvent).clientX - ofsX}px`;
+    ref!.style.top = `${(e as MouseEvent).clientY - ofsY}px`;
+  }
 
-        document.addEventListener(
-          "mousemove",
-          (event) => {
-            const position = state();
-            if (position.type !== "floating") return controller.abort();
+  function mouseUp(e: MouseEvent | TouchEvent) {
+    if (!touchToMouse(e)) return;
+    const sty = ref!.style,
+      left = (e as MouseEvent).clientX < outerWidth / 2,
+      top = (e as MouseEvent).clientY < outerHeight / 2;
 
-            setOffset((pos) => ({
-              x: pos.x + event.movementX,
-              y: pos.y + event.movementY,
-            }));
-          },
-          { signal: controller.signal },
-        );
+    sty.transition = "all .2s cubic-bezier(0, 1.67, 0.85, 0.8)";
+    setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");
+    setTimeout(() => (sty.transition = ""), 1);
+    resetEvents();
+  }
 
-        document.addEventListener(
-          "mouseup",
-          (event) => {
-            batch(() => {
-              setMoving(false);
+  function addEvents() {
+    if (events) return;
+    events = new AbortController();
+    const sig = { passive: false, signal: events.signal };
+    document.addEventListener("mousemove", mouseMove, sig);
+    document.addEventListener("mouseup", mouseUp, sig);
+    document.addEventListener("touchmove", mouseMove, sig);
+    document.addEventListener("touchend", mouseUp, sig);
+  }
 
-              const left = event.clientX < window.outerWidth / 2;
-              const top = event.clientY < window.outerHeight / 2;
+  function resetEvents() {
+    events?.abort();
+    events = null;
+  }
 
-              setState({
-                type: "floating",
-                corner: left
-                  ? top
-                    ? "top-left"
-                    : "bottom-left"
-                  : top
-                    ? "top-right"
-                    : "bottom-right",
-              });
-            });
-          },
-          { signal: controller.signal },
-        );
-
-        onCleanup(() => controller.abort());
+  function setInfo(info?: Info) {
+    if (ref!) {
+      if (info) {
+        channel = info.channel;
+        const sty = ref.style;
+        sty.left = `${info.pos.x}px`;
+        sty.top = `${info.pos.y}px`;
+        sty.width = `${info.pos.width}px`;
+        setState({ mode: "fixed" });
+      } else {
+        channel = null;
+        setFloat("tr");
       }
-    }),
-  );
-
-  function updateState(state?: NewState) {
-    if (state) {
-      setState({
-        type: "fixed",
-        width: state.width,
-        x: state.x,
-        y: state.y,
-        channel: state.channel,
-      });
-    } else {
-      setState({
-        type: "floating",
-        corner: "bottom-right",
-      });
     }
+    resetEvents();
   }
 
-  function updateStateWithTransition(state?: NewState) {
-    // no clue if this works
-
-    if (!document.startViewTransition) {
-      updateState(state);
-      return;
-    }
-
-    document.startViewTransition(() => updateState(state));
+  function setFloat(float: FloatMode) {
+    const sty = ref!.style;
+    sty.left =
+      float[1] === "l" ? PAD_X : `calc(100vw - var(--width) - ${PAD_X})`;
+    sty.top =
+      float[0] === "t" ? PAD_Y : `calc(100vh - var(--height) - ${PAD_Y})`;
+    sty.width = "";
+    setState({ mode: "floating", float });
   }
+
+  onCleanup(resetEvents);
 
   return (
-    <callCardContext.Provider value={updateStateWithTransition}>
+    <callCardContext.Provider value={setInfo}>
       {props.children}
-
       <Portal ref={document.getElementById("floating")! as HTMLDivElement}>
-        <div
-          style={{
-            position: "fixed",
-            "z-index": 10,
-            transition: moving()
-              ? "all .2s cubic-bezier(0, 1.67, 0.85, 0.8), width 0s"
-              : "all .3s cubic-bezier(1, 0, 0, 1), width 0s",
-            ...position(),
-            "pointer-events": "none",
-            cursor:
-              state().type === "floating"
-                ? moving()
-                  ? "grabbing"
-                  : "grab"
-                : "auto",
-            "--offset-x": `${moving() ? offset().x : 0}px`,
-            "--offset-y": `${moving() ? offset().y : 0}px`,
-          }}
-          // dragging logic for mice
-          onMouseDown={() => {
-            if (state().type === "floating") {
-              batch(() => {
-                setMoving(true);
-                setOffset({ x: 0, y: 0 });
-              });
-            }
-          }}
-          // dragging logic for touch input
-          // todo
-        >
-          <Switch>
-            <Match when={state().type === "fixed"}>
-              <VoiceCallCard
-                channel={(state() as { channel: Channel }).channel}
-              />
-            </Match>
-            <Match when={state().type === "floating"}>
-              <InRoom>
-                <VoiceCallCardPiP />
-              </InRoom>
-            </Match>
-          </Switch>
-        </div>
+        <Show when={voice.channel()}>
+          <Float
+            ref={ref!}
+            mode={state().mode}
+            onMouseDown={mouseDown}
+            onTouchStart={mouseDown}
+          >
+            <Show
+              when={state().mode === "fixed"}
+              fallback={
+                <InRoom>
+                  <VoiceCallCardPiP />
+                </InRoom>
+              }
+            >
+              <VoiceCallCard channel={channel!} />
+            </Show>
+          </Float>
+        </Show>
       </Portal>
     </callCardContext.Provider>
   );
 }
 
-/**
- * 'Marker' to send position information for mounting the floating call card
- */
+const Float = styled("div", {
+  base: {
+    position: "fixed",
+    zIndex: 10,
+    pointerEvents: "none",
+    transition: "all .3s cubic-bezier(1, 0, 0, 1)",
+    height: "40vh",
+  },
+
+  variants: {
+    mode: {
+      floating: { cursor: "grab" },
+      moving: {
+        cursor: "grabbing",
+        transition: "none",
+      },
+      fixed: {},
+    },
+  },
+  compoundVariants: [
+    {
+      mode: ["floating", "moving"],
+      css: {
+        "--width": "300px",
+        "--height": "170px",
+        width: "var(--width)",
+        height: "var(--height)",
+      },
+    },
+  ],
+});
+
+/** 'Marker' to send position information for mounting the floating call card */
 export function VoiceChannelCallCardMount(props: { channel: Channel }) {
   const voice = useVoice();
   const [width, setWidth] = createSignal(0);
-
   const [ref, setRef] = createSignal<HTMLDivElement>();
-  const updateSize = useContext(callCardContext)!;
-
-  const ongoingCallElsewhere = () =>
-    voice.channel() && voice.channel()?.id !== props.channel.id;
+  const setInfo = useContext(callCardContext)!;
 
   createEffect(() => {
-    const rect = ref()?.getBoundingClientRect();
-    const w = width();
-
-    const activeChannel = voice.channel();
-    const canUpdate = !activeChannel || activeChannel.id === props.channel.id;
-
-    if (rect?.left && w) {
-      if (canUpdate) {
-        updateSize({
-          x: rect.left,
-          y: rect.top,
-          width: w,
-          channel: props.channel,
-        });
-      } else {
-        updateSize();
-      }
-    }
+    width();
+    const active = voice.channel();
+    const isActive = !active || active.id === props.channel.id;
+    const pos = ref()?.getBoundingClientRect();
+    if (pos) setInfo(isActive ? { pos, channel: props.channel } : undefined);
   });
 
-  onCleanup(() => updateSize());
+  onCleanup(setInfo);
+
+  //TODO React to pos change and not only width change
 
   return (
-    <div
-      ref={setRef}
-      class={css({ position: "relative", pointerEvents: "none" })}
-    >
-      <div class={css({ position: "absolute", width: "100%" })}>
+    <Show when={voice.channel()}>
+      <div ref={setRef}>
         <AutoSizer>
           {({ width }) => {
             setWidth(width);
@@ -267,11 +234,7 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
           }}
         </AutoSizer>
       </div>
-
-      <Show when={ongoingCallElsewhere()}>
-        <VoiceCallCard channel={props.channel} />
-      </Show>
-    </div>
+    </Show>
   );
 }
 

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -29,6 +29,7 @@ type FloatType = "tl" | "tr" | "bl" | "br";
 type Info = {
   channel: Channel;
   pos?: DOMRect;
+  //drawer?: SlideState; TODO PR #835
 };
 
 const PAD = 16,
@@ -47,7 +48,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
 
   const [mode, setMode] = createSignal<Mode>();
   const [info, setInfo] = createSignal<Info>();
-  let ref: HTMLDivElement;
+  let ref: HTMLDivElement | undefined;
 
   let events: AbortController | null,
     tid = 0,
@@ -116,19 +117,20 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
   const channel = createMemo(() => {
     const inf = info();
 
-    if (!ref!) return;
+    if (!ref) return;
     const sty = ref.style;
-    //TODO for PR #835 to adapt VoiceCallCard to mobile UI
-    //const drawer = state.appDrawer();
 
     //Set mode based on state
-    if (inf?.pos /*&& (!drawer || drawer.state === SlideState.SHOWN)*/) {
+    //TODO for PR #835 to adapt VoiceCallCard to mobile UI
+    if (inf?.pos /*&& (!inf.drawer || inf.drawer === SlideState.SHOWN)*/) {
       sty.left = `${inf.pos.x}px`;
       sty.top = `${inf.pos.y}px`;
       sty.width = `${inf.pos.width}px`;
       setMode();
-    } else if (!voice.channel()) setMode();
-    else if (!mode()) setFloat("tr");
+    } else if (!voice.channel()) {
+      sty.left = `${innerWidth + 50}px`;
+      setMode();
+    } else if (!mode()) setFloat("tr");
 
     resetEvents();
     return inf?.channel;
@@ -137,9 +139,9 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
   function setFloat(float: FloatType) {
     const sty = ref!.style;
     sty.left =
-      float[1] === "l" ? PAD_X : `calc(100vw - var(--width) - ${PAD_X})`;
+      float[1] === "l" ? PAD_X : `calc(100vw - var(--flt-w) - ${PAD_X})`;
     sty.top =
-      float[0] === "t" ? PAD_Y : `calc(100vh - var(--height) - ${PAD_Y})`;
+      float[0] === "t" ? PAD_Y : `calc(100vh - var(--flt-h) - ${PAD_Y})`;
     sty.width = "";
     setMode("floating");
   }
@@ -151,7 +153,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
       {props.children}
       <Portal ref={document.getElementById("floating")! as HTMLDivElement}>
         <Float
-          ref={ref!}
+          ref={ref}
           mode={mode()}
           onMouseDown={mouseDown}
           onTouchStart={mouseDown}
@@ -178,7 +180,6 @@ const Float = styled("div", {
     transition: "all .3s cubic-bezier(1, 0, 0, 1)",
     height: "40vh",
   },
-
   variants: {
     mode: {
       floating: { cursor: "grab" },
@@ -192,10 +193,10 @@ const Float = styled("div", {
     {
       mode: ["floating", "moving"],
       css: {
-        "--width": "300px",
-        "--height": "170px",
-        width: "var(--width)",
-        height: "var(--height)",
+        "--flt-w": "300px",
+        "--flt-h": "170px",
+        width: "var(--flt-w)",
+        height: "var(--flt-h)",
       },
     },
   ],
@@ -203,6 +204,7 @@ const Float = styled("div", {
 
 /** 'Marker' to send position information for mounting the floating call card */
 export function VoiceChannelCallCardMount(props: { channel: Channel }) {
+  //const state = useState();
   const voice = useVoice();
   const [width, setWidth] = createSignal(0);
   const [ref, setRef] = createSignal<HTMLDivElement>();
@@ -216,6 +218,7 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
       setInfo({
         channel: props.channel,
         pos: ref()?.getBoundingClientRect(),
+        //drawer: state.appDrawer()?.state, TODO PR #835
       });
   });
 

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -116,8 +116,6 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
   const channel = createMemo(() => {
     const inf = info();
 
-    console.log("SET INFO", inf);
-
     if (!ref!) return;
     const sty = ref.style;
     //TODO for PR #835 to adapt VoiceCallCard to mobile UI
@@ -240,8 +238,8 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
  */
 function VoiceCallCard(props: { channel: Channel }) {
   const voice = useVoice();
-
   const inCall = () => !!voice.channel();
+
   let viewRef: HTMLDivElement | undefined;
 
   onMount(() => {

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -82,8 +82,9 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
   function mouseMove(e: MouseEvent | TouchEvent) {
     if (!touchToMouse(e)) return;
     e.preventDefault();
-    ref!.style.left = `${(e as MouseEvent).clientX - ofsX}px`;
-    ref!.style.top = `${(e as MouseEvent).clientY - ofsY}px`;
+    const x = (e as MouseEvent).clientX - ofsX,
+      y = (e as MouseEvent).clientY - ofsY;
+    ref!.style.transform = `translate(${x}px, ${y}px)`;
   }
 
   function mouseUp(e: MouseEvent | TouchEvent) {
@@ -123,12 +124,12 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     //Set mode based on state
     //TODO for PR #835 to adapt VoiceCallCard to mobile UI
     if (inf?.pos /*&& (!inf.drawer || inf.drawer === SlideState.SHOWN)*/) {
-      sty.left = `${inf.pos.x}px`;
-      sty.top = `${inf.pos.y}px`;
+      sty.transform = `translate(${inf.pos.x}px, ${inf.pos.y}px)`;
       sty.width = `${inf.pos.width}px`;
       setMode();
     } else if (!voice.channel()) {
-      sty.left = `${innerWidth + 50}px`;
+      const y = inf?.pos?.y ?? ref.getBoundingClientRect().y;
+      sty.transform = `translate(${innerWidth + 50}px, ${y}px)`;
       setMode();
     } else if (!mode()) setFloat("tr");
 
@@ -137,11 +138,10 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
   });
 
   function setFloat(float: FloatType) {
-    const sty = ref!.style;
-    sty.left =
-      float[1] === "l" ? PAD_X : `calc(100vw - var(--flt-w) - ${PAD_X})`;
-    sty.top =
-      float[0] === "t" ? PAD_Y : `calc(100vh - var(--flt-h) - ${PAD_Y})`;
+    const sty = ref!.style,
+      x = float[1] === "l" ? PAD_X : `calc(100vw - var(--flt-w) - ${PAD_X})`,
+      y = float[0] === "t" ? PAD_Y : `calc(100vh - var(--flt-h) - ${PAD_Y})`;
+    sty.transform = `translate(${x}, ${y})`;
     sty.width = "";
     setMode("floating");
   }
@@ -282,8 +282,8 @@ function VoiceCallCard(props: { channel: Channel }) {
 
 const Base = styled("div", {
   base: {
-    // todo: temp for Mount
-    top: "var(--gap-md)",
+    top: 0,
+    left: 0,
     padding: "var(--gap-md)",
 
     width: "100%",

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "solid-js";
 import { Portal } from "solid-js/web";
 
-import { AutoSizer } from "@dschz/solid-auto-sizer";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 import { Channel } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
@@ -207,8 +207,12 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
   //const state = useState();
   const voice = useVoice();
   const [width, setWidth] = createSignal(0);
-  const [ref, setRef] = createSignal<HTMLDivElement>();
   const setInfo = useContext(callCardContext)!;
+  let ref: HTMLDivElement | undefined;
+
+  onMount(() => {
+    createResizeObserver(ref, ({ width }) => setWidth(width));
+  });
 
   createEffect(() => {
     width();
@@ -217,23 +221,14 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
     if (canUpdate)
       setInfo({
         channel: props.channel,
-        pos: ref()?.getBoundingClientRect(),
+        pos: ref!.getBoundingClientRect(),
         //drawer: state.appDrawer()?.state, TODO PR #835
       });
   });
 
   onCleanup(setInfo);
 
-  return (
-    <div ref={setRef}>
-      <AutoSizer>
-        {({ width }) => {
-          setWidth(width);
-          return null;
-        }}
-      </AutoSizer>
-    </div>
-  );
+  return <div ref={ref!} />;
 }
 
 /**

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -1,8 +1,11 @@
 import {
   JSX,
+  Match,
   Show,
+  Switch,
   createContext,
   createEffect,
+  createMemo,
   createSignal,
   onCleanup,
   onMount,
@@ -14,26 +17,18 @@ import { AutoSizer } from "@dschz/solid-auto-sizer";
 import { Channel } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
-import { InRoom, useVoice } from "@revolt/rtc";
+import { useVoice } from "@revolt/rtc";
 
 import { VoiceCallCardActiveRoom } from "./VoiceCallCardActiveRoom";
 import { VoiceCallCardPiP } from "./VoiceCallCardPiP";
 import { VoiceCallCardPreview } from "./VoiceCallCardPreview";
 
-type FloatMode = "tl" | "tr" | "bl" | "br";
-
-type State =
-  | {
-      mode: "floating";
-      float: FloatMode;
-    }
-  | {
-      mode?: "fixed" | "moving";
-    };
+type Mode = "floating" | "moving";
+type FloatType = "tl" | "tr" | "bl" | "br";
 
 type Info = {
-  pos: DOMRect;
   channel: Channel;
+  pos?: DOMRect;
 };
 
 const PAD = 16,
@@ -50,8 +45,9 @@ function getTouch(id: number, tl: TouchList) {
 export function VoiceCallCardContext(props: { children: JSX.Element }) {
   const voice = useVoice();
 
-  const [state, setState] = createSignal<State>({});
-  let ref: HTMLDivElement, channel: Channel | null;
+  const [mode, setMode] = createSignal<Mode>();
+  const [info, setInfo] = createSignal<Info>();
+  let ref: HTMLDivElement;
 
   let events: AbortController | null,
     tid = 0,
@@ -73,11 +69,11 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
 
   function mouseDown(e: MouseEvent | TouchEvent) {
     touchToMouse(e, true);
-    if (state().mode === "floating") {
+    if (mode() === "floating") {
       const pos = ref!.getBoundingClientRect();
       ofsX = (e as MouseEvent).clientX - pos.x;
       ofsY = (e as MouseEvent).clientY - pos.y;
-      setState({ mode: "moving" });
+      setMode("moving");
       addEvents();
     }
   }
@@ -92,8 +88,9 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
   function mouseUp(e: MouseEvent | TouchEvent) {
     if (!touchToMouse(e)) return;
     const sty = ref!.style,
-      left = (e as MouseEvent).clientX < outerWidth / 2,
-      top = (e as MouseEvent).clientY < outerHeight / 2;
+      pos = ref!.getBoundingClientRect(),
+      left = (e as MouseEvent).clientX - ofsX + pos.width / 2 < outerWidth / 2,
+      top = (e as MouseEvent).clientY - ofsY + pos.height / 2 < outerHeight / 2;
 
     sty.transition = "all .2s cubic-bezier(0, 1.67, 0.85, 0.8)";
     setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");
@@ -104,11 +101,11 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
   function addEvents() {
     if (events) return;
     events = new AbortController();
-    const sig = { passive: false, signal: events.signal };
-    document.addEventListener("mousemove", mouseMove, sig);
-    document.addEventListener("mouseup", mouseUp, sig);
-    document.addEventListener("touchmove", mouseMove, sig);
-    document.addEventListener("touchend", mouseUp, sig);
+    const opt = { passive: false, signal: events.signal };
+    document.addEventListener("mousemove", mouseMove, opt);
+    document.addEventListener("mouseup", mouseUp, opt);
+    document.addEventListener("touchmove", mouseMove, opt);
+    document.addEventListener("touchend", mouseUp, opt);
   }
 
   function resetEvents() {
@@ -116,31 +113,37 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     events = null;
   }
 
-  function setInfo(info?: Info) {
-    if (ref!) {
-      if (info) {
-        channel = info.channel;
-        const sty = ref.style;
-        sty.left = `${info.pos.x}px`;
-        sty.top = `${info.pos.y}px`;
-        sty.width = `${info.pos.width}px`;
-        setState({ mode: "fixed" });
-      } else {
-        channel = null;
-        setFloat("tr");
-      }
-    }
-    resetEvents();
-  }
+  const channel = createMemo(() => {
+    const inf = info();
 
-  function setFloat(float: FloatMode) {
+    console.log("SET INFO", inf);
+
+    if (!ref!) return;
+    const sty = ref.style;
+    //TODO for PR #835 to adapt VoiceCallCard to mobile UI
+    //const drawer = state.appDrawer();
+
+    //Set mode based on state
+    if (inf?.pos /*&& (!drawer || drawer.state === SlideState.SHOWN)*/) {
+      sty.left = `${inf.pos.x}px`;
+      sty.top = `${inf.pos.y}px`;
+      sty.width = `${inf.pos.width}px`;
+      setMode();
+    } else if (!voice.channel()) setMode();
+    else if (!mode()) setFloat("tr");
+
+    resetEvents();
+    return inf?.channel;
+  });
+
+  function setFloat(float: FloatType) {
     const sty = ref!.style;
     sty.left =
       float[1] === "l" ? PAD_X : `calc(100vw - var(--width) - ${PAD_X})`;
     sty.top =
       float[0] === "t" ? PAD_Y : `calc(100vh - var(--height) - ${PAD_Y})`;
     sty.width = "";
-    setState({ mode: "floating", float });
+    setMode("floating");
   }
 
   onCleanup(resetEvents);
@@ -149,25 +152,21 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     <callCardContext.Provider value={setInfo}>
       {props.children}
       <Portal ref={document.getElementById("floating")! as HTMLDivElement}>
-        <Show when={voice.channel()}>
-          <Float
-            ref={ref!}
-            mode={state().mode}
-            onMouseDown={mouseDown}
-            onTouchStart={mouseDown}
-          >
-            <Show
-              when={state().mode === "fixed"}
-              fallback={
-                <InRoom>
-                  <VoiceCallCardPiP />
-                </InRoom>
-              }
-            >
-              <VoiceCallCard channel={channel!} />
-            </Show>
-          </Float>
-        </Show>
+        <Float
+          ref={ref!}
+          mode={mode()}
+          onMouseDown={mouseDown}
+          onTouchStart={mouseDown}
+        >
+          <Switch>
+            <Match when={mode()}>
+              <VoiceCallCardPiP />
+            </Match>
+            <Match when={info() && channel()}>
+              <VoiceCallCard channel={channel()!} />
+            </Match>
+          </Switch>
+        </Float>
       </Portal>
     </callCardContext.Provider>
   );
@@ -189,7 +188,6 @@ const Float = styled("div", {
         cursor: "grabbing",
         transition: "none",
       },
-      fixed: {},
     },
   },
   compoundVariants: [
@@ -214,27 +212,26 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
 
   createEffect(() => {
     width();
-    const active = voice.channel();
-    const isActive = !active || active.id === props.channel.id;
-    const pos = ref()?.getBoundingClientRect();
-    if (pos) setInfo(isActive ? { pos, channel: props.channel } : undefined);
+    const active = voice.channel(),
+      canUpdate = !active || active.id === props.channel.id;
+    if (canUpdate)
+      setInfo({
+        channel: props.channel,
+        pos: ref()?.getBoundingClientRect(),
+      });
   });
 
   onCleanup(setInfo);
 
-  //TODO React to pos change and not only width change
-
   return (
-    <Show when={voice.channel()}>
-      <div ref={setRef}>
-        <AutoSizer>
-          {({ width }) => {
-            setWidth(width);
-            return null;
-          }}
-        </AutoSizer>
-      </div>
-    </Show>
+    <div ref={setRef}>
+      <AutoSizer>
+        {({ width }) => {
+          setWidth(width);
+          return null;
+        }}
+      </AutoSizer>
+    </div>
   );
 }
 
@@ -243,8 +240,8 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
  */
 function VoiceCallCard(props: { channel: Channel }) {
   const voice = useVoice();
-  const inCall = () => voice.channel()?.id === props.channel.id;
 
+  const inCall = () => !!voice.channel();
   let viewRef: HTMLDivElement | undefined;
 
   onMount(() => {

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -277,8 +277,8 @@ function VoiceCallCard(props: { channel: Channel }) {
 
 const Base = styled("div", {
   base: {
-    top: 0,
     left: 0,
+    top: "var(--gap-md)",
     padding: "var(--gap-md)",
 
     width: "100%",

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -29,7 +29,6 @@ type FloatType = "tl" | "tr" | "bl" | "br";
 type Info = {
   channel: Channel;
   pos?: DOMRect;
-  //drawer?: SlideState; TODO PR #835
 };
 
 const PAD = 16,
@@ -122,8 +121,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     const sty = ref.style;
 
     //Set mode based on state
-    //TODO for PR #835 to adapt VoiceCallCard to mobile UI
-    if (inf?.pos /*&& (!inf.drawer || inf.drawer === SlideState.SHOWN)*/) {
+    if (inf?.pos) {
       sty.transform = `translate(${inf.pos.x}px, ${inf.pos.y}px)`;
       sty.width = `${inf.pos.width}px`;
       setMode();
@@ -222,7 +220,6 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
       setInfo({
         channel: props.channel,
         pos: ref!.getBoundingClientRect(),
-        //drawer: state.appDrawer()?.state, TODO PR #835
       });
   });
 

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -31,15 +31,18 @@ type Info = {
   pos?: DOMRect;
 };
 
+type PtrEvent = {
+  type: string;
+  tid: number;
+  clientX: number;
+  clientY: number;
+};
+
 const PAD = 16,
   PAD_X = `${PAD}px`,
   PAD_Y = `${PAD + 56}px`;
 
 const callCardContext = createContext<(info?: Info) => void>();
-
-function getTouch(id: number, tl: TouchList) {
-  for (const t of tl) if (t.identifier === id) return t;
-}
 
 /** Voice call card context */
 export function VoiceCallCardContext(props: { children: JSX.Element }) {
@@ -54,44 +57,55 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     ofsX = 0,
     ofsY = 0;
 
-  function touchToMouse(e: MouseEvent | TouchEvent, down = false) {
+  function getTouch(id: number, tl: TouchList) {
+    for (const t of tl) if (t.identifier === id) return t;
+  }
+
+  function getPointer(
+    e: MouseEvent | TouchEvent,
+    tid: number | null,
+  ): PtrEvent | undefined {
+    let t: MouseEvent | Touch | undefined;
     if (e instanceof TouchEvent) {
-      const t = down ? e.touches[0] : getTouch(tid, e.changedTouches);
-      if (down) tid = t!.identifier;
-      else if (!t) return false;
-      //@ts-expect-error prop
-      e.clientX = t.clientX;
-      //@ts-expect-error prop
-      e.clientY = t.clientY;
-    }
-    return true;
+      t = tid ? getTouch(tid, e.changedTouches) : e.touches[0];
+      if (!t) return;
+    } else t = e;
+    return {
+      type: e.type,
+      tid: (t as Touch).identifier || 0,
+      clientX: t!.clientX,
+      clientY: t!.clientY,
+    };
   }
 
   function mouseDown(e: MouseEvent | TouchEvent) {
-    touchToMouse(e, true);
+    const ptr = getPointer(e, null)!;
+    tid = ptr.tid;
     if (mode() === "floating") {
       const pos = ref!.getBoundingClientRect();
-      ofsX = (e as MouseEvent).clientX - pos.x;
-      ofsY = (e as MouseEvent).clientY - pos.y;
+      ofsX = ptr.clientX - pos.x;
+      ofsY = ptr.clientY - pos.y;
       setMode("moving");
       addEvents();
     }
   }
 
   function mouseMove(e: MouseEvent | TouchEvent) {
-    if (!touchToMouse(e)) return;
+    const ptr = getPointer(e, tid);
+    if (!ptr) return;
     e.preventDefault();
-    const x = (e as MouseEvent).clientX - ofsX,
-      y = (e as MouseEvent).clientY - ofsY;
+    const x = ptr.clientX - ofsX,
+      y = ptr.clientY - ofsY;
     ref!.style.transform = `translate(${x}px, ${y}px)`;
   }
 
   function mouseUp(e: MouseEvent | TouchEvent) {
-    if (!touchToMouse(e)) return;
+    const ptr = getPointer(e, tid);
+    if (!ptr) return;
     const sty = ref!.style,
       pos = ref!.getBoundingClientRect(),
-      left = (e as MouseEvent).clientX - ofsX + pos.width / 2 < outerWidth / 2,
-      top = (e as MouseEvent).clientY - ofsY + pos.height / 2 < outerHeight / 2;
+      left = ptr.clientX - ofsX + pos.width / 2 < outerWidth / 2,
+      top = ptr.clientY - ofsY + pos.height / 2 < outerHeight / 2;
 
     sty.transition = "all .2s cubic-bezier(0, 1.67, 0.85, 0.8)";
     setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -1,13 +1,9 @@
 import {
   JSX,
-  Match,
   Show,
-  Switch,
-  batch,
   createContext,
   createEffect,
   createSignal,
-  on,
   onCleanup,
   onMount,
   useContext,
@@ -16,7 +12,6 @@ import { Portal } from "solid-js/web";
 
 import { AutoSizer } from "@dschz/solid-auto-sizer";
 import { Channel } from "stoat.js";
-import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { InRoom, useVoice } from "@revolt/rtc";
@@ -25,239 +20,213 @@ import { VoiceCallCardActiveRoom } from "./VoiceCallCardActiveRoom";
 import { VoiceCallCardPiP } from "./VoiceCallCardPiP";
 import { VoiceCallCardPreview } from "./VoiceCallCardPreview";
 
+type FloatMode = "tl" | "tr" | "bl" | "br";
+
 type State =
   | {
-      type: "floating";
-      corner: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+      mode: "floating";
+      float: FloatMode;
     }
   | {
-      type: "fixed";
-      x: number;
-      y: number;
-      width: number;
-      channel: Channel;
+      mode?: "fixed" | "moving";
     };
 
-type NewState = { channel: Channel; x: number; y: number; width: number };
+type Info = {
+  pos: DOMRect;
+  channel: Channel;
+};
 
-const callCardContext = createContext<(state?: NewState) => void>(null!);
+const PAD = 16,
+  PAD_X = `${PAD}px`,
+  PAD_Y = `${PAD + 56}px`;
 
-/**
- * Voice call card context
- */
+const callCardContext = createContext<(info?: Info) => void>();
+
+function getTouch(id: number, tl: TouchList) {
+  for (const t of tl) if (t.identifier === id) return t;
+}
+
+/** Voice call card context */
 export function VoiceCallCardContext(props: { children: JSX.Element }) {
-  const [state, setState] = createSignal<State>({
-    type: "floating",
-    corner: "bottom-right",
-  });
+  const voice = useVoice();
 
-  const [moving, setMoving] = createSignal<boolean>();
-  const [offset, setOffset] = createSignal({ x: 0, y: 0 });
+  const [state, setState] = createSignal<State>({});
+  let ref: HTMLDivElement, channel: Channel | null;
 
-  function position() {
-    const position = state();
+  let events: AbortController | null,
+    tid = 0,
+    ofsX = 0,
+    ofsY = 0;
 
-    switch (position.type) {
-      case "fixed":
-        return {
-          transform: `translate(${position.x}px, ${position.y}px)`,
-          // top: position.y + "px",
-          // left: position.x + "px",
-          width: position.width + "px",
-          height: "40vh",
-        };
-      case "floating":
-        return {
-          "--width": "280px",
-          "--height": "158px",
-          "--padding-x": "32px",
-          "--padding-y": "96px",
-          transform: `translate(${
-            position.corner === "top-left" || position.corner === "bottom-left"
-              ? "calc(var(--padding-x) + var(--offset-x))"
-              : "calc(100vw - var(--padding-x) - var(--width) + var(--offset-x))"
-          }, ${
-            position.corner === "top-left" || position.corner === "top-right"
-              ? "calc(var(--padding-y) + var(--offset-y))"
-              : "calc(100vh - var(--padding-y) - var(--height) + var(--offset-y))"
-          })`,
-          width: "var(--width)",
-          height: "var(--height)",
-        };
+  function touchToMouse(e: MouseEvent | TouchEvent, down = false) {
+    if (e instanceof TouchEvent) {
+      const t = down ? e.touches[0] : getTouch(tid, e.changedTouches);
+      if (down) tid = t!.identifier;
+      else if (!t) return false;
+      //@ts-expect-error prop
+      e.clientX = t.clientX;
+      //@ts-expect-error prop
+      e.clientY = t.clientY;
+    }
+    return true;
+  }
+
+  function mouseDown(e: MouseEvent | TouchEvent) {
+    touchToMouse(e, true);
+    if (state().mode === "floating") {
+      const pos = ref!.getBoundingClientRect();
+      ofsX = (e as MouseEvent).clientX - pos.x;
+      ofsY = (e as MouseEvent).clientY - pos.y;
+      setState({ mode: "moving" });
+      addEvents();
     }
   }
 
-  createEffect(
-    on(moving, (moving) => {
-      if (moving) {
-        const controller = new AbortController();
+  function mouseMove(e: MouseEvent | TouchEvent) {
+    if (!touchToMouse(e)) return;
+    e.preventDefault();
+    ref!.style.left = `${(e as MouseEvent).clientX - ofsX}px`;
+    ref!.style.top = `${(e as MouseEvent).clientY - ofsY}px`;
+  }
 
-        document.addEventListener(
-          "mousemove",
-          (event) => {
-            const position = state();
-            if (position.type !== "floating") return controller.abort();
+  function mouseUp(e: MouseEvent | TouchEvent) {
+    if (!touchToMouse(e)) return;
+    const sty = ref!.style,
+      left = (e as MouseEvent).clientX < outerWidth / 2,
+      top = (e as MouseEvent).clientY < outerHeight / 2;
 
-            setOffset((pos) => ({
-              x: pos.x + event.movementX,
-              y: pos.y + event.movementY,
-            }));
-          },
-          { signal: controller.signal },
-        );
+    sty.transition = "all .2s cubic-bezier(0, 1.67, 0.85, 0.8)";
+    setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");
+    setTimeout(() => (sty.transition = ""), 1);
+    resetEvents();
+  }
 
-        document.addEventListener(
-          "mouseup",
-          (event) => {
-            batch(() => {
-              setMoving(false);
+  function addEvents() {
+    if (events) return;
+    events = new AbortController();
+    const sig = { passive: false, signal: events.signal };
+    document.addEventListener("mousemove", mouseMove, sig);
+    document.addEventListener("mouseup", mouseUp, sig);
+    document.addEventListener("touchmove", mouseMove, sig);
+    document.addEventListener("touchend", mouseUp, sig);
+  }
 
-              const left = event.clientX < window.outerWidth / 2;
-              const top = event.clientY < window.outerHeight / 2;
+  function resetEvents() {
+    events?.abort();
+    events = null;
+  }
 
-              setState({
-                type: "floating",
-                corner: left
-                  ? top
-                    ? "top-left"
-                    : "bottom-left"
-                  : top
-                    ? "top-right"
-                    : "bottom-right",
-              });
-            });
-          },
-          { signal: controller.signal },
-        );
-
-        onCleanup(() => controller.abort());
+  function setInfo(info?: Info) {
+    if (ref!) {
+      if (info) {
+        channel = info.channel;
+        const sty = ref.style;
+        sty.left = `${info.pos.x}px`;
+        sty.top = `${info.pos.y}px`;
+        sty.width = `${info.pos.width}px`;
+        setState({ mode: "fixed" });
+      } else {
+        channel = null;
+        setFloat("tr");
       }
-    }),
-  );
-
-  function updateState(state?: NewState) {
-    if (state) {
-      setState({
-        type: "fixed",
-        width: state.width,
-        x: state.x,
-        y: state.y,
-        channel: state.channel,
-      });
-    } else {
-      setState({
-        type: "floating",
-        corner: "bottom-right",
-      });
     }
+    resetEvents();
   }
 
-  function updateStateWithTransition(state?: NewState) {
-    // no clue if this works
-
-    if (!document.startViewTransition) {
-      updateState(state);
-      return;
-    }
-
-    document.startViewTransition(() => updateState(state));
+  function setFloat(float: FloatMode) {
+    const sty = ref!.style;
+    sty.left =
+      float[1] === "l" ? PAD_X : `calc(100vw - var(--width) - ${PAD_X})`;
+    sty.top =
+      float[0] === "t" ? PAD_Y : `calc(100vh - var(--height) - ${PAD_Y})`;
+    sty.width = "";
+    setState({ mode: "floating", float });
   }
+
+  onCleanup(resetEvents);
 
   return (
-    <callCardContext.Provider value={updateStateWithTransition}>
+    <callCardContext.Provider value={setInfo}>
       {props.children}
-
       <Portal ref={document.getElementById("floating")! as HTMLDivElement}>
-        <div
-          style={{
-            position: "fixed",
-            "z-index": 10,
-            transition: moving()
-              ? "all .2s cubic-bezier(0, 1.67, 0.85, 0.8), width 0s"
-              : "all .3s cubic-bezier(1, 0, 0, 1), width 0s",
-            ...position(),
-            "pointer-events": "none",
-            cursor:
-              state().type === "floating"
-                ? moving()
-                  ? "grabbing"
-                  : "grab"
-                : "auto",
-            "--offset-x": `${moving() ? offset().x : 0}px`,
-            "--offset-y": `${moving() ? offset().y : 0}px`,
-          }}
-          // dragging logic for mice
-          onMouseDown={() => {
-            if (state().type === "floating") {
-              batch(() => {
-                setMoving(true);
-                setOffset({ x: 0, y: 0 });
-              });
-            }
-          }}
-          // dragging logic for touch input
-          // todo
-        >
-          <Switch>
-            <Match when={state().type === "fixed"}>
-              <VoiceCallCard
-                channel={(state() as { channel: Channel }).channel}
-              />
-            </Match>
-            <Match when={state().type === "floating"}>
-              <InRoom>
-                <VoiceCallCardPiP />
-              </InRoom>
-            </Match>
-          </Switch>
-        </div>
+        <Show when={voice.channel()}>
+          <Float
+            ref={ref!}
+            mode={state().mode}
+            onMouseDown={mouseDown}
+            onTouchStart={mouseDown}
+          >
+            <Show
+              when={state().mode === "fixed"}
+              fallback={
+                <InRoom>
+                  <VoiceCallCardPiP />
+                </InRoom>
+              }
+            >
+              <VoiceCallCard channel={channel!} />
+            </Show>
+          </Float>
+        </Show>
       </Portal>
     </callCardContext.Provider>
   );
 }
 
-/**
- * 'Marker' to send position information for mounting the floating call card
- */
+const Float = styled("div", {
+  base: {
+    position: "fixed",
+    zIndex: 10,
+    pointerEvents: "none",
+    transition: "all .3s cubic-bezier(1, 0, 0, 1)",
+    height: "40vh",
+  },
+
+  variants: {
+    mode: {
+      floating: { cursor: "grab" },
+      moving: {
+        cursor: "grabbing",
+        transition: "none",
+      },
+      fixed: {},
+    },
+  },
+  compoundVariants: [
+    {
+      mode: ["floating", "moving"],
+      css: {
+        "--width": "300px",
+        "--height": "170px",
+        width: "var(--width)",
+        height: "var(--height)",
+      },
+    },
+  ],
+});
+
+/** 'Marker' to send position information for mounting the floating call card */
 export function VoiceChannelCallCardMount(props: { channel: Channel }) {
   const voice = useVoice();
   const [width, setWidth] = createSignal(0);
-
   const [ref, setRef] = createSignal<HTMLDivElement>();
-  const updateSize = useContext(callCardContext)!;
-
-  const ongoingCallElsewhere = () =>
-    voice.channel() && voice.channel()?.id !== props.channel.id;
+  const setInfo = useContext(callCardContext)!;
 
   createEffect(() => {
-    const rect = ref()?.getBoundingClientRect();
-    const w = width();
-
-    const activeChannel = voice.channel();
-    const canUpdate = !activeChannel || activeChannel.id === props.channel.id;
-
-    if (rect?.left && w) {
-      if (canUpdate) {
-        updateSize({
-          x: rect.left,
-          y: rect.top,
-          width: w,
-          channel: props.channel,
-        });
-      } else {
-        updateSize();
-      }
-    }
+    width();
+    const active = voice.channel();
+    const isActive = !active || active.id === props.channel.id;
+    const pos = ref()?.getBoundingClientRect();
+    if (pos) setInfo(isActive ? { pos, channel: props.channel } : undefined);
   });
 
-  onCleanup(() => updateSize());
+  onCleanup(setInfo);
+
+  //TODO React to pos change and not only width change
 
   return (
-    <div
-      ref={setRef}
-      class={css({ position: "relative", pointerEvents: "none" })}
-    >
-      <div class={css({ position: "absolute", width: "100%" })}>
+    <Show when={voice.channel()}>
+      <div ref={setRef}>
         <AutoSizer>
           {({ width }) => {
             setWidth(width);
@@ -265,11 +234,7 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
           }}
         </AutoSizer>
       </div>
-
-      <Show when={ongoingCallElsewhere()}>
-        <VoiceCallCard channel={props.channel} />
-      </Show>
-    </div>
+    </Show>
   );
 }
 

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -31,13 +31,6 @@ type Info = {
   pos: DOMRect;
 };
 
-type PtrEvent = {
-  type: string;
-  tid: number;
-  clientX: number;
-  clientY: number;
-};
-
 const PAD = 16,
   PAD_X = `${PAD}px`,
   PAD_Y = `${PAD + 56}px`;
@@ -53,62 +46,35 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
 
   let ref: HTMLDivElement | undefined,
     events: AbortController | null,
-    tid = 0,
+    pid = 0,
     ofsX = 0,
     ofsY = 0;
 
-  function getTouch(id: number, tl: TouchList) {
-    for (const t of tl) if (t.identifier === id) return t;
-  }
-
-  /**
-   * @param tid Touch ID, or null to track new touch
-   */
-  function getPointer(
-    e: MouseEvent | TouchEvent,
-    tid: number | null,
-  ): PtrEvent | undefined {
-    let t: MouseEvent | Touch | undefined;
-    if (e instanceof TouchEvent) {
-      t = tid != null ? getTouch(tid, e.changedTouches) : e.touches[0];
-      if (!t) return;
-    } else t = e;
-    return {
-      type: e.type,
-      tid: (t as Touch).identifier || 0,
-      clientX: t!.clientX,
-      clientY: t!.clientY,
-    };
-  }
-
-  function mouseDown(e: MouseEvent | TouchEvent) {
-    const ptr = getPointer(e, null)!;
-    tid = ptr.tid;
+  function mouseDown(e: PointerEvent) {
+    pid = e.pointerId;
     if (mode() === "floating") {
       const pos = ref!.getBoundingClientRect();
-      ofsX = ptr.clientX - pos.x;
-      ofsY = ptr.clientY - pos.y;
+      ofsX = e.clientX - pos.x;
+      ofsY = e.clientY - pos.y;
       setMode("moving");
       addEvents();
     }
   }
 
-  function mouseMove(e: MouseEvent | TouchEvent) {
-    const ptr = getPointer(e, tid);
-    if (!ptr) return;
+  function mouseMove(e: PointerEvent) {
+    if (e.pointerId !== pid) return;
     e.preventDefault();
-    const x = ptr.clientX - ofsX,
-      y = ptr.clientY - ofsY;
+    const x = e.clientX - ofsX,
+      y = e.clientY - ofsY;
     ref!.style.transform = `translate(${x}px, ${y}px)`;
   }
 
-  function mouseUp(e: MouseEvent | TouchEvent) {
-    const ptr = getPointer(e, tid);
-    if (!ptr) return;
+  function mouseUp(e: PointerEvent) {
+    if (e.pointerId !== pid) return;
     const sty = ref!.style,
       pos = ref!.getBoundingClientRect(),
-      left = ptr.clientX - ofsX + pos.width / 2 < outerWidth / 2,
-      top = ptr.clientY - ofsY + pos.height / 2 < outerHeight / 2;
+      left = e.clientX - ofsX + pos.width / 2 < outerWidth / 2,
+      top = e.clientY - ofsY + pos.height / 2 < outerHeight / 2;
 
     sty.transition = "all .2s cubic-bezier(0, 1.67, 0.85, 0.8)";
     setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");
@@ -121,10 +87,8 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     if (events) return;
     events = new AbortController();
     const opt = { passive: false, signal: events.signal };
-    document.addEventListener("mousemove", mouseMove, opt);
-    document.addEventListener("mouseup", mouseUp, opt);
-    document.addEventListener("touchmove", mouseMove, opt);
-    document.addEventListener("touchend", mouseUp, opt);
+    document.addEventListener("pointermove", mouseMove, opt);
+    document.addEventListener("pointerup", mouseUp, opt);
   }
 
   function resetEvents() {
@@ -168,12 +132,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     <callCardContext.Provider value={setInfo}>
       {props.children}
       <Portal ref={document.getElementById("floating")! as HTMLDivElement}>
-        <Float
-          ref={ref}
-          mode={mode()}
-          onMouseDown={mouseDown}
-          onTouchStart={mouseDown}
-        >
+        <Float ref={ref} mode={mode()} onPointerDown={mouseDown}>
           <Switch>
             <Match when={mode()}>
               <VoiceCallCardPiP />
@@ -195,6 +154,7 @@ const Float = styled("div", {
     pointerEvents: "none",
     transition: "all .3s cubic-bezier(1, 0, 0, 1)",
     height: "40vh",
+    touchAction: "none",
   },
   variants: {
     mode: {

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -76,7 +76,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
       left = e.clientX - ofsX + pos.width / 2 < outerWidth / 2,
       top = e.clientY - ofsY + pos.height / 2 < outerHeight / 2;
 
-    sty.transition = "all .2s cubic-bezier(0, 1.67, 0.85, 0.8)";
+    sty.transition = "all .2s cubic-bezier(0, 1.5, 0.85, 0.8)";
     setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");
     //Reset CSS transition on next render pass
     setTimeout(() => (sty.transition = ""), 1);

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -73,8 +73,8 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     if (e.pointerId !== pid) return;
     const sty = ref!.style,
       pos = ref!.getBoundingClientRect(),
-      left = e.clientX - ofsX + pos.width / 2 < outerWidth / 2,
-      top = e.clientY - ofsY + pos.height / 2 < outerHeight / 2;
+      left = e.clientX - ofsX + pos.width / 2 < innerWidth / 2,
+      top = e.clientY - ofsY + pos.height / 2 < innerHeight / 2;
 
     sty.transition = "all .2s cubic-bezier(0, 1.5, 0.85, 0.8)";
     setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "solid-js";
 import { Portal } from "solid-js/web";
 
-import { createResizeObserver } from "@solid-primitives/resize-observer";
+import { makeResizeObserver } from "@solid-primitives/resize-observer";
 import { Channel } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
@@ -28,7 +28,7 @@ type FloatType = "tl" | "tr" | "bl" | "br";
 
 type Info = {
   channel: Channel;
-  pos?: DOMRect;
+  pos: DOMRect;
 };
 
 type PtrEvent = {
@@ -50,9 +50,9 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
 
   const [mode, setMode] = createSignal<Mode>();
   const [info, setInfo] = createSignal<Info>();
-  let ref: HTMLDivElement | undefined;
 
-  let events: AbortController | null,
+  let ref: HTMLDivElement | undefined,
+    events: AbortController | null,
     tid = 0,
     ofsX = 0,
     ofsY = 0;
@@ -61,13 +61,16 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     for (const t of tl) if (t.identifier === id) return t;
   }
 
+  /**
+   * @param tid Touch ID, or null to track new touch
+   */
   function getPointer(
     e: MouseEvent | TouchEvent,
     tid: number | null,
   ): PtrEvent | undefined {
     let t: MouseEvent | Touch | undefined;
     if (e instanceof TouchEvent) {
-      t = tid ? getTouch(tid, e.changedTouches) : e.touches[0];
+      t = tid != null ? getTouch(tid, e.changedTouches) : e.touches[0];
       if (!t) return;
     } else t = e;
     return {
@@ -109,6 +112,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
 
     sty.transition = "all .2s cubic-bezier(0, 1.67, 0.85, 0.8)";
     setFloat(left ? (top ? "tl" : "bl") : top ? "tr" : "br");
+    //Reset CSS transition on next render pass
     setTimeout(() => (sty.transition = ""), 1);
     resetEvents();
   }
@@ -140,7 +144,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
       sty.width = `${inf.pos.width}px`;
       setMode();
     } else if (!voice.channel()) {
-      const y = inf?.pos?.y ?? ref.getBoundingClientRect().y;
+      const y = inf?.pos.y ?? ref.getBoundingClientRect().y;
       sty.transform = `translate(${innerWidth + 50}px, ${y}px)`;
       setMode();
     } else if (!mode()) setFloat("tr");
@@ -174,7 +178,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
             <Match when={mode()}>
               <VoiceCallCardPiP />
             </Match>
-            <Match when={info() && channel()}>
+            <Match when={channel()}>
               <VoiceCallCard channel={channel()!} />
             </Match>
           </Switch>
@@ -216,28 +220,34 @@ const Float = styled("div", {
 
 /** 'Marker' to send position information for mounting the floating call card */
 export function VoiceChannelCallCardMount(props: { channel: Channel }) {
-  //const state = useState();
   const voice = useVoice();
-  const [width, setWidth] = createSignal(0);
   const setInfo = useContext(callCardContext)!;
   let ref: HTMLDivElement | undefined;
 
+  function updateInfo() {
+    const vc = voice.channel();
+    setInfo(
+      !vc || vc.id === props.channel.id
+        ? {
+            channel: props.channel,
+            pos: ref!.getBoundingClientRect(),
+          }
+        : undefined,
+    );
+  }
+
+  createEffect(updateInfo);
+
+  //Observe resize of parent
+  let obs: ReturnType<typeof makeResizeObserver>;
   onMount(() => {
-    createResizeObserver(ref, ({ width }) => setWidth(width));
+    obs = makeResizeObserver(updateInfo);
+    obs.observe(ref!.parentElement!);
   });
-
-  createEffect(() => {
-    width();
-    const active = voice.channel(),
-      canUpdate = !active || active.id === props.channel.id;
-    if (canUpdate)
-      setInfo({
-        channel: props.channel,
-        pos: ref!.getBoundingClientRect(),
-      });
+  onCleanup(() => {
+    obs.unobserve(ref!.parentElement!);
+    setInfo();
   });
-
-  onCleanup(setInfo);
 
   return <div ref={ref!} />;
 }

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -148,6 +148,7 @@ const Actions = styled("div", {
     flexShrink: 0,
     gap: "var(--gap-md)",
     padding: "var(--gap-md)",
+    zIndex: 2,
 
     display: "flex",
     width: "fit-content",

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@solidjs/router";
 import { Show } from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
@@ -10,32 +11,46 @@ import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
 export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
   const voice = useVoice();
+  const navigate = useNavigate();
   const { t } = useLingui();
 
-  function isVideoEnabled() {
-    return CONFIGURATION.ENABLE_VIDEO;
-  }
+  //TODO For changes in PR #999
+  const enableVideo = CONFIGURATION.ENABLE_VIDEO;
 
   return (
     <Actions>
       <Show when={props.size === "xs"}>
-        <a href={voice.channel()?.path}>
-          <IconButton variant="standard" size={props.size}>
-            <Symbol>arrow_top_left</Symbol>
-          </IconButton>
-        </a>
+        <IconButton
+          variant="standard"
+          size={props.size}
+          onPress={() => {
+            navigate(voice.channel()?.path ?? "");
+            //TODO For change in PR #835
+            //state.appDrawer()?.setShown(true);
+          }}
+          use:floating={{
+            tooltip: {
+              placement: "top",
+              content: t`Return to voice channel`,
+            },
+          }}
+        >
+          <Symbol>arrow_top_left</Symbol>
+        </IconButton>
       </Show>
       <IconButton
         size={props.size}
         variant={voice.microphone() ? "filled" : "tonal"}
         onPress={() => voice.toggleMute()}
         use:floating={{
-          tooltip: voice.speakingPermission
-            ? undefined
-            : {
-                placement: "top",
-                content: t`Missing permission`,
-              },
+          tooltip: {
+            placement: "top",
+            content: voice.speakingPermission
+              ? voice.microphone()
+                ? t`Unmute`
+                : t`Mute`
+              : t`Missing permission`,
+          },
         }}
         isDisabled={!voice.speakingPermission}
       >
@@ -48,12 +63,14 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
         variant={voice.deafen() || !voice.listenPermission ? "tonal" : "filled"}
         onPress={() => voice.toggleDeafen()}
         use:floating={{
-          tooltip: voice.listenPermission
-            ? undefined
-            : {
-                placement: "top",
-                content: t`Missing permission`,
-              },
+          tooltip: {
+            placement: "top",
+            content: voice.listenPermission
+              ? voice.deafen()
+                ? t`Listen`
+                : t`Defean`
+              : t`Missing permission`,
+          },
         }}
         isDisabled={!voice.listenPermission}
       >
@@ -66,44 +83,44 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
       </IconButton>
       <IconButton
         size={props.size}
-        variant={isVideoEnabled() && voice.video() ? "filled" : "tonal"}
+        variant={enableVideo && voice.video() ? "filled" : "tonal"}
         onPress={() => {
-          if (isVideoEnabled()) voice.toggleCamera();
+          if (enableVideo) voice.toggleCamera();
         }}
         use:floating={{
           tooltip: {
             placement: "top",
-            content: isVideoEnabled()
+            content: enableVideo
               ? voice.video()
-                ? "Stop Camera"
-                : "Start Camera"
-              : "Coming soon! 👀",
+                ? t`Stop camera`
+                : t`Start camera`
+              : t`Coming soon! 👀`,
           },
         }}
-        isDisabled={!isVideoEnabled()}
+        isDisabled={!enableVideo}
       >
         <Symbol>camera_video</Symbol>
       </IconButton>
       <IconButton
         size={props.size}
-        variant={isVideoEnabled() && voice.screenshare() ? "filled" : "tonal"}
+        variant={enableVideo && voice.screenshare() ? "filled" : "tonal"}
         onPress={() => {
-          if (isVideoEnabled()) voice.toggleScreenshare();
+          if (enableVideo) voice.toggleScreenshare();
         }}
         use:floating={{
           tooltip: {
             placement: "top",
-            content: isVideoEnabled()
+            content: enableVideo
               ? voice.screenshare()
-                ? "Stop Sharing"
-                : "Share Screen"
-              : "Coming soon! 👀",
+                ? t`Stop sharing`
+                : t`Share screen`
+              : t`Coming soon! 👀`,
           },
         }}
-        isDisabled={!isVideoEnabled()}
+        isDisabled={!enableVideo}
       >
         <Show
-          when={!isVideoEnabled() || voice.screenshare()}
+          when={!enableVideo || voice.screenshare()}
           fallback={<Symbol>stop_screen_share</Symbol>}
         >
           <Symbol>screen_share</Symbol>
@@ -113,6 +130,12 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
         size={props.size}
         variant="_error"
         onPress={() => voice.disconnect()}
+        use:floating={{
+          tooltip: {
+            placement: "top",
+            content: t`End call`,
+          },
+        }}
       >
         <Symbol>call_end</Symbol>
       </Button>

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -47,8 +47,8 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
             placement: "top",
             content: voice.speakingPermission
               ? voice.microphone()
-                ? t`Unmute`
-                : t`Mute`
+                ? t`Mute`
+                : t`Unmute`
               : t`Missing permission`,
           },
         }}

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -14,7 +14,6 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
   const navigate = useNavigate();
   const { t } = useLingui();
 
-  //TODO For changes in PR #999
   const enableVideo = CONFIGURATION.ENABLE_VIDEO;
 
   return (
@@ -25,8 +24,6 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
           size={props.size}
           onPress={() => {
             navigate(voice.channel()?.path ?? "");
-            //TODO For change in PR #835
-            //state.appDrawer()?.setShown(true);
           }}
           use:floating={{
             tooltip: {

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
@@ -90,7 +90,7 @@ const MiniCard = styled("div", {
     display: "flex",
     alignItems: "center",
     flexDirection: "column",
-    justifyContent: "center",
+    justifyContent: "end",
 
     gap: "var(--gap-md)",
     padding: "var(--gap-md)",

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
@@ -149,6 +149,5 @@ const MiniCard = styled("div", {
 
     borderRadius: "var(--borderRadius-lg)",
     background: "var(--md-sys-color-secondary-container)",
-    transform: "translateZ(0)", //Tells WebKit browsers to render on GPU
   },
 });

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
@@ -19,17 +19,17 @@ import { VoiceCallCardActions } from "./VoiceCallCardActions";
 import { VoiceCallCardStatus } from "./VoiceCallCardStatus";
 
 export function VoiceCallCardPiP() {
-  const tracks = useTracks(
+  const audTracks = useTracks(
     [{ source: Track.Source.Microphone, withPlaceholder: true }],
     { onlySubscribed: false },
   );
 
   return (
     <MiniCard>
-      <Row>
-        <TrackLoop tracks={tracks}>{() => <ConnectedUser />}</TrackLoop>
+      <VoiceCallCardStatus pip />
+      <Row align justify grow wrap>
+        <TrackLoop tracks={audTracks}>{() => <ConnectedUser />}</TrackLoop>
       </Row>
-      <VoiceCallCardStatus />
       <VoiceCallCardActions size="xs" />
     </MiniCard>
   );
@@ -61,6 +61,7 @@ const UserIcon = styled("div", {
     display: "grid",
     width: "24px",
     height: "24px",
+    color: "#fffb",
 
     "& *": {
       gridArea: "1/1",

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
@@ -1,16 +1,20 @@
 import { Show } from "solid-js";
 import {
   TrackLoop,
+  TrackReference,
   useEnsureParticipant,
   useIsMuted,
   useIsSpeaking,
+  useTrackRefContext,
   useTracks,
+  VideoTrack,
 } from "solid-livekit-components";
 
 import { Track } from "livekit-client";
 import { styled } from "styled-system/jsx";
 
 import { useUser } from "@revolt/markdown/users";
+import { useVoice } from "@revolt/rtc";
 import { Avatar } from "@revolt/ui/components/design";
 import { Row } from "@revolt/ui/components/layout";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
@@ -19,17 +23,33 @@ import { VoiceCallCardActions } from "./VoiceCallCardActions";
 import { VoiceCallCardStatus } from "./VoiceCallCardStatus";
 
 export function VoiceCallCardPiP() {
+  const voice = useVoice();
   const audTracks = useTracks(
     [{ source: Track.Source.Microphone, withPlaceholder: true }],
     { onlySubscribed: false },
   );
 
+  const hasFocusVideo = () => {
+    const track = voice.focusTrack();
+    if (!track) return false;
+
+    return (
+      track.source === Track.Source.ScreenShare ||
+      !useIsMuted({
+        participant: track.participant,
+        source: Track.Source.Camera,
+      })()
+    );
+  };
+
   return (
     <MiniCard>
       <VoiceCallCardStatus pip />
-      <Row align justify grow wrap>
-        <TrackLoop tracks={audTracks}>{() => <ConnectedUser />}</TrackLoop>
-      </Row>
+      <Show when={!hasFocusVideo()} fallback={<MiniVideoTile />}>
+        <Row align justify grow wrap>
+          <TrackLoop tracks={audTracks}>{() => <ConnectedUser />}</TrackLoop>
+        </Row>
+      </Show>
       <VoiceCallCardActions size="xs" />
     </MiniCard>
   );
@@ -53,6 +73,37 @@ function ConnectedUser() {
         <Symbol>mic_off</Symbol>
       </Show>
     </UserIcon>
+  );
+}
+
+function MiniVideoTile() {
+  const voice = useVoice();
+
+  return (
+    <TrackLoop tracks={() => [voice.focusTrack()!]}>
+      {() => <MiniVideo />}
+    </TrackLoop>
+  );
+}
+
+function MiniVideo() {
+  const track = useTrackRefContext();
+
+  return (
+    <VideoTrack
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        "border-radius": "inherit",
+        "object-fit": "cover",
+        overflow: "hidden",
+      }}
+      trackRef={track as TrackReference}
+      manageSubscription={true}
+    />
   );
 }
 
@@ -98,5 +149,6 @@ const MiniCard = styled("div", {
 
     borderRadius: "var(--borderRadius-lg)",
     background: "var(--md-sys-color-secondary-container)",
+    transform: "translateZ(0)", //Tells WebKit browsers to render on GPU
   },
 });

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
@@ -68,9 +68,14 @@ function ConnectedUser() {
 
   return (
     <UserIcon speaking={isSpeaking()}>
-      <Avatar size={24} src={user().avatar} fallback={user().username} />
+      <Avatar
+        size={24}
+        src={user().avatar}
+        fallback={user().username}
+        shape="square"
+      />
       <Show when={isMuted()}>
-        <Symbol>mic_off</Symbol>
+        <Symbol background="rgba(0,0,0,.5)">mic_off</Symbol>
       </Show>
     </UserIcon>
   );
@@ -113,6 +118,8 @@ const UserIcon = styled("div", {
     width: "24px",
     height: "24px",
     color: "#fffb",
+    overflow: "hidden",
+    borderRadius: "var(--borderRadius-circle)",
 
     "& *": {
       gridArea: "1/1",

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardStatus.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardStatus.tsx
@@ -4,7 +4,7 @@ import { styled } from "styled-system/jsx";
 import { useVoice } from "@revolt/rtc";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
-export function VoiceCallCardStatus() {
+export function VoiceCallCardStatus(props: { pip?: boolean }) {
   const voice = useVoice();
 
   const symbol = () => {
@@ -38,7 +38,7 @@ export function VoiceCallCardStatus() {
   };
 
   return (
-    <Status status={voice.state()}>
+    <Status status={voice.state()} pip={props.pip}>
       <Symbol>{symbol()}</Symbol>{" "}
       <FadeOut fade={voice.state() === "CONNECTED"}>{text()}</FadeOut>
     </Status>
@@ -92,6 +92,13 @@ const Status = styled("div", {
       },
       RECONNECTING: {
         color: "var(--md-sys-color-outline)",
+      },
+    },
+    pip: {
+      true: {
+        position: "absolute",
+        left: "var(--gap-md)",
+        top: "var(--gap-md)",
       },
     },
   },

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardStatus.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardStatus.tsx
@@ -68,6 +68,7 @@ const Status = styled("div", {
 
     display: "flex",
     justifyContent: "center",
+    zIndex: 1,
 
     _hover: {
       "& div": {


### PR DESCRIPTION
- Added missing tooltips for all the action buttons
- Massive performance improvement for dragging & dropping the PIP window around
- Compatibility with touchscreen dragging as well as mobile layout in #835
- Mini video preview when focused view from #1090 is active
- Dim background behind muted icons to ensure they are visible on both dark and light avatars

Without focused video: <img src="https://github.com/user-attachments/assets/a64ca29c-ad34-4bc0-9d88-2b75ecad1e65" />

With focused video: <img src="https://github.com/user-attachments/assets/38cc0359-9cfb-418b-9ee4-94409ac6a129" />

Dragging (no change to animations)

<https://github.com/user-attachments/assets/7ccd5328-7451-41d0-9d34-6376107b615f>

Slightly tweaked drop animation, at suggestion of @Dadadah, before vs after

<https://github.com/user-attachments/assets/e8187315-940f-4bbf-b53f-487cc92bcf5b>

- `main` <!-- branch-stack -->
  - \#1102 :point\_left:
