### PR TITLE
refactor: Replace TextField.Select with FloatingSelect

### DIFF
--- a/packages/client/components/app/interface/settings/server/Overview.tsx
+++ b/packages/client/components/app/interface/settings/server/Overview.tsx
@@ -254,10 +254,8 @@ export default function ServerOverview(props: ServerSettingsProps) {
             <Trans>System message channels</Trans>
           </Text>
           <Column>
-            <Text class="label">
-              <Trans>User Joined</Trans>
-            </Text>
-            <Form2.TextField.Select
+            <Form2.Select
+              label={t`User Joined`}
               control={editGroup.controls.sys_user_joined}
             >
               <MenuItem value="none">
@@ -268,13 +266,13 @@ export default function ServerOverview(props: ServerSettingsProps) {
                   <MenuItem value={element.value}>{element.item.name}</MenuItem>
                 )}
               </For>
-            </Form2.TextField.Select>
+            </Form2.Select>
           </Column>
           <Column>
-            <Text class="label">
-              <Trans>User Left</Trans>
-            </Text>
-            <Form2.TextField.Select control={editGroup.controls.sys_user_left}>
+            <Form2.Select
+              label={t`User Left`}
+              control={editGroup.controls.sys_user_left}
+            >
               <MenuItem value="none">
                 <Trans>Disabled</Trans>
               </MenuItem>
@@ -283,13 +281,11 @@ export default function ServerOverview(props: ServerSettingsProps) {
                   <MenuItem value={element.value}>{element.item.name}</MenuItem>
                 )}
               </For>
-            </Form2.TextField.Select>
+            </Form2.Select>
           </Column>
           <Column>
-            <Text class="label">
-              <Trans>User Kicked</Trans>
-            </Text>
-            <Form2.TextField.Select
+            <Form2.Select
+              label={t`User Kicked`}
               control={editGroup.controls.sys_user_kicked}
             >
               <MenuItem value="none">
@@ -300,13 +296,11 @@ export default function ServerOverview(props: ServerSettingsProps) {
                   <MenuItem value={element.value}>{element.item.name}</MenuItem>
                 )}
               </For>
-            </Form2.TextField.Select>
+            </Form2.Select>
           </Column>
           <Column>
-            <Text class="label">
-              <Trans>User Banned</Trans>
-            </Text>
-            <Form2.TextField.Select
+            <Form2.Select
+              label={t`User Banned`}
               control={editGroup.controls.sys_user_banned}
             >
               <MenuItem value="none">
@@ -317,7 +311,7 @@ export default function ServerOverview(props: ServerSettingsProps) {
                   <MenuItem value={element.value}>{element.item.name}</MenuItem>
                 )}
               </For>
-            </Form2.TextField.Select>
+            </Form2.Select>
           </Column>
           <Row>
             <Form2.Reset group={editGroup} onReset={onReset} />

