### PR TITLE
fix: Navigation keybinds

### DIFF
--- a/packages/client/components/app/interface/settings/UserSettings.tsx
+++ b/packages/client/components/app/interface/settings/UserSettings.tsx
@@ -35,6 +35,7 @@ import { Sessions } from "./user/Sessions";
 import { AccountCard } from "./user/_AccountCard";
 import { AppearanceMenu } from "./user/appearance";
 import { MyBots, ViewBot } from "./user/bots";
+import { KeybindSettings } from "./user/keybinds/KeybindSettings";
 import { EditProfile } from "./user/profile";
 import { EditSubscription } from "./user/subscriptions";
 import { VoiceSettings } from "./user/voice/VoiceSettings";
@@ -93,6 +94,8 @@ const Config: SettingsConfiguration<{ server: Server }> = {
         return <Native />;
       case "voice":
         return <VoiceSettings />;
+      case "keybinds":
+        return <KeybindSettings />;
       default:
         return null;
     }
@@ -228,11 +231,11 @@ const Config: SettingsConfiguration<{ server: Server }> = {
             //   icon: <MdNotifications {...iconSize(20)} />,
             //   title: t("app.settings.pages.notifications.title"),
             // },
-            // {
-            //   id: "keybinds",
-            //   icon: <MdKeybinds {...iconSize(20)} />,
-            //   title: t("app.settings.pages.keybinds.title"),
-            // },
+            {
+              id: "keybinds",
+              icon: <Symbol size={20}>keyboard</Symbol>,
+              title: <Trans>Keybinds</Trans>,
+            },
             {
               id: "language",
               icon: <MdLanguage {...iconSize(20)} />,

--- a/packages/client/components/app/interface/settings/UserSettings.tsx
+++ b/packages/client/components/app/interface/settings/UserSettings.tsx
@@ -35,7 +35,7 @@ import { Sessions } from "./user/Sessions";
 import { AccountCard } from "./user/_AccountCard";
 import { AppearanceMenu } from "./user/appearance";
 import { MyBots, ViewBot } from "./user/bots";
-import { KeybindSettings } from "./user/keybinds/KeybindSettings";
+import { KeybindSettings } from "./user/keybinds";
 import { EditProfile } from "./user/profile";
 import { EditSubscription } from "./user/subscriptions";
 import { VoiceSettings } from "./user/voice/VoiceSettings";

--- a/packages/client/components/app/interface/settings/user/keybinds/KeybindSettings.tsx
+++ b/packages/client/components/app/interface/settings/user/keybinds/KeybindSettings.tsx
@@ -1,0 +1,33 @@
+import { Trans } from "@lingui-solid/solid/macro";
+import { Column } from "@revolt/ui";
+import { Show } from "solid-js";
+import { css } from "styled-system/css/css";
+//import { KeybindVoiceToggle } from "./KeybindVoiceToggle";
+import { NavigationKeybinds } from "./Navigation";
+
+export function KeybindSettings() {
+  return (
+    <Column gap="lg">
+      <Show when={!window.native}>
+        <small class={css({ opacity: 0.6 })}>
+          <Trans>
+            Keyboard shortcuts work in the browser, but only while Stoat is
+            active and focused.
+            {/*             <br />
+            To use them when Stoat is in the background and customise them,
+            <a
+              class={css({ color: "var(--md-sys-color-primary)" })}
+              href="https://stoat.chat/download"
+            >
+              {" "}
+              Download{" "}
+            </a>
+            Stoat for desktop. */}
+          </Trans>
+        </small>
+      </Show>
+      {/* <KeybindVoiceToggle /> */}
+      <NavigationKeybinds />
+    </Column>
+  );
+}

--- a/packages/client/components/app/interface/settings/user/keybinds/Navigation.tsx
+++ b/packages/client/components/app/interface/settings/user/keybinds/Navigation.tsx
@@ -1,0 +1,79 @@
+import { Trans } from "@lingui-solid/solid/macro";
+import { CategoryButton, Column, Text } from "@revolt/ui";
+import { Symbol } from "@revolt/ui/components/utils/Symbol";
+import { SequencePills } from "./shared";
+
+import { KeybindAction } from "@revolt/keybinds";
+import { getSequences } from "@revolt/keybinds/keybindSequences";
+
+export function NavigationKeybinds() {
+  return (
+    <Column gap="lg">
+      <Text class="title" size="small">
+        <Trans>Navigation Keybinds </Trans>
+      </Text>
+      <CategoryButton.Group>
+        <CategoryButton
+          icon={<Symbol>keyboard_arrow_up</Symbol>}
+          action={
+            <SequencePills
+              seq={getSequences(KeybindAction.NAVIGATION_CHANNEL_UP)}
+            />
+          }
+          description={
+            <Trans>
+              Navigate to the channel above the currently selected one.
+            </Trans>
+          }
+        >
+          <Trans>Channel Up</Trans>
+        </CategoryButton>
+        <CategoryButton
+          icon={<Symbol>keyboard_arrow_down</Symbol>}
+          action={
+            <SequencePills
+              seq={getSequences(KeybindAction.NAVIGATION_CHANNEL_DOWN)}
+            />
+          }
+          description={
+            <Trans>
+              Navigate to the channel below the currently selected one.
+            </Trans>
+          }
+        >
+          <Trans>Channel Down</Trans>
+        </CategoryButton>
+        <CategoryButton
+          icon={<Symbol>arrow_upward</Symbol>}
+          action={
+            <SequencePills
+              seq={getSequences(KeybindAction.NAVIGATION_SERVER_UP)}
+            />
+          }
+          description={
+            <Trans>
+              Navigate to the server above the currently selected one.
+            </Trans>
+          }
+        >
+          <Trans>Server Up</Trans>
+        </CategoryButton>
+        <CategoryButton
+          icon={<Symbol>arrow_downward</Symbol>}
+          action={
+            <SequencePills
+              seq={getSequences(KeybindAction.NAVIGATION_SERVER_DOWN)}
+            />
+          }
+          description={
+            <Trans>
+              Navigate to the server below the currently selected one.
+            </Trans>
+          }
+        >
+          <Trans>Server Down</Trans>
+        </CategoryButton>
+      </CategoryButton.Group>
+    </Column>
+  );
+}

--- a/packages/client/components/app/interface/settings/user/keybinds/index.ts
+++ b/packages/client/components/app/interface/settings/user/keybinds/index.ts
@@ -1,0 +1,3 @@
+export { KeybindSettings } from "./KeybindSettings";
+export { NavigationKeybinds } from "./Navigation";
+export { SequencePills, formatKey } from "./shared";

--- a/packages/client/components/app/interface/settings/user/keybinds/shared.tsx
+++ b/packages/client/components/app/interface/settings/user/keybinds/shared.tsx
@@ -1,0 +1,59 @@
+import { For, Show } from "solid-js";
+import { css } from "styled-system/css";
+
+export function formatKey(key: string | RegExp) {
+  if (key instanceof RegExp) return "Any";
+
+  const map: Record<string, string> = {
+    Control: "Ctrl",
+    Alt: "Alt",
+    Meta: "Meta",
+    Shift: "Shift",
+    Escape: "Esc",
+    ArrowUp: "↑",
+    ArrowDown: "↓",
+    ArrowLeft: "←",
+    ArrowRight: "→",
+    " ": "Space",
+  };
+
+  if (map[key]) return map[key];
+  return key.length === 1 ? key.toUpperCase() : key;
+}
+
+export function SequencePills(props: { seq?: (string | RegExp)[] }) {
+  return (
+    <Show
+      when={props.seq && props.seq.length > 0}
+      fallback={<div class={emptyStateClass}>-</div>}
+    >
+      <div class={pillContainerClass}>
+        <For each={props.seq}>
+          {(k) => <div class={keyPillClass}>{formatKey(k)}</div>}
+        </For>
+      </div>
+    </Show>
+  );
+}
+
+const pillContainerClass = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+});
+
+const keyPillClass = css({
+  padding: "4px 8px",
+  borderRadius: "8px",
+  border: "1px solid var(--md-sys-color-outline)",
+  fontSize: "0.9em",
+  color: "var(--md-sys-color-on-surface)",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: "32px",
+});
+
+const emptyStateClass = css({
+  opacity: 0.6,
+});

