### PR TITLE
fix: call cb on role deletion to redirect to roles list

### DIFF
--- a/packages/client/components/modal/modals/DeleteRole.tsx
+++ b/packages/client/components/modal/modals/DeleteRole.tsx
@@ -1,8 +1,6 @@
 import { Trans } from "@lingui-solid/solid/macro";
 import { useMutation } from "@tanstack/solid-query";
-
 import { Dialog, DialogProps } from "@revolt/ui";
-
 import { useModals } from "..";
 import { Modals } from "../types";
 
@@ -13,10 +11,10 @@ export function DeleteRoleModal(
   props: DialogProps & Modals & { type: "delete_role" },
 ) {
   const { showError } = useModals();
-
   const deleteRole = useMutation(() => ({
     mutationFn: () => props.role.delete(),
     onError: showError,
+    onSuccess: () => props.cb(),
   }));
 
   return (

--- a/packages/client/components/modal/modals/DeleteRole.tsx
+++ b/packages/client/components/modal/modals/DeleteRole.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui-solid/solid/macro";
+
 import { useMutation } from "@tanstack/solid-query";
 import { Dialog, DialogProps } from "@revolt/ui";
 import { useModals } from "..";

--- a/packages/client/components/modal/modals/DeleteRole.tsx
+++ b/packages/client/components/modal/modals/DeleteRole.tsx
@@ -1,7 +1,8 @@
 import { Trans } from "@lingui-solid/solid/macro";
-
 import { useMutation } from "@tanstack/solid-query";
+
 import { Dialog, DialogProps } from "@revolt/ui";
+
 import { useModals } from "..";
 import { Modals } from "../types";
 
@@ -9,9 +10,10 @@ import { Modals } from "../types";
  * Modal to delete a role
  */
 export function DeleteRoleModal(
-  props: DialogProps & Modals & { type: "delete_role" },
+  props: DialogProps & Modals & { type:
 ) {
   const { showError } = useModals();
+
   const deleteRole = useMutation(() => ({
     mutationFn: () => props.role.delete(),
     onError: showError,


### PR DESCRIPTION

The `DeleteRoleModal` was not calling `props.cb()` on successful deletion, 
so the navigation callback passed by `ServerRoleEditor` never fired, 
leaving the user on the deleted role's page.

Fixes #1137

**How was this PR tested?**
- [x] Test A - Created a role, deleted it, confirmed redirect to roles list