### PR TITLE
fix: autoscrolling bug on chrome and desktop when adding messages

### DIFF
--- a/packages/client/components/ui/components/utils/ListView2.tsx
+++ b/packages/client/components/ui/components/utils/ListView2.tsx
@@ -111,6 +111,14 @@ export function ListView2(props: Props) {
           parent: true,
         }),
       }}
+      // Account for https://issues.chromium.org/issues/40829494
+      // Chromium based browsers (read: Chrome and Electron) will overscroll on reverse column flexboxes
+      // breaking automatic scrolling when adding new messages. This caps the scrolltop at 0 (it's negative.)
+      onScroll={(e) => {
+        if (e.target.scrollTop > 0) {
+          e.target.scrollTop = 0;
+        }
+      }}
     >
       <div class={container()}>
         <div>


### PR DESCRIPTION
Mitigate [Chromium bug 40829494](https://issues.chromium.org/issues/40829494) on the Messages view.

Supersedes #820
Fixes #660

## How was this PR tested?
This bug was a bit tricky to replicate, but you can replicate it using either Chromium or Electron. Once replicated, you can test this change easily by attempting to replicate the bug again and see it not happening.

For more information about the chromium bug, please view the link above. The codepen linked in the chromium bug makes testing this change easy.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Generative AI was not used in the writing of this PR.