--- a/packages/client/components/app/interface/settings/user/keybinds/shared.tsx
+++ b/packages/client/components/app/interface/settings/user/keybinds/shared.tsx
@@ -1,5 +1,5 @@
 import { For, Show } from "solid-js";
-import { css } from "styled-system/css";
+import { styled } from "styled-system/jsx";
 
 export function formatKey(key: string | RegExp) {
   if (key instanceof RegExp) return "Any";
@@ -25,35 +25,41 @@ export function SequencePills(props: { seq?: (string | RegExp)[] }) {
   return (
     <Show
       when={props.seq && props.seq.length > 0}
-      fallback={<div class={emptyStateClass}>-</div>}
+      fallback={<EmptyStateClass>-</EmptyStateClass>}
     >
-      <div class={pillContainerClass}>
+      <PillContainerClass>
         <For each={props.seq}>
-          {(k) => <div class={keyPillClass}>{formatKey(k)}</div>}
+          {(k) => <KeyPillClass>{formatKey(k)}</KeyPillClass>}
         </For>
-      </div>
+      </PillContainerClass>
     </Show>
   );
 }
 
-const pillContainerClass = css({
-  display: "flex",
-  alignItems: "center",
-  gap: "4px",
+const PillContainerClass = styled("div", {
+  base: {
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+  },
 });
 
-const keyPillClass = css({
-  padding: "4px 8px",
-  borderRadius: "8px",
-  border: "1px solid var(--md-sys-color-outline)",
-  fontSize: "0.9em",
-  color: "var(--md-sys-color-on-surface)",
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  minWidth: "32px",
+const KeyPillClass = styled("div", {
+  base: {
+    padding: "4px 8px",
+    borderRadius: "8px",
+    border: "1px solid var(--md-sys-color-outline)",
+    fontSize: "0.9em",
+    color: "var(--md-sys-color-on-surface)",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: "32px",
+  },
 });
 
-const emptyStateClass = css({
-  opacity: 0.6,
+const EmptyStateClass = styled("div", {
+  base: {
+    opacity: 0.6,
+  },
 });

--- a/packages/client/components/keybinds/keybindHandler.tsx
+++ b/packages/client/components/keybinds/keybindHandler.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   createEffect,
   onCleanup,
+  untrack,
   useContext,
 } from "solid-js";
 
@@ -147,7 +148,7 @@ export function KeybindContext(props: { children: JSXElement }) {
           createEffect(() => {
             const _ = [...activeKeys]; // track dependency
             if (isFired(keybind)) {
-              callback();
+              untrack(callback);
             }
           });
         },

--- a/packages/client/components/keybinds/keybindSequences.ts
+++ b/packages/client/components/keybinds/keybindSequences.ts
@@ -4,7 +4,7 @@ import { KeybindAction } from "./keybindActions";
  * Sequences are a set of keys that must be pressed at the same time
  */
 export const DEFAULT_SEQUENCES: Record<KeybindAction, (string | RegExp)[]> = {
-  [KeybindAction.NAVIGATION_CHANNEL_UP]: ["Alt", "ArrowDown"],
+  [KeybindAction.NAVIGATION_CHANNEL_UP]: ["Alt", "ArrowUp"],
   [KeybindAction.NAVIGATION_CHANNEL_DOWN]: ["Alt", "ArrowDown"],
   [KeybindAction.NAVIGATION_SERVER_UP]: ["Control", "Alt", "ArrowUp"],
   [KeybindAction.NAVIGATION_SERVER_DOWN]: ["Control", "Alt", "ArrowDown"],
@@ -16,6 +16,8 @@ export const DEFAULT_SEQUENCES: Record<KeybindAction, (string | RegExp)[]> = {
   [KeybindAction.CLOSE_MODAL]: ["Escape"],
   [KeybindAction.CLOSE_FLOATING]: ["Escape"],
   [KeybindAction.CLOSE_SIDEBAR]: ["Escape"],
+  [KeybindAction.VOICE_TOGGLE_MUTE]: ["Alt", "d"],
+  [KeybindAction.VOICE_TOGGLE_DEAFEN]: ["Alt", "m"],
 };
 
 /**
@@ -44,4 +46,13 @@ export const DEFAULT_MAC_SEQUENCES: Record<KeybindAction, (string | RegExp)[]> =
     [KeybindAction.CLOSE_MODAL]: ["Escape"],
     [KeybindAction.CLOSE_FLOATING]: ["Escape"],
     [KeybindAction.CLOSE_SIDEBAR]: ["Escape"],
+    [KeybindAction.VOICE_TOGGLE_MUTE]: ["Alt", "m"],
+    [KeybindAction.VOICE_TOGGLE_DEAFEN]: ["Alt", "d"],
   };
+
+export function getSequences(action: KeybindAction) {
+  if (navigator.platform.startsWith("Mac")) {
+    return DEFAULT_MAC_SEQUENCES[action];
+  }
+  return DEFAULT_SEQUENCES[action];
+}

--- a/packages/client/components/keybinds/keybindSequences.ts
+++ b/packages/client/components/keybinds/keybindSequences.ts
@@ -16,8 +16,6 @@ export const DEFAULT_SEQUENCES: Record<KeybindAction, (string | RegExp)[]> = {
   [KeybindAction.CLOSE_MODAL]: ["Escape"],
   [KeybindAction.CLOSE_FLOATING]: ["Escape"],
   [KeybindAction.CLOSE_SIDEBAR]: ["Escape"],
-  [KeybindAction.VOICE_TOGGLE_MUTE]: ["Alt", "d"],
-  [KeybindAction.VOICE_TOGGLE_DEAFEN]: ["Alt", "m"],
 };
 
 /**
@@ -46,8 +44,6 @@ export const DEFAULT_MAC_SEQUENCES: Record<KeybindAction, (string | RegExp)[]> =
     [KeybindAction.CLOSE_MODAL]: ["Escape"],
     [KeybindAction.CLOSE_FLOATING]: ["Escape"],
     [KeybindAction.CLOSE_SIDEBAR]: ["Escape"],
-    [KeybindAction.VOICE_TOGGLE_MUTE]: ["Alt", "m"],
-    [KeybindAction.VOICE_TOGGLE_DEAFEN]: ["Alt", "d"],
   };
 
 export function getSequences(action: KeybindAction) {

--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -132,13 +132,13 @@ export const ServerSidebar = (props: Props) => {
     }
   };
 
-  // todo: I think these cause the infinite hang bug:
+  createKeybind(KeybindAction.NAVIGATION_CHANNEL_UP, () =>
+    _navigateChannel(-1),
+  );
 
-  // createKeybind(KeybindAction.NAVIGATION_CHANNEL_UP, () => navigateChannel(-1));
-
-  // createKeybind(KeybindAction.NAVIGATION_CHANNEL_DOWN, () =>
-  //   navigateChannel(1),
-  // );
+  createKeybind(KeybindAction.NAVIGATION_CHANNEL_DOWN, () =>
+    _navigateChannel(1),
+  );
 
   createKeybind(KeybindAction.CHAT_MARK_SERVER_AS_READ, () => {
     if (props.server.unread) {


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes a long lasting issue with navigation keybinds and re-enable channel navigation, issue was caused by reactive values inside callback being tracked by `createEffect` and callback was being triggerd multiple times, by wrapping the callback in `untrack()` the `createEffect` tracks only the `activeKeys`

- Added keybind section inside of settings tab for Navigation buttons

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Testing keybinds to move around different servers and channels
```
  [KeybindAction.NAVIGATION_CHANNEL_UP]: ["Alt", "ArrowUp"],
  [KeybindAction.NAVIGATION_CHANNEL_DOWN]: ["Alt", "ArrowDown"],
  [KeybindAction.NAVIGATION_SERVER_UP]: ["Control", "Alt", "ArrowUp"],
  [KeybindAction.NAVIGATION_SERVER_DOWN]: ["Control", "Alt", "ArrowDown"],
  ```


<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

https://github.com/user-attachments/assets/0a4e04c4-002d-4b71-96d5-57905ba42bd9

<img width="1059" height="730" alt="image" src="https://github.com/user-attachments/assets/cbd0b1a4-a407-44b6-83e1-1cb02d4bf4fd" />


</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No LLM usage involved in creating this PR
