### PR TITLE
feat: add message deletion options to ban member dialog

### DIFF
--- a/packages/client/components/modal/modals/BanMember.tsx
+++ b/packages/client/components/modal/modals/BanMember.tsx
@@ -2,7 +2,7 @@ import { createFormControl, createFormGroup } from "solid-forms";
 
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
 
-import { Avatar, Button, Column, Dialog, DialogProps, FloatingSelect, Form2, MenuItem, Row, Text } from "@revolt/ui";
+import { Avatar, Column, Dialog, DialogProps, FloatingSelect, Form2, MenuItem, Text } from "@revolt/ui";
 
 import { useModals } from "..";
 import { Modals } from "../types";

--- a/packages/client/components/modal/modals/BanMember.tsx
+++ b/packages/client/components/modal/modals/BanMember.tsx
@@ -92,6 +92,12 @@ export function BanMemberModal(
             <MenuItem value="0">
               <Trans>Don't delete messages</Trans>
             </MenuItem>
+            <MenuItem value="3600">
+              <Trans>1 hour</Trans>
+            </MenuItem>
+            <MenuItem value="21600">
+              <Trans>6 hours</Trans>
+            </MenuItem>
             <MenuItem value="86400">
               <Trans>1 day</Trans>
             </MenuItem>

--- a/packages/client/components/modal/modals/BanMember.tsx
+++ b/packages/client/components/modal/modals/BanMember.tsx
@@ -27,14 +27,14 @@ export function BanMemberModal(
 
   const group = createFormGroup({
     reason: createFormControl(""),
-    delete_message_seconds: createFormControl("0"),
+    deleteMessageSeconds: createFormControl("0"),
   });
   async function onSubmit() {
     try {
       await props.member.ban({
         reason: group.controls.reason.value,
         delete_message_seconds: Number(
-          group.controls.delete_message_seconds.value,
+          group.controls.deleteMessageSeconds.value,
         ),
       });
 
@@ -80,11 +80,11 @@ export function BanMemberModal(
           />
           <FloatingSelect
             label={t`Delete Message History`}
-            value={group.controls.delete_message_seconds.value}
+            value={group.controls.deleteMessageSeconds.value}
             onChange={(
               e: Event & { currentTarget: HTMLElement; target: Element },
             ) =>
-              group.controls.delete_message_seconds.setValue(
+              group.controls.deleteMessageSeconds.setValue(
                 e.currentTarget.getAttribute("value") || "0",
               )
             }

--- a/packages/client/components/modal/modals/BanMember.tsx
+++ b/packages/client/components/modal/modals/BanMember.tsx
@@ -2,7 +2,16 @@ import { createFormControl, createFormGroup } from "solid-forms";
 
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
 
-import { Avatar, Column, Dialog, DialogProps, FloatingSelect, Form2, MenuItem, Text } from "@revolt/ui";
+import {
+  Avatar,
+  Column,
+  Dialog,
+  DialogProps,
+  FloatingSelect,
+  Form2,
+  MenuItem,
+  Text,
+} from "@revolt/ui";
 
 import { useModals } from "..";
 import { Modals } from "../types";
@@ -18,13 +27,15 @@ export function BanMemberModal(
 
   const group = createFormGroup({
     reason: createFormControl(""),
-    delete_message_seconds: createFormControl("0")
+    delete_message_seconds: createFormControl("0"),
   });
   async function onSubmit() {
     try {
       await props.member.ban({
         reason: group.controls.reason.value,
-        delete_message_seconds: Number(group.controls.delete_message_seconds.value),
+        delete_message_seconds: Number(
+          group.controls.delete_message_seconds.value,
+        ),
       });
 
       props.onClose();

--- a/packages/client/components/modal/modals/BanMember.tsx
+++ b/packages/client/components/modal/modals/BanMember.tsx
@@ -2,7 +2,7 @@ import { createFormControl, createFormGroup } from "solid-forms";
 
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
 
-import { Avatar, Column, Dialog, DialogProps, Form2, Text } from "@revolt/ui";
+import { Avatar, Button, Column, Dialog, DialogProps, FloatingSelect, Form2, MenuItem, Row, Text } from "@revolt/ui";
 
 import { useModals } from "..";
 import { Modals } from "../types";
@@ -18,12 +18,13 @@ export function BanMemberModal(
 
   const group = createFormGroup({
     reason: createFormControl(""),
+    delete_message_seconds: createFormControl("0")
   });
-
   async function onSubmit() {
     try {
       await props.member.ban({
         reason: group.controls.reason.value,
+        delete_message_seconds: Number(group.controls.delete_message_seconds.value),
       });
 
       props.onClose();
@@ -66,6 +67,30 @@ export function BanMemberModal(
             label={t`Reason`}
             placeholder={t`User broke a certain rule…`}
           />
+          <FloatingSelect
+            label={t`Delete Message History`}
+            value={group.controls.delete_message_seconds.value}
+            onChange={(
+              e: Event & { currentTarget: HTMLElement; target: Element },
+            ) =>
+              group.controls.delete_message_seconds.setValue(
+                e.currentTarget.getAttribute("value") || "0",
+              )
+            }
+          >
+            <MenuItem value="0">
+              <Trans>Don't delete messages</Trans>
+            </MenuItem>
+            <MenuItem value="86400">
+              <Trans>1 day</Trans>
+            </MenuItem>
+            <MenuItem value="259200">
+              <Trans>3 days</Trans>
+            </MenuItem>
+            <MenuItem value="604800">
+              <Trans>7 days</Trans>
+            </MenuItem>
+          </FloatingSelect>
         </Column>
       </form>
     </Dialog>


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #1127

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Clicked on the ban user action
- [x] Selected different options to ban the member with or without message deletion

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->
<img width="366" height="654" alt="resim" src="https://github.com/user-attachments/assets/f8142eaa-1f8f-4250-88ba-989b7a208dc6" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No LLM was involved in this PR