### PR TITLE
feat: add ability to copy links from messages

### DIFF
--- a/packages/client/components/app/index.tsx
+++ b/packages/client/components/app/index.tsx
@@ -1,5 +1,5 @@
 export { DraftMessages } from "./interface/channels/text/DraftMessages";
-export { Message } from "./interface/channels/text/Message";
+export { Message, useMessage } from "./interface/channels/text/Message";
 export { Messages } from "./interface/channels/text/Messages";
 
 export * from "./interface/settings";

--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -84,14 +84,21 @@ interface Props {
   isLink?: boolean;
 }
 
-const messageContext = createContext<MessageInterface | undefined>(undefined);
+interface MessageContextShape {
+  message?: MessageInterface;
+}
+
+const messageContext = createContext<MessageContextShape>({});
 
 function MessageContext(props: {
   children: JSX.Element;
   message: MessageInterface;
 }) {
+  // eslint-disable-next-line solid/reactivity
+  const contextShape = { message: props.message };
+
   return (
-    <messageContext.Provider value={props.message}>
+    <messageContext.Provider value={contextShape}>
       {props.children}
     </messageContext.Provider>
   );

--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -1,4 +1,14 @@
-import { For, Match, Show, Switch, createSignal, onMount } from "solid-js";
+import {
+  For,
+  JSX,
+  Match,
+  Show,
+  Switch,
+  createContext,
+  createSignal,
+  onMount,
+  useContext,
+} from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
 import {
@@ -74,6 +84,21 @@ interface Props {
   isLink?: boolean;
 }
 
+const messageContext = createContext<MessageInterface | undefined>(undefined);
+
+function MessageContext(props: {
+  children: JSX.Element;
+  message: MessageInterface;
+}) {
+  return (
+    <messageContext.Provider value={props.message}>
+      {props.children}
+    </messageContext.Provider>
+  );
+}
+
+export const useMessage = () => useContext(messageContext);
+
 /**
  * Render a Message with or without a tail
  */
@@ -118,220 +143,223 @@ export function Message(props: Props) {
   const unreact = (emoji: string) => props.message.unreact(emoji);
 
   return (
-    <MessageContainer
-      message={props.message}
-      onHover={setIsHovering}
-      username={
-        <div use:floating={floatingUserMenusFromMessage(props.message)}>
-          <Username
-            username={
-              props.message.masquerade?.name ??
-              props.message.member?.nickname ??
-              props.message.author?.displayName ??
-              props.message.author?.username ??
-              props.message.username
-            }
-            colour={props.message.roleColour!}
-          />
-        </div>
-      }
-      avatar={
-        <div
-          class={avatarContainer()}
-          use:floating={floatingUserMenusFromMessage(props.message)}
-        >
-          <Avatar
-            size={36}
-            src={
-              isHovering()
-                ? props.message.animatedAvatarURL
-                : props.message.avatarURL
-            }
-          />
-        </div>
-      }
-      contextMenu={() => <MessageContextMenu message={props.message} />}
-      timestamp={props.message.createdAt}
-      edited={props.message.editedAt}
-      mentioned={props.message.mentioned}
-      highlight={props.highlight}
-      editing={props.editing}
-      isLink={props.isLink}
-      tail={props.tail || state.settings.getValue("appearance:compact_mode")}
-      header={
-        <Show when={props.message.replyIds}>
-          <For each={props.message.replyIds}>
-            {(reply_id) => {
-              /**
-               * Signal the actual message
-               */
-              const message = () => client().messages.get(reply_id);
+    <MessageContext message={props.message}>
+      <MessageContainer
+        onHover={setIsHovering}
+        username={
+          <div use:floating={floatingUserMenusFromMessage(props.message)}>
+            <Username
+              username={
+                props.message.masquerade?.name ??
+                props.message.member?.nickname ??
+                props.message.author?.displayName ??
+                props.message.author?.username ??
+                props.message.username
+              }
+              colour={props.message.roleColour!}
+            />
+          </div>
+        }
+        avatar={
+          <div
+            class={avatarContainer()}
+            use:floating={floatingUserMenusFromMessage(props.message)}
+          >
+            <Avatar
+              size={36}
+              src={
+                isHovering()
+                  ? props.message.animatedAvatarURL
+                  : props.message.avatarURL
+              }
+            />
+          </div>
+        }
+        contextMenu={() => <MessageContextMenu message={props.message} />}
+        timestamp={props.message.createdAt}
+        edited={props.message.editedAt}
+        mentioned={props.message.mentioned}
+        highlight={props.highlight}
+        editing={props.editing}
+        isLink={props.isLink}
+        tail={props.tail || state.settings.getValue("appearance:compact_mode")}
+        header={
+          <Show when={props.message.replyIds}>
+            <For each={props.message.replyIds}>
+              {(reply_id) => {
+                /**
+                 * Signal the actual message
+                 */
+                const message = () => client().messages.get(reply_id);
 
-              onMount(() => {
-                if (!message()) {
-                  props.message.channel!.fetchMessage(reply_id);
-                }
-              });
+                onMount(() => {
+                  if (!message()) {
+                    props.message.channel!.fetchMessage(reply_id);
+                  }
+                });
 
-              return (
-                <MessageReply
-                  mention={props.message.mentionIds?.includes(
-                    message()!.authorId!,
-                  )}
-                  message={message()}
+                return (
+                  <MessageReply
+                    mention={props.message.mentionIds?.includes(
+                      message()!.authorId!,
+                    )}
+                    message={message()}
+                  />
+                );
+              }}
+            </For>
+          </Show>
+        }
+        info={
+          <Switch fallback={<div />}>
+            <Match when={props.message.iconRole}>
+              <Tooltip content={props.message.iconRole!.name} placement="top">
+                <Avatar
+                  size={16}
+                  shape="rounded-square"
+                  src={props.message.iconRole!.icon?.previewUrl}
                 />
-              );
-            }}
-          </For>
-        </Show>
-      }
-      info={
-        <Switch fallback={<div />}>
-          <Match when={props.message.iconRole}>
-            <Tooltip content={props.message.iconRole!.name} placement="top">
-              <Avatar
-                size={16}
-                shape="rounded-square"
-                src={props.message.iconRole!.icon?.previewUrl}
-              />
-            </Tooltip>
-          </Match>
-          <Match
-            when={
-              props.message.masquerade &&
-              props.message.authorId === "01FHGJ3NPP7XANQQH8C2BE44ZY"
-            }
-          >
-            <Tooltip
-              content={t`Message was sent on another platform`}
-              placement="top"
+              </Tooltip>
+            </Match>
+            <Match
+              when={
+                props.message.masquerade &&
+                props.message.authorId === "01FHGJ3NPP7XANQQH8C2BE44ZY"
+              }
             >
-              <Symbol size={16}>link</Symbol>
-            </Tooltip>
-          </Match>
-          <Match when={props.message.author?.privileged}>
-            <Tooltip content={t`Official Communication`} placement="top">
-              <Symbol size={16}>brightness_alert</Symbol>
-            </Tooltip>
-          </Match>
-          <Match when={props.message.author?.bot}>
-            <Tooltip content={t`Bot`} placement="top">
-              <Symbol size={16} fill>
-                smart_toy
-              </Symbol>
-            </Tooltip>
-          </Match>
-          <Match when={props.message.webhook}>
-            <Tooltip content={t`Webhook`} placement="top">
-              <Symbol size={16} fill>
-                cloud
-              </Symbol>
-            </Tooltip>
-          </Match>
-          <Match when={props.message.isSuppressed}>
-            <Tooltip content={t`Silent`} placement="top">
-              <Symbol size={16} fill>
-                notifications_off
-              </Symbol>
-            </Tooltip>
-          </Match>
-          <Match
-            when={
-              props.message.authorId &&
-              dayjs().diff(decodeTime(props.message.authorId), "day") < 1
-            }
-          >
-            <NewUser>
-              <Tooltip content={t`New to Stoat`} placement="top">
+              <Tooltip
+                content={t`Message was sent on another platform`}
+                placement="top"
+              >
+                <Symbol size={16}>link</Symbol>
+              </Tooltip>
+            </Match>
+            <Match when={props.message.author?.privileged}>
+              <Tooltip content={t`Official Communication`} placement="top">
+                <Symbol size={16}>brightness_alert</Symbol>
+              </Tooltip>
+            </Match>
+            <Match when={props.message.author?.bot}>
+              <Tooltip content={t`Bot`} placement="top">
                 <Symbol size={16} fill>
-                  spa
+                  smart_toy
                 </Symbol>
               </Tooltip>
-            </NewUser>
-          </Match>
-          <Match
-            when={
-              props.message.member &&
-              dayjs().diff(props.message.member.joinedAt, "day") < 1
-            }
-          >
-            <NewUser>
-              <Tooltip content={t`New to the server`} placement="top">
-                <Symbol size={16}>spa</Symbol>
+            </Match>
+            <Match when={props.message.webhook}>
+              <Tooltip content={t`Webhook`} placement="top">
+                <Symbol size={16} fill>
+                  cloud
+                </Symbol>
               </Tooltip>
-            </NewUser>
-          </Match>
-          {/* <Match when={props.message.authorId === "01EX2NCWQ0CHS3QJF0FEQS1GR4"}>
+            </Match>
+            <Match when={props.message.isSuppressed}>
+              <Tooltip content={t`Silent`} placement="top">
+                <Symbol size={16} fill>
+                  notifications_off
+                </Symbol>
+              </Tooltip>
+            </Match>
+            <Match
+              when={
+                props.message.authorId &&
+                dayjs().diff(decodeTime(props.message.authorId), "day") < 1
+              }
+            >
+              <NewUser>
+                <Tooltip content={t`New to Stoat`} placement="top">
+                  <Symbol size={16} fill>
+                    spa
+                  </Symbol>
+                </Tooltip>
+              </NewUser>
+            </Match>
+            <Match
+              when={
+                props.message.member &&
+                dayjs().diff(props.message.member.joinedAt, "day") < 1
+              }
+            >
+              <NewUser>
+                <Tooltip content={t`New to the server`} placement="top">
+                  <Symbol size={16}>spa</Symbol>
+                </Tooltip>
+              </NewUser>
+            </Match>
+            {/* <Match when={props.message.authorId === "01EX2NCWQ0CHS3QJF0FEQS1GR4"}>
             <span />
             <span>placeholder &middot; </span>
           </Match> */}
-        </Switch>
-      }
-      compact={
-        !!props.message.systemMessage ||
-        state.settings.getValue("appearance:compact_mode")
-      }
-      infoMatch={
-        <Match when={props.message.systemMessage}>
-          <SystemMessageIcon
+          </Switch>
+        }
+        compact={
+          !!props.message.systemMessage ||
+          state.settings.getValue("appearance:compact_mode")
+        }
+        infoMatch={
+          <Match when={props.message.systemMessage}>
+            <SystemMessageIcon
+              systemMessage={props.message.systemMessage!}
+              createdAt={props.message.createdAt}
+              isServer={!!props.message.server}
+            />
+          </Match>
+        }
+      >
+        <Show when={props.message.systemMessage}>
+          <SystemMessage
             systemMessage={props.message.systemMessage!}
-            createdAt={props.message.createdAt}
+            menuGenerator={(user) =>
+              user
+                ? floatingUserMenus(
+                    user!,
+                    // TODO: try to fetch on demand member
+                    props.message.server?.getMember(user!.id),
+                  )
+                : {}
+            }
             isServer={!!props.message.server}
           />
-        </Match>
-      }
-    >
-      <Show when={props.message.systemMessage}>
-        <SystemMessage
-          systemMessage={props.message.systemMessage!}
-          menuGenerator={(user) =>
-            user
-              ? floatingUserMenus(
-                  user!,
-                  // TODO: try to fetch on demand member
-                  props.message.server?.getMember(user!.id),
-                )
-              : {}
+        </Show>
+        <Switch>
+          <Match when={props.editing}>
+            <EditMessage message={props.message} />
+          </Match>
+          <Match when={props.message.content && !isOnlyGIF()}>
+            <BreakText>
+              <Markdown content={props.message.content!} />
+            </BreakText>
+          </Match>
+        </Switch>
+        <Show when={props.message.attachments}>
+          <For each={props.message.attachments}>
+            {(attachment) => (
+              <Attachment message={props.message} file={attachment} />
+            )}
+          </For>
+        </Show>
+        <Show when={props.message.embeds}>
+          <For each={props.message.embeds}>
+            {(embed) => <Embed embed={embed} />}
+          </For>
+        </Show>
+        <Reactions
+          reactions={
+            props.message.reactions as never as Map<string, Set<string>>
           }
-          isServer={!!props.message.server}
+          interactions={props.message.interactions}
+          userId={client().user!.id}
+          addReaction={react}
+          removeReaction={unreact}
+          sendGIF={(content) =>
+            props.message?.channel?.sendMessage({
+              content,
+              replies: [{ id: props.message.id, mention: true }],
+            })
+          }
         />
-      </Show>
-      <Switch>
-        <Match when={props.editing}>
-          <EditMessage message={props.message} />
-        </Match>
-        <Match when={props.message.content && !isOnlyGIF()}>
-          <BreakText>
-            <Markdown content={props.message.content!} />
-          </BreakText>
-        </Match>
-      </Switch>
-      <Show when={props.message.attachments}>
-        <For each={props.message.attachments}>
-          {(attachment) => (
-            <Attachment message={props.message} file={attachment} />
-          )}
-        </For>
-      </Show>
-      <Show when={props.message.embeds}>
-        <For each={props.message.embeds}>
-          {(embed) => <Embed embed={embed} />}
-        </For>
-      </Show>
-      <Reactions
-        reactions={props.message.reactions as never as Map<string, Set<string>>}
-        interactions={props.message.interactions}
-        userId={client().user!.id}
-        addReaction={react}
-        removeReaction={unreact}
-        sendGIF={(content) =>
-          props.message?.channel?.sendMessage({
-            content,
-            replies: [{ id: props.message.id, mention: true }],
-          })
-        }
-      />
-    </MessageContainer>
+      </MessageContainer>
+    </MessageContext>
   );
 }
 

--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -35,7 +35,11 @@ import {
 /**
  * Context menu for messages
  */
-export function MessageContextMenu(props: { message?: Message; file?: File }) {
+export function MessageContextMenu(props: {
+  message?: Message;
+  file?: File;
+  link?: string;
+}) {
   const user = useUser();
   const state = useState();
   const client = useClient();
@@ -100,7 +104,7 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
   /**
    * Copy message link to clipboard
    */
-  function copyLink() {
+  function copyMessageLink() {
     navigator.clipboard.writeText(
       `${location.origin}${
         props.message!.server ? `/server/${props.message!.server?.id}` : ""
@@ -118,25 +122,29 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
   /**
    * Opens the file preview in a new tab
    */
-  function OpenFile() {
+  function openFile() {
     window.open(props.file?.originalUrl, "_blank");
   }
 
   /**
    * Copies the link to the original url of the file
    */
-  function CopyLink() {
+  function copyFileLink() {
     navigator.clipboard.writeText(props.file?.originalUrl ?? "");
+  }
+
+  function copyLink() {
+    navigator.clipboard.writeText(props.link ?? "");
   }
 
   return (
     <ContextMenu>
       <Show when={props.file}>
-        <ContextMenuButton icon={MdOpenInNew} onClick={OpenFile}>
+        <ContextMenuButton icon={MdOpenInNew} onClick={openFile}>
           <Trans>Open file</Trans>
         </ContextMenuButton>
-        <ContextMenuButton icon={MdLink} onClick={CopyLink}>
-          <Trans>Copy link</Trans>
+        <ContextMenuButton icon={MdLink} onClick={copyFileLink}>
+          <Trans>Copy file link</Trans>
         </ContextMenuButton>
         <a
           target="_blank"
@@ -147,6 +155,13 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
             <Trans>Save file</Trans>
           </ContextMenuButton>
         </a>
+
+        <ContextMenuDivider />
+      </Show>
+      <Show when={props.link}>
+        <ContextMenuButton icon={MdLink} onClick={copyLink}>
+          <Trans>Copy link</Trans>
+        </ContextMenuButton>
 
         <ContextMenuDivider />
       </Show>
@@ -267,8 +282,8 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
             <Trans>Admin Panel</Trans>
           </ContextMenuButton>
         </Show>
-        <ContextMenuButton icon={MdShare} onClick={copyLink}>
-          <Trans>Copy link</Trans>
+        <ContextMenuButton icon={MdShare} onClick={copyMessageLink}>
+          <Trans>Copy message link</Trans>
         </ContextMenuButton>
         <Show when={state.settings.getValue("advanced:copy_id")}>
           <ContextMenuButton icon={MdBadge} onClick={copyId}>

--- a/packages/client/components/markdown/plugins/anchors.tsx
+++ b/packages/client/components/markdown/plugins/anchors.tsx
@@ -256,11 +256,15 @@ function LinkComponent(
   }
   return (
     <a
-      use:floating={{
-        contextMenu: () => (
-          <MessageContextMenu message={message} link={localProps.dest} />
-        ),
-      }}
+      use:floating={
+        message
+          ? {
+              contextMenu: () => (
+                <MessageContextMenu message={message} link={localProps.dest} />
+              ),
+            }
+          : undefined
+      }
       {...remoteProps}
     />
   );

--- a/packages/client/components/markdown/plugins/anchors.tsx
+++ b/packages/client/components/markdown/plugins/anchors.tsx
@@ -3,6 +3,7 @@ import { JSX, Match, Show, Switch, splitProps } from "solid-js";
 import { Trans } from "@lingui-solid/solid/macro";
 import { cva } from "styled-system/css";
 
+import { MessageContextMenu, useMessage } from "@revolt/app";
 import { useClient } from "@revolt/client";
 import { useModals } from "@revolt/modal";
 import { paramsFromPathname } from "@revolt/routing";
@@ -216,6 +217,7 @@ export function RenderAnchor(
           <LinkComponent
             {...remoteProps}
             class={link()}
+            dest={localProps.href}
             disabled={localProps.disabled}
             onClick={onHandleWarning}
             onAuxClick={onHandleWarning}
@@ -226,6 +228,7 @@ export function RenderAnchor(
           {...remoteProps}
           class={link()}
           disabled={localProps.disabled}
+          dest={localProps.href}
           href={localProps.href}
           target={"_blank"}
           rel="noreferrer"
@@ -241,11 +244,24 @@ export function RenderAnchor(
 }
 
 function LinkComponent(
-  props: { disabled?: boolean } & JSX.AnchorHTMLAttributes<HTMLAnchorElement>,
+  props: {
+    disabled?: boolean;
+    dest?: string;
+  } & JSX.AnchorHTMLAttributes<HTMLAnchorElement>,
 ) {
-  const [localProps, remoteProps] = splitProps(props, ["disabled"]);
+  const message = useMessage();
+  const [localProps, remoteProps] = splitProps(props, ["disabled", "dest"]);
   if (localProps.disabled) {
     return <span class={remoteProps.class}>{remoteProps.children}</span>;
   }
-  return <a {...remoteProps} />;
+  return (
+    <a
+      use:floating={{
+        contextMenu: () => (
+          <MessageContextMenu message={message} link={localProps.dest} />
+        ),
+      }}
+      {...remoteProps}
+    />
+  );
 }

--- a/packages/client/components/markdown/plugins/anchors.tsx
+++ b/packages/client/components/markdown/plugins/anchors.tsx
@@ -249,7 +249,7 @@ function LinkComponent(
     dest?: string;
   } & JSX.AnchorHTMLAttributes<HTMLAnchorElement>,
 ) {
-  const message = useMessage();
+  const { message } = useMessage();
   const [localProps, remoteProps] = splitProps(props, ["disabled", "dest"]);
   if (localProps.disabled) {
     return <span class={remoteProps.class}>{remoteProps.children}</span>;

--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -1,10 +1,10 @@
 import { JSX, Match, Show, Switch } from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
-import { Message } from "stoat.js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
+import { useMessage } from "@revolt/app";
 import { Ripple, typography } from "@revolt/ui/components/design";
 import { Column, Row } from "@revolt/ui/components/layout";
 import {
@@ -35,8 +35,6 @@ interface CommonProps {
 }
 
 type Props = CommonProps & {
-  message?: Message;
-
   /**
    * Avatar URL
    */
@@ -306,10 +304,11 @@ const CompactInfo = styled(Row, {
  */
 export function MessageContainer(props: Props) {
   const { t } = useLingui();
+  const message = useMessage();
 
   return (
     <div
-      id={props.message?.id}
+      id={message?.id}
       onMouseEnter={() => props.onHover && props.onHover(true)}
       onMouseLeave={() => props.onHover && props.onHover(false)}
       class={
@@ -324,10 +323,8 @@ export function MessageContainer(props: Props) {
       }
       use:floating={{ contextMenu: props.contextMenu }}
     >
-      <Show
-        when={props.message && props.isLink !== true && props.isLink !== "hide"}
-      >
-        <MessageToolbar message={props.message} />
+      <Show when={message && props.isLink !== true && props.isLink !== "hide"}>
+        <MessageToolbar />
       </Show>
 
       <Show when={props.isLink}>

--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -304,7 +304,7 @@ const CompactInfo = styled(Row, {
  */
 export function MessageContainer(props: Props) {
   const { t } = useLingui();
-  const message = useMessage();
+  const { message } = useMessage();
 
   return (
     <div

--- a/packages/client/components/ui/components/features/messaging/elements/MessageToolbar.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageToolbar.tsx
@@ -1,11 +1,11 @@
 import { Show } from "solid-js";
 
-import { Message } from "stoat.js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
-import { MessageContextMenu } from "@revolt/app";
+import { MessageContextMenu, useMessage } from "@revolt/app";
 import { useUser } from "@revolt/client";
+import { startsWithPackPUA } from "@revolt/markdown/emoji/UnicodeEmoji";
 import { useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
 import { Ripple } from "@revolt/ui/components/design";
@@ -17,13 +17,13 @@ import MdEmojiEmotions from "@material-design-icons/svg/outlined/emoji_emotions.
 import MdMoreVert from "@material-design-icons/svg/outlined/more_vert.svg?component-solid";
 import MdReply from "@material-design-icons/svg/outlined/reply.svg?component-solid";
 
-import { startsWithPackPUA } from "@revolt/markdown/emoji/UnicodeEmoji";
 import { CompositionMediaPicker } from "../composition";
 
-export function MessageToolbar(props: { message?: Message }) {
+export function MessageToolbar() {
   const user = useUser();
   const state = useState();
   const { openModal } = useModals();
+  const message = useMessage();
 
   // todo: a11y for buttons; tabindex
 
@@ -32,36 +32,36 @@ export function MessageToolbar(props: { message?: Message }) {
    */
   function deleteMessage(ev: MouseEvent) {
     if (ev.shiftKey) {
-      props.message?.delete();
-    } else if (props.message) {
+      message?.delete();
+    } else if (message) {
       openModal({
         type: "delete_message",
-        message: props.message,
+        message: message,
       });
     }
   }
 
   return (
     <Base class="Toolbar">
-      <Show when={props.message?.channel?.havePermission("SendMessage")}>
+      <Show when={message?.channel?.havePermission("SendMessage")}>
         <div
           class={tool()}
-          onClick={() => state.draft.addReply(props.message!, user()!.id)}
+          onClick={() => state.draft.addReply(message!, user()!.id)}
         >
           <Ripple />
           <MdReply {...iconSize(20)} />
         </div>
       </Show>
-      <Show when={props.message?.channel?.havePermission("React")}>
+      <Show when={message?.channel?.havePermission("React")}>
         <CompositionMediaPicker
           onMessage={(content) =>
-            props.message?.channel?.sendMessage({
+            message?.channel?.sendMessage({
               content,
-              replies: [{ id: props.message.id, mention: true }],
+              replies: [{ id: message.id, mention: true }],
             })
           }
           onTextReplacement={(emoji) =>
-            props.message!.react(
+            message!.react(
               emoji.startsWith(":")
                 ? emoji.slice(1, emoji.length - 1)
                 : startsWithPackPUA(emoji)
@@ -82,10 +82,10 @@ export function MessageToolbar(props: { message?: Message }) {
           )}
         </CompositionMediaPicker>
       </Show>
-      <Show when={props.message?.author?.self}>
+      <Show when={message?.author?.self}>
         <div
           class={tool()}
-          onClick={() => state.draft.setEditingMessage(props.message)}
+          onClick={() => state.draft.setEditingMessage(message)}
         >
           <Ripple />
           <MdEdit {...iconSize(20)} />
@@ -93,8 +93,8 @@ export function MessageToolbar(props: { message?: Message }) {
       </Show>
       <Show
         when={
-          props.message?.author?.self ||
-          props.message?.channel?.havePermission("ManageMessages")
+          message?.author?.self ||
+          message?.channel?.havePermission("ManageMessages")
         }
       >
         <div class={tool()} onClick={deleteMessage}>
@@ -105,7 +105,7 @@ export function MessageToolbar(props: { message?: Message }) {
       <div
         class={tool()}
         use:floating={{
-          contextMenu: () => <MessageContextMenu message={props.message!} />,
+          contextMenu: () => <MessageContextMenu message={message!} />,
           contextMenuHandler: "click",
         }}
       >

--- a/packages/client/components/ui/components/features/messaging/elements/MessageToolbar.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageToolbar.tsx
@@ -23,7 +23,7 @@ export function MessageToolbar() {
   const user = useUser();
   const state = useState();
   const { openModal } = useModals();
-  const message = useMessage();
+  const { message } = useMessage();
 
   // todo: a11y for buttons; tabindex
 


### PR DESCRIPTION
Add ability to right click copy links from messages.
Rename `Copy link` to `Copy message link` in the context menu to avoid confusion.
Add a message context to allow easier access to message data in markdown (this process is a pain, a context makes it easy.)

Do note that the context menu cannot use the context. It exists outside of it in the floating manager, therefore it must still have the `message` prop.

## How was this PR tested?
Right clicked a bunch of messages with and without links to ensure context menu was as expected.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<img width="352" height="407" alt="image" src="https://github.com/user-attachments/assets/b69aa31b-b2eb-4e60-8ac0-3dfec9222e96" />
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Generative AI was not used in the writing of this PR.