--- a/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
+++ b/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
@@ -16,13 +16,13 @@ import {
   Button,
   Checkbox,
   Column,
+  FloatingSelect,
   IconButton,
   MenuItem,
   MessageContainer,
   Row,
   Slider,
   Text,
-  TextField,
 } from "@revolt/ui";
 import {
   FONT_KEYS,
@@ -31,6 +31,7 @@ import {
   MonospaceFonts,
 } from "@revolt/ui/themes/fonts";
 
+import { t } from "@lingui/core/macro";
 import MDPalette from "@material-design-icons/svg/outlined/palette.svg?component-solid";
 
 /**
@@ -345,11 +346,8 @@ export function AppearanceMenu() {
         }
       />
 
-      <Text class="label">
-        <Trans>Interface Font</Trans>
-      </Text>
-      <TextField.Select
-        title="Interface Font"
+      <FloatingSelect
+        label={t`Interface Font`}
         value={state.theme.interfaceFont}
         onChange={(e) =>
           state.theme.setInterfaceFont(e.currentTarget.value as Fonts)
@@ -358,13 +356,10 @@ export function AppearanceMenu() {
         <For each={FONT_KEYS}>
           {(key) => <MenuItem value={key}>{key}</MenuItem>}
         </For>
-      </TextField.Select>
+      </FloatingSelect>
 
-      <Text class="label">
-        <Trans>Monospace Font</Trans>
-      </Text>
-      <TextField.Select
-        title="Monospace Font"
+      <FloatingSelect
+        label={t`Monospace Font`}
         value={state.theme.monospaceFont}
         onChange={(e) =>
           state.theme.setMonospaceFont(e.currentTarget.value as MonospaceFonts)
@@ -373,7 +368,7 @@ export function AppearanceMenu() {
         <For each={MONOSPACE_FONT_KEYS}>
           {(key) => <MenuItem value={key}>{key}</MenuItem>}
         </For>
-      </TextField.Select>
+      </FloatingSelect>
 
       <Column>
         <Text class="title" size="small">
@@ -392,10 +387,8 @@ export function AppearanceMenu() {
           <Trans>Show send message button</Trans>
         </Checkbox>
 
-        <Text class="label">
-          <Trans>Emoji Pack (affects your messages only)</Trans>
-        </Text>
-        <TextField.Select
+        <FloatingSelect
+          label={t`Emoji Pack (affects your messages only)`}
           value={state.settings.getValue("appearance:unicode_emoji")}
           onChange={(e) =>
             state.settings.setValue(
@@ -407,7 +400,7 @@ export function AppearanceMenu() {
           <For each={UNICODE_EMOJI_PACKS}>
             {(pack) => <EmojiPack pack={pack} />}
           </For>
-        </TextField.Select>
+        </FloatingSelect>
       </Column>
     </Column>
   );

--- a/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
+++ b/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
@@ -1,6 +1,6 @@
 import { For, Match, Show, Switch, createSignal } from "solid-js";
 
-import { Trans } from "@lingui-solid/solid/macro";
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
@@ -31,7 +31,6 @@ import {
   MonospaceFonts,
 } from "@revolt/ui/themes/fonts";
 
-import { t } from "@lingui/core/macro";
 import MDPalette from "@material-design-icons/svg/outlined/palette.svg?component-solid";
 
 /**
@@ -40,6 +39,7 @@ import MDPalette from "@material-design-icons/svg/outlined/palette.svg?component
 export function AppearanceMenu() {
   const user = useUser();
   const state = useState();
+  const { t } = useLingui();
   const [pickerRef, setPickerRef] = createSignal<HTMLDivElement>();
 
   return (

--- a/packages/client/components/modal/modals/BanMember.tsx
+++ b/packages/client/components/modal/modals/BanMember.tsx
@@ -7,7 +7,6 @@ import {
   Column,
   Dialog,
   DialogProps,
-  FloatingSelect,
   Form2,
   MenuItem,
   Text,
@@ -78,14 +77,9 @@ export function BanMemberModal(
             label={t`Reason`}
             placeholder={t`User broke a certain rule…`}
           />
-          <FloatingSelect
+          <Form2.Select
             label={t`Delete Message History`}
-            value={group.controls.deleteMessageSeconds.value}
-            onChange={(e) =>
-              group.controls.deleteMessageSeconds.setValue(
-                e.currentTarget.value || "0",
-              )
-            }
+            control={group.controls.deleteMessageSeconds}
           >
             <MenuItem value="0">
               <Trans>Don't delete messages</Trans>
@@ -105,7 +99,7 @@ export function BanMemberModal(
             <MenuItem value="604800">
               <Trans>7 days</Trans>
             </MenuItem>
-          </FloatingSelect>
+          </Form2.Select>
         </Column>
       </form>
     </Dialog>

--- a/packages/client/components/modal/modals/BanMember.tsx
+++ b/packages/client/components/modal/modals/BanMember.tsx
@@ -81,11 +81,9 @@ export function BanMemberModal(
           <FloatingSelect
             label={t`Delete Message History`}
             value={group.controls.deleteMessageSeconds.value}
-            onChange={(
-              e: Event & { currentTarget: HTMLElement; target: Element },
-            ) =>
+            onChange={(e) =>
               group.controls.deleteMessageSeconds.setValue(
-                e.currentTarget.getAttribute("value") || "0",
+                e.currentTarget.value || "0",
               )
             }
           >

--- a/packages/client/components/modal/modals/ReportContent.tsx
+++ b/packages/client/components/modal/modals/ReportContent.tsx
@@ -11,7 +11,6 @@ import {
   Column,
   Dialog,
   DialogProps,
-  FloatingSelect,
   Form2,
   Initials,
   MenuItem,
@@ -181,25 +180,17 @@ export function ReportContentModal(
             )}
           </div>
 
-          <FloatingSelect
+          <Form2.Select
             label={t`Reason for report`}
-            required
-            value={group.controls.category.value}
-            onChange={(
-              e: Event & { currentTarget: HTMLElement; target: Element },
-            ) =>
-              group.controls.category.setValue(
-                e.currentTarget.getAttribute("value") || "",
-              )
-            }
+            control={group.controls.category}
           >
-            <MenuItem value="">
+            <MenuItem>
               <Trans>Please select a reason</Trans>
             </MenuItem>
             <For each={reasons}>
               {(value) => <MenuItem value={value}>{strings[value]}</MenuItem>}
             </For>
-          </FloatingSelect>
+          </Form2.Select>
 
           {/* TODO: use TextEditor? */}
           <Form2.TextField

