### PR TITLE
feat: Use default upload file size limit from configuration

### DIFF
--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -198,8 +198,13 @@ export function MessageComposition(props: Props) {
     const rejectedFiles: File[] = [];
     const validFiles: File[] = [];
 
+    const maxSize = client().configured()
+      ? (client().configuration?.features.limits.default.file_upload_size_limits
+          .attachments ?? CONFIGURATION.MAX_FILE_SIZE)
+      : CONFIGURATION.MAX_FILE_SIZE;
+
     for (const file of files) {
-      if (file.size > CONFIGURATION.MAX_FILE_SIZE) {
+      if (file.size > maxSize) {
         console.log("File too large:", file);
         rejectedFiles.push(file);
       } else {
@@ -208,7 +213,7 @@ export function MessageComposition(props: Props) {
     }
 
     if (rejectedFiles.length > 0) {
-      const maxSizeFormatted = humanFileSize(CONFIGURATION.MAX_FILE_SIZE);
+      const maxSizeFormatted = humanFileSize(maxSize);
 
       if (rejectedFiles.length === 1) {
         const file = rejectedFiles[0];


### PR DESCRIPTION
This PR changes the max file size to read from the server configuration. It will default to `CONFIGURATION.MAX_FILE_SIZE` if the configuration fails to load or is undefined for some reason.


Closes #844 
Closes stoatchat/self-hosted#189


## How was this PR tested?
Increased file upload limit to 100MB in my self-hosted instance. Tested upload of 36MB file on main (failed, as expected), tested upload of 36MB on dev (passed) and tested upload of 400MB (passed with disallow.)

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Generative AI was not used in the writing of this PR.
