### PR TITLE
fix: use HTTPS URL for assets submodule so public CI can clone branding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/stoatchat/javascript-client-sdk
 [submodule "packages/client/assets"]
 	path = packages/client/assets
-	url = ssh://git@github.com/stoatchat/assets
+	url = https://github.com/stoatchat/assets
 	update = none
 [submodule "packages/solid-livekit-components"]
 	path = packages/solid-livekit-components


### PR DESCRIPTION
The `packages/client/assets` submodule currently uses an SSH URL (`ssh://git@github.com/stoatchat/assets`). Public CI (the `docker-build.yml` workflow) runs `actions/checkout` with `submodules: recursive` but has no SSH credentials, so the submodule comes back empty. The build then falls back to `scripts/assets_fallback/web/wordmark.svg`, which is the old Revolt wordmark — causing self-hosted instances built from the public Docker image (`ghcr.io/stoatchat/for-web`) to display "Revolt" branding instead of Stoat.

The `stoatchat/assets` repository is already public and accessible over HTTPS with no credentials. This change switches the submodule URL to HTTPS, which is all that is needed for public CI to clone it correctly.

Note: the private `production-release.yml` workflow already works around this by explicitly rewriting the URL to HTTPS before cloning — this PR makes the public build consistent with that.