### PR TITLE
fix(profile): avatar toggle closes status menu properly

### DIFF
--- a/packages/client/src/interface/navigation/servers/UserMenu.tsx
+++ b/packages/client/src/interface/navigation/servers/UserMenu.tsx
@@ -73,8 +73,16 @@ export function UserMenu(props: Props) {
     setShow(false);
   }
 
-  onMount(() => document.addEventListener("mousedown", close));
-  onCleanup(() => document.removeEventListener("mousedown", close));
+  function onMouseDown(event: MouseEvent) {
+    const target = event.target as Node;
+    // Ignore clicks on the anchor (avatar) — the click handler on the anchor
+    // will toggle the menu. Ignore clicks inside the menu itself too.
+    if (props.anchor()?.contains(target) || ref()?.contains(target)) return;
+    close();
+  }
+
+  onMount(() => document.addEventListener("mousedown", onMouseDown));
+  onCleanup(() => document.removeEventListener("mousedown", onMouseDown));
 
   createEffect(
     on(

--- a/packages/client/src/interface/navigation/servers/UserMenu.tsx
+++ b/packages/client/src/interface/navigation/servers/UserMenu.tsx
@@ -77,7 +77,7 @@ export function UserMenu(props: Props) {
     const target = event.target as Node;
     // Ignore clicks on the anchor (avatar) — the click handler on the anchor
     // will toggle the menu. Ignore clicks inside the menu itself too.
-    if (props.anchor()?.contains(target) || ref()?.contains(target)) return;
+    if (props.anchor()?.contains(target)) return;
     close();
   }
 


### PR DESCRIPTION
Fixed issue #1113 where clicking the user profile for the first time opens the UserMenu or UserStatusMenu a second time when you click on it to close it, it did not close the profile status menu or Just flickers when your try to close it, have to click elsewhere on the screen to close it.

## How was this PR tested?
- [x] I Clicking avatar toggles menu open/close correctly
- [x] I Clicking inside menu does not close it
- [x] I Clicking outside closes the menu
- [x] I No flickering on repeated clicks
 
## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No LLM usage involved in creating this PR