### PR TITLE
fix: wrap long text inside dialog modal content

### DIFF
--- a/packages/client/components/ui/components/design/Dialog.tsx
+++ b/packages/client/components/ui/components/design/Dialog.tsx
@@ -218,6 +218,8 @@ const Title = styled("span", {
 const Content = styled("div", {
   base: {
     color: "var(--md-sys-color-on-surface-variant)",
+    overflowWrap: "anywhere",
+    wordBreak: "break-word",
   },
 });
 


### PR DESCRIPTION
<!-- Describe your changes -->

The `Content` styled-div in `Dialog.tsx` had no `overflow-wrap` / `word-break` rules so any long unbreakable string inside a dialog (long error messages,
file paths, URLs, etc.) would render on a single line and overflow the modal's rounded box.

  Added `overflowWrap: "anywhere"` plus `wordBreak: "break-word"` as a fallback.

  Fixes #1167 

  ## How was this PR tested?

  <!-- What did you do to test your changes? -->

  - [x] Opened an invalid invite link locally and confirmed the long JSON error string now wraps inside the modal instead of bleeding outside the box.
  - [x] Spot-checked other dialog usages (settings confirmations, etc.) short strings render the same as before.

  <details><summary><h2>Screenshots & Screencasts</h2></summary>

<img width="1698" height="1026" alt="image" src="https://github.com/user-attachments/assets/b33a4936-10b7-4e09-9f8d-7f674bc582dc" />


<img width="1698" height="1026" alt="image" src="https://github.com/user-attachments/assets/01818ad1-0dab-4690-b7b2-080aed334ee4" />

  </details>

  ## Checklist:

  - [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
  - [x] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation if applicable
  - [x] I have no unrelated changes in the PR
  - [x] I have confirmed that any new dependencies are strictly necessary
  - [ ] I have written tests for new code (if applicable)
  - [x] I have followed naming conventions/patterns in the surrounding code

  ## Please declare, if any, LLM usage involved in creating this PR

  None.