### PR TITLE
fix: Map edit message up keybind before default keybinds in texteditor2

### DIFF
--- a/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
+++ b/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
@@ -124,8 +124,8 @@ export function TextEditor2(props: Props) {
 
         /* Mount keymaps */
         enterKeymap,
-        keymap.of(defaultKeymap as never), // required for atomic ranges to work: https://github.com/codemirror/dev/issues/923
         arrowUpKeymap,
+        keymap.of(defaultKeymap as never), // required for atomic ranges to work: https://github.com/codemirror/dev/issues/923
 
         /* Enable history */
         history(),


### PR DESCRIPTION
Bind the arrow up key on the text editor before the default keybinds to make it have priority.

Fixes #1158

## How was this PR tested?
Reproduced #1158 before implementing change, unable to reproduce after change. Edited a long draft in the message box as well.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Generative AI was not used in the writing of this PR.
