### PR TITLE
fix: @mentions in DMs show users not in the DM

### DIFF
--- a/packages/client/components/ui/components/utils/autoComplete.ts
+++ b/packages/client/components/ui/components/utils/autoComplete.ts
@@ -24,7 +24,7 @@ function generateSearchSpaceFrom(
     if (object.channel) return generateSearchSpaceFrom(object.channel, client);
   } else if (object instanceof Channel) {
     if (object.server) return generateSearchSpaceFrom(object.server, client);
-    if (object.type === "Group") {
+    if (object.type === "Group" || object.type === "DirectMessage") {
       return {
         users: object.recipients,
       };


### PR DESCRIPTION
Fixes #1147

<!-- Describe your changes -->
When composing a message in a DM, the @mention autocomplete incorrectly listed users who were not part of the conversation. This change filters the mention suggestions so only relevant users appear in DM contexts.

Fixes # (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Opened a DM with user A, typed `@` in the message box, and verified the suggestion list only includes users in that DM (and/or expected mention targets)
- [x] Compared behavior in a server text channel to ensure mentions there still behave as before.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->
<img width="1996" height="187" alt="Screenshot 2026-05-04 040657" src="https://github.com/user-attachments/assets/ae023061-f7a0-4270-bb03-a72c801c89f7" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No generative AI tools were used for this PR.
...