--- a/packages/client/components/ui/components/design/FloatingSelect.tsx
+++ b/packages/client/components/ui/components/design/FloatingSelect.tsx
@@ -15,10 +15,12 @@ import { autoUpdate, flip, offset, shift, size } from "@floating-ui/dom";
 import { MenuItem } from "mdui/components/menu-item";
 import { styled } from "styled-system/jsx";
 
-type FloatingSelectProps = {
+type FloatingSelectPropsLabel =
+  | { required: true; label: string }
+  | { required?: false; label?: string };
+
+type FloatingSelectProps = FloatingSelectPropsLabel & {
   value?: string;
-  label?: string;
-  required?: boolean;
   disabled?: boolean;
   variant?: "filled" | "outlined";
   children: JSX.Element;

--- a/packages/client/components/ui/components/design/FloatingSelect.tsx
+++ b/packages/client/components/ui/components/design/FloatingSelect.tsx
@@ -15,16 +15,14 @@ import { autoUpdate, flip, offset, shift, size } from "@floating-ui/dom";
 import { MenuItem } from "mdui/components/menu-item";
 import { styled } from "styled-system/jsx";
 
-type FloatingSelectProps = JSX.HTMLAttributes<HTMLButtonElement> & {
+type FloatingSelectProps = {
   value?: string;
   label?: string;
   required?: boolean;
   disabled?: boolean;
   variant?: "filled" | "outlined";
   children: JSX.Element;
-  onChange?: (
-    event: Event & { currentTarget: HTMLElement; target: Element },
-  ) => void;
+  onChange?: (event: Event & { currentTarget: MenuItem }) => void;
 };
 
 /**
@@ -113,17 +111,7 @@ export function FloatingSelect(props: FloatingSelectProps) {
       const value = menuItem.getAttribute("value");
       if (value !== null && local.onChange) {
         // Create a synthetic event that matches the expected interface
-        const syntheticEvent = {
-          ...event,
-          currentTarget: menuItem as HTMLElement,
-          target: menuItem as Element,
-        };
-        local.onChange(
-          syntheticEvent as Event & {
-            currentTarget: HTMLElement;
-            target: Element;
-          },
-        );
+        local.onChange({ ...event, currentTarget: menuItem });
       }
       setIsOpen(false);
     }
@@ -139,11 +127,13 @@ export function FloatingSelect(props: FloatingSelectProps) {
         onClick={() => !local.disabled && setIsOpen(!isOpen())}
         {...others}
       >
-        <SelectLabel floating={!!local.value || isOpen()}>
-          {local.label}
-          {local.required && " *"}
-        </SelectLabel>
-        <SelectValue>{selectedText()}</SelectValue>
+        <Show when={local.label}>
+          <SelectLabel floating={!!local.value || isOpen()}>
+            {local.label}
+            {local.required && " *"}
+          </SelectLabel>
+        </Show>
+        <SelectValue labeled={!!local.label}>{selectedText()}</SelectValue>
         <ArrowIcon open={isOpen()} viewBox="0 0 24 24">
           <path d="M7 10l5 5 5-5z" />
         </ArrowIcon>
@@ -250,10 +240,17 @@ const SelectLabel = styled("label", {
 const SelectValue = styled("span", {
   base: {
     flex: 1,
-    paddingTop: "16px",
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
+  },
+
+  variants: {
+    labeled: {
+      true: {
+        paddingTop: "16px",
+      },
+    },
   },
 });
 

--- a/packages/client/components/ui/components/design/FloatingSelect.tsx
+++ b/packages/client/components/ui/components/design/FloatingSelect.tsx
@@ -110,8 +110,7 @@ export function FloatingSelect(props: FloatingSelectProps) {
         ) as MenuItem);
 
     if (menuItem) {
-      const value = menuItem.getAttribute("value");
-      if (value !== null && local.onChange) {
+      if (menuItem.value != null && local.onChange) {
         // Create a synthetic event that matches the expected interface
         local.onChange({ ...event, currentTarget: menuItem });
       }

--- a/packages/client/components/ui/components/design/TextField.tsx
+++ b/packages/client/components/ui/components/design/TextField.tsx
@@ -92,30 +92,3 @@ export function TextField(props: Props) {
     />
   );
 }
-
-function Select(
-  props: JSX.HTMLAttributes<HTMLInputElement> & {
-    value?: string;
-    variant?: "filled" | "outlined";
-    required?: boolean;
-    disabled?: boolean;
-  },
-) {
-  return <mdui-select {...props} />;
-}
-
-/**
- * Select menu allows the user to pick a menu item
- *
- * Use the `MenuItem` component as the child:
- * ```tsx
- * <TextField.Select>
- *   <MenuItem value="itemA">hello!</MenuItem>
- *   <MenuItem value="itemB">world!</MenuItem>
- * </TextField.Select>
- * ```
- *
- * @library MDUI
- * @specification https://m3.material.io/components/menus
- */
-TextField.Select = Select;

--- a/packages/client/components/ui/components/features/legacy/ComboBox.tsx
+++ b/packages/client/components/ui/components/features/legacy/ComboBox.tsx
@@ -3,7 +3,7 @@ import { styled } from "styled-system/jsx";
 /**
  * Dropdown element
  *
- * @deprecated Use TextField.Select instead
+ * @deprecated Use FloatingSelect or Form2.Select instead
  */
 export const ComboBox = styled("select", {
   base: {

--- a/packages/client/components/ui/components/features/legacy/index.ts
+++ b/packages/client/components/ui/components/features/legacy/index.ts
@@ -1,6 +1,5 @@
 import { Checkbox, List, Switch } from "../../design";
 import { type DialogProps, Dialog } from "../../design/Dialog";
-import { TextField } from "../../design/TextField";
 import { NavigationRail } from "../../navigation";
 
 /**
@@ -32,11 +31,6 @@ export const ListSubheader = List.Subheader;
  * @deprecated Use the `NavigationRail.Item` export instead!
  */
 export const NavigationRailItem = NavigationRail.Item;
-
-/**
- * @deprecated Use the `TextField.Select` export instead!
- */
-export const Select = TextField.Select;
 
 /**
  * @deprecated Use the `Switch.Override` export instead!

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -1,4 +1,4 @@
-import { type IFormControl, ControlId, IFormGroup } from "solid-forms";
+import { type IFormControl, IFormGroup } from "solid-forms";
 import {
   type JSX,
   ComponentProps,
@@ -105,27 +105,35 @@ const EditorBox = styled("div", {
 /**
  * Form wrapper for FloatingSelect
  */
-export function FormSelect(props: {
-  label?: string;
-  variant?: "filled" | "outlined";
-  control: IFormControl<string, Record<ControlId, unknown>>;
-  children: JSX.Element;
-}) {
+export function FormSelect(
+  props: { control: IFormControl<string> } & Omit<
+    ComponentProps<typeof FloatingSelect>,
+    "value" | "required" | "disabled" | "onChange"
+  >,
+) {
   const [local, others] = splitProps(props, ["control", "children"]);
 
   return (
-    <FloatingSelect
-      {...others}
-      value={local.control.value}
-      required={local.control.isRequired}
-      disabled={local.control.isDisabled}
-      onChange={(e) => {
-        local.control.setValue(e.currentTarget.value || "");
-        local.control.markDirty(true);
-      }}
-    >
-      {local.children}
-    </FloatingSelect>
+    <>
+      <FloatingSelect
+        {...others}
+        value={local.control.value}
+        required={local.control.isRequired}
+        disabled={local.control.isDisabled}
+        onChange={(e) => {
+          local.control.setValue(e.currentTarget.value || "");
+          local.control.markDirty(true);
+        }}
+      >
+        {local.children}
+      </FloatingSelect>
+
+      <Show when={local.control.isTouched && !local.control.isValid}>
+        <For each={Object.keys(local.control.errors!)}>
+          {(errorMsg: string) => <small>{errorMsg}</small>}
+        </For>
+      </Show>
+    </>
   );
 }
 

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -104,11 +104,14 @@ const EditorBox = styled("div", {
 
 /**
  * Form wrapper for FloatingSelect
+ *
+ * Note: If control is 'required', an '*' will only appear if the control has a label.
+ * Required will still be enforced, this is just visual.
  */
 export function FormSelect(
-  props: { control: IFormControl<string> } & Omit<
+  props: { control: IFormControl<string>; label?: string } & Omit<
     ComponentProps<typeof FloatingSelect>,
-    "value" | "required" | "disabled" | "onChange"
+    "value" | "label" | "required" | "disabled" | "onChange"
   >,
 ) {
   const [local, others] = splitProps(props, ["control", "children"]);
@@ -118,7 +121,7 @@ export function FormSelect(
       <FloatingSelect
         {...others}
         value={local.control.value}
-        required={local.control.isRequired}
+        required={local.control.isRequired as never}
         disabled={local.control.isDisabled}
         onChange={(e) => {
           local.control.setValue(e.currentTarget.value || "");

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -1,4 +1,4 @@
-import { type IFormControl, IFormGroup } from "solid-forms";
+import { type IFormControl, ControlId, IFormGroup } from "solid-forms";
 import {
   type JSX,
   ComponentProps,
@@ -15,7 +15,14 @@ import { VirtualContainer } from "@minht11/solid-virtual-container";
 import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
-import { Button, Checkbox, Radio2, Text, TextField } from "../design";
+import {
+  Button,
+  Checkbox,
+  FloatingSelect,
+  Radio2,
+  Text,
+  TextField,
+} from "../design";
 import { TextEditor2 } from "../features/texteditor/TextEditor2";
 import { Row } from "../layout";
 
@@ -96,36 +103,31 @@ const EditorBox = styled("div", {
 });
 
 /**
- * Form wrapper for TextField.Select
+ * Form wrapper for FloatingSelect
  */
-FormTextField.Select = (
-  props: {
-    control: IFormControl<string>;
-  } & ComponentProps<typeof TextField.Select>,
-) => {
-  const [local, remote] = splitProps(props, ["control"]);
+export function FormSelect(props: {
+  label?: string;
+  variant?: "filled" | "outlined";
+  control: IFormControl<string, Record<ControlId, unknown>>;
+  children: JSX.Element;
+}) {
+  const [local, others] = splitProps(props, ["control", "children"]);
 
   return (
-    <>
-      <TextField.Select
-        {...remote}
-        value={local.control.value}
-        onChange={(e) => {
-          local.control.setValue(e.currentTarget.value);
-          local.control.markDirty(true);
-        }}
-        required={local.control.isRequired}
-        disabled={local.control.isDisabled}
-      />
-
-      <Show when={local.control.isTouched && !local.control.isValid}>
-        <For each={Object.keys(local.control.errors!)}>
-          {(errorMsg: string) => <small>{errorMsg}</small>}
-        </For>
-      </Show>
-    </>
+    <FloatingSelect
+      {...others}
+      value={local.control.value}
+      required={local.control.isRequired}
+      disabled={local.control.isDisabled}
+      onChange={(e) => {
+        local.control.setValue(e.currentTarget.value || "");
+        local.control.markDirty(true);
+      }}
+    >
+      {local.children}
+    </FloatingSelect>
   );
-};
+}
 
 /**
  * Form wrapper for, single file, FileInput
@@ -478,6 +480,7 @@ function useSubmitHandler(
 export const Form2 = {
   TextField: FormTextField,
   TextEditor: FormTextEditor,
+  Select: FormSelect,
   FileInput: FormFileInput,
   Checkbox: FormCheckbox,
   Radio: FormRadio,


### PR DESCRIPTION
This is split off from #835

- Replaces instances of TextField.Select with new FloatingSelect dropdown from #819
- Add ControlSelect wrapper accepting an IFormControl
- Remove unused & redundant legacy exports

## How was this PR tested?
Been in use by my mobile UI testers for a while and no issues.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
TBD
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
I am 100% Raichu-powered

Added by maintainers:

Fixes #1033
Fixes #684 