### PR TITLE
fix: show friendly errors

### DIFF
--- a/packages/client/components/auth/src/flows/FlowLogin.tsx
+++ b/packages/client/components/auth/src/flows/FlowLogin.tsx
@@ -37,6 +37,8 @@ export default function FlowLogin() {
     const email = data.get("email") as string;
     const password = data.get("password") as string;
 
+    if (!email || !password) return;
+
     await login(
       {
         email,

--- a/packages/client/components/auth/src/flows/Form.tsx
+++ b/packages/client/components/auth/src/flows/Form.tsx
@@ -1,10 +1,12 @@
 import HCaptcha, { HCaptchaFunctions } from "solid-hcaptcha";
-import { For, JSX, Show, createSignal } from "solid-js";
+import { createSignal, For, JSX, Show } from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
 
 import { useError } from "@revolt/i18n";
-import { Checkbox2, Column, Text, TextField } from "@revolt/ui";
+import { Checkbox, Column, iconSize, Text, TextField } from "@revolt/ui";
+
+import MdError from "@material-design-icons/svg/filled/error.svg?component-solid";
 
 /**
  * Available field types
@@ -93,9 +95,9 @@ export function Fields(props: FieldProps) {
         return (
           <label>
             {field.field === "log-out" ? (
-              <Checkbox2 name={field.field}>
+              <Checkbox name={field.field}>
                 {fieldConfiguration[field.field].name()}
-              </Checkbox2>
+              </Checkbox>
             ) : (
               <TextField
                 required
@@ -157,6 +159,7 @@ export function Form(props: Props) {
     try {
       await props.onSubmit(formData);
     } catch (err) {
+      console.error(err);
       setError(err);
     }
   }
@@ -166,9 +169,23 @@ export function Form(props: Props) {
       <Column gap="lg">
         {props.children}
         <Show when={error()}>
-          <Text class="label" size="small">
-            {err(error())}
-          </Text>
+          <span
+            style={{
+              color: "var(--md-sys-color-error)",
+              display: "flex",
+              "align-items": "center",
+              gap: "0.25em",
+            }}
+          >
+            <MdError
+              {...iconSize("1rem")}
+              fill="currentColor"
+              style={{ "flex-shrink": 0 }}
+            />
+            <Text class="label" size="small">
+              {err(error())}
+            </Text>
+          </span>
         </Show>
       </Column>
       <Show when={props.captcha}>

--- a/packages/client/components/auth/src/flows/Form.tsx
+++ b/packages/client/components/auth/src/flows/Form.tsx
@@ -5,8 +5,18 @@ import { useLingui } from "@lingui-solid/solid/macro";
 
 import { useError } from "@revolt/i18n";
 import { Checkbox, Column, iconSize, Text, TextField } from "@revolt/ui";
+import { styled } from "styled-system/jsx";
 
 import MdError from "@material-design-icons/svg/filled/error.svg?component-solid";
+
+const ErrorContainer = styled("span", {
+  base: {
+    color: "var(--md-sys-color-error)",
+    display: "flex",
+    alignItems: "center",
+    gap: "0.25em",
+  },
+});
 
 /**
  * Available field types
@@ -169,14 +179,7 @@ export function Form(props: Props) {
       <Column gap="lg">
         {props.children}
         <Show when={error()}>
-          <span
-            style={{
-              color: "var(--md-sys-color-error)",
-              display: "flex",
-              "align-items": "center",
-              gap: "0.25em",
-            }}
-          >
+          <ErrorContainer>
             <MdError
               {...iconSize("1rem")}
               fill="currentColor"
@@ -185,7 +188,7 @@ export function Form(props: Props) {
             <Text class="label" size="small">
               {err(error())}
             </Text>
-          </span>
+          </ErrorContainer>
         </Show>
       </Column>
       <Show when={props.captcha}>

--- a/packages/client/components/i18n/errors.ts
+++ b/packages/client/components/i18n/errors.ts
@@ -16,7 +16,9 @@ export function useError() {
     if (typeof error === "string") {
       try {
         error = JSON.parse(error);
-      } catch {}
+      } catch {
+        // Ignore JSON parse errors
+      }
     }
 
     // handle Revolt API errors

--- a/packages/client/components/i18n/errors.ts
+++ b/packages/client/components/i18n/errors.ts
@@ -10,6 +10,15 @@ export function useError() {
   return (error: unknown) => {
     // TODO: HTTP errors
 
+    // Attempt to parse the incoming error as JSON if it is a string,
+    // as some errors (e.g on login) are sent to this function as a string,
+    // which then causes the error message to be unlocalised and unhelpful.
+    if (typeof error === "string") {
+      try {
+        error = JSON.parse(error);
+      } catch {}
+    }
+
     // handle Revolt API errors
     if (
       (error as { type?: never } | undefined)?.type &&


### PR DESCRIPTION
I noticed when using stoat for the first time today, that some errors looked "unfriendly" to the user. For example, on the login page: 

<img width="376" height="110" alt="image" src="https://github.com/user-attachments/assets/a8c09de0-0c4a-43ee-85d2-dca561301624" />

This turned out to be three separate issues:

1. Errors weren't being parsed correctly. The API throws the error response as a raw JSON string (e.g. {"type":"InvalidCredentials"}), but `useError` expected a parsed object. It was falling 
  through to the catch-all Something went wrong! message instead of matching the friendly strings already defined.                                                                              
  2. The error UI lacked visual treatment. The error text had no colour or icon to draw attention to it.                                                                                       
 3. The login form would submit even if either field was empty.                 
 
This PR fixes both. Errors are now parsed before matching, and the error display shows the message in red with an inline error icon:  

<img width="423" height="158" alt="image" src="https://github.com/user-attachments/assets/73681429-1185-4af3-9268-9454dafceb3c" />

## How was this PR tested?
The following cases have been tested:

- [x] Trigging a translated string error
- [x] Trigging a fall through error

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
It was used to explore the project only and give me a general overview of how the code was strucutured. No code was generated by an LLM for this PR.

Added by maintainers:
Fixes #1012 
Fixes #875
