### PR TITLE
feat: Add an error for messages being too long and a countdown

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/MessageBox.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/MessageBox.tsx
@@ -168,6 +168,49 @@ export const InlineIcon = styled("div", {
   },
 });
 
+const FloatingAction = styled("div", {
+  base: {
+    flexShrink: 0,
+    flexGrow: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "end",
+  },
+  variants: {
+    size: {
+      short: {
+        height: "1em",
+      },
+      normal: {
+        height: "1.5em",
+      },
+      tall: {
+        height: "2em",
+      },
+    },
+    error: {
+      true: {
+        color: "var(--md-sys-color-error)",
+      },
+    },
+  },
+});
+
+const ActionContainer = styled("div", {
+  base: {
+    flexShrink: 0,
+    display: "flex",
+    flexGrow: 1,
+  },
+  variants: {
+    column: {
+      true: {
+        flexFlow: "column",
+      },
+    },
+  },
+});
+
 /**
  * Message box
  */
@@ -228,3 +271,7 @@ export function MessageBox(props: Props) {
 }
 
 MessageBox.InlineIcon = InlineIcon;
+
+MessageBox.FloatingAction = FloatingAction;
+
+MessageBox.ActionContainer = ActionContainer;

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -68,12 +68,27 @@ export function MessageComposition(props: Props) {
     return state.draft.getDraft(props.channel.id);
   }
 
+  const messageLength = () => draft().content?.length ?? 0;
+
+  const maxMessageLength = () => {
+    const cl = client();
+    return cl.configured()
+      ? (cl.configuration?.features.limits.default.message_length ?? 2000)
+      : 2000;
+  };
+
+  const isAlmostTooLong = () => messageLength() > maxMessageLength() - 200;
+
   // Whether the send button should be active/clickable
   const canSend = createMemo(() => {
     const draftContent = draft()?.content ?? "";
     const draftFiles = draft()?.files ?? [];
 
-    return draftContent.trim().length > 0 || draftFiles.length > 0;
+    const tooLong = messageLength() > maxMessageLength();
+
+    return (
+      !tooLong && (draftContent.trim().length > 0 || draftFiles.length > 0)
+    );
   });
 
   // TEMP
@@ -339,27 +354,39 @@ export function MessageComposition(props: Props) {
           </Switch>
         }
         actionsEnd={
-          <CompositionMediaPicker
-            onMessage={sendMessage}
-            onTextReplacement={(text) => setNodeReplacement([text])}
-          >
-            {(triggerProps) => (
-              <>
-                <MessageBox.InlineIcon size="normal">
-                  <IconButton onPress={triggerProps.onClickGif}>
-                    <Symbol>gif</Symbol>
-                  </IconButton>
-                </MessageBox.InlineIcon>
-                <MessageBox.InlineIcon size="normal">
-                  <IconButton onPress={triggerProps.onClickEmoji}>
-                    <Symbol>emoticon</Symbol>
-                  </IconButton>
-                </MessageBox.InlineIcon>
+          <MessageBox.ActionContainer column>
+            <Show when={isAlmostTooLong()}>
+              <MessageBox.FloatingAction
+                size="normal"
+                error={messageLength() > maxMessageLength()}
+              >
+                {maxMessageLength() - messageLength()}
+              </MessageBox.FloatingAction>
+            </Show>
+            <MessageBox.ActionContainer>
+              <CompositionMediaPicker
+                onMessage={sendMessage}
+                onTextReplacement={(text) => setNodeReplacement([text])}
+              >
+                {(triggerProps) => (
+                  <>
+                    <MessageBox.InlineIcon size="normal">
+                      <IconButton onPress={triggerProps.onClickGif}>
+                        <Symbol>gif</Symbol>
+                      </IconButton>
+                    </MessageBox.InlineIcon>
+                    <MessageBox.InlineIcon size="normal">
+                      <IconButton onPress={triggerProps.onClickEmoji}>
+                        <Symbol>emoticon</Symbol>
+                      </IconButton>
+                    </MessageBox.InlineIcon>
 
-                <div ref={triggerProps.ref} />
-              </>
-            )}
-          </CompositionMediaPicker>
+                    <div ref={triggerProps.ref} />
+                  </>
+                )}
+              </CompositionMediaPicker>
+            </MessageBox.ActionContainer>
+          </MessageBox.ActionContainer>
         }
         placeholder={
           props.channel.type === "SavedMessages"

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -79,6 +79,8 @@ export function MessageComposition(props: Props) {
 
   const isAlmostTooLong = () => messageLength() > maxMessageLength() - 200;
 
+  const wayTooLong = () => messageLength() > maxMessageLength() + 10000;
+
   // Whether the send button should be active/clickable
   const canSend = createMemo(() => {
     const draftContent = draft()?.content ?? "";
@@ -363,7 +365,9 @@ export function MessageComposition(props: Props) {
                 size="normal"
                 error={messageLength() > maxMessageLength()}
               >
-                {maxMessageLength() - messageLength()}
+                {wayTooLong()
+                  ? "Too Long"
+                  : maxMessageLength() - messageLength()}
               </MessageBox.FloatingAction>
             </Show>
             <MessageBox.ActionContainer>

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -175,6 +175,9 @@ export function MessageComposition(props: Props) {
    * @param useContent Content to send
    */
   async function sendMessage(useContent?: unknown) {
+    if (!canSend()) {
+      return;
+    }
     stopTyping();
     props.onMessageSend?.();
 

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -79,7 +79,7 @@ export function MessageComposition(props: Props) {
 
   const isAlmostTooLong = () => messageLength() > maxMessageLength() - 200;
 
-  const wayTooLong = () => messageLength() > maxMessageLength() + 10000;
+  const wayTooLong = () => messageLength() > maxMessageLength() + 9999;
 
   // Whether the send button should be active/clickable
   const canSend = createMemo(() => {


### PR DESCRIPTION
This PR adds a message length ticker that shows when you are 200 characters away from hitting the message limit. It shows red when you are over the limit. It will not allow you to send the message if you are over the limit. It respects the limits in the server side configuration.

Fixes #1125

## Tests
Tested with a 2000 character limit on my self-hosted instance.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

[Screencast from 2026-04-23 17-27-19.webm](https://github.com/user-attachments/assets/19996c0e-ba4c-4644-ba02-151bf3f17bb1)

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Generative AI was not used in the writing of this PR.
