### PR TITLE
fix: make remove all reactions action require ManageMessages permission

### DIFF
--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -226,7 +226,12 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
             </For>
           </ContextMenuSubMenu>
         </Show>
-        <Show when={props.message!.reactions.size}>
+        <Show
+          when={
+            props.message!.reactions.size &&
+            props.message!.channel?.havePermission("ManageMessages")
+          }
+        >
           <ContextMenuButton
             symbol={MdSentimentContent}
             onClick={() => props.message!.clearReactions()}


### PR DESCRIPTION
Adds ManageMessage permission to the Remove All Reactions context menu item.

Fixes #1006 

## How was this PR tested?
Attempted to remove all reactions on message without permissions before and after change. Remove all reactions context action was not present after change when lacking permission.
Attempted to remove all reactions on message with permissions, worked before and after.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Generative AI was not used in the writing of this PR.