### PR TITLE
fix: translate hide/show others correctly

### DIFF
--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActiveRoom.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActiveRoom.tsx
@@ -1,8 +1,7 @@
+import { useLingui } from "@lingui-solid/solid/macro";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 import { createEffect, For, onMount, Show } from "solid-js";
 import { TrackLoop } from "solid-livekit-components";
-
-import { t } from "@lingui/core/macro";
-import { createResizeObserver } from "@solid-primitives/resize-observer";
 import { styled } from "styled-system/jsx";
 
 import { InRoom, useVoice } from "@revolt/rtc";
@@ -57,6 +56,7 @@ const TILE_MIN_WIDTH = "250px",
  */
 function Participants() {
   const voice = useVoice();
+  const { t } = useLingui();
 
   // Modify this value to get test tracks
   const testTrackCount = 0;


### PR DESCRIPTION
Fix a bug that makes the Show/Hide others tooltip not be translated.
<!-- Describe your changes -->

## How was this PR tested?
Loaded a local version of the repo and checked that tooltip was translated.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

This commit was made without the use of generative AI.
