### PR TITLE
fix: remove member option was not showing correctly

### DIFF
--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -293,8 +293,9 @@ export function UserContextMenu(props: {
     return (
       props.channel?.type === "Group" &&
       !props.user.self &&
-      props.channel.havePermission("ManageChannel") &&
-      !props.channel.owner?.self
+      !(props.channel.owner?.id !== props.user.id) &&
+      (props.channel.havePermission("ManageChannel") ||
+        props.channel.owner?.self)
     );
   }
 
@@ -415,8 +416,22 @@ export function UserContextMenu(props: {
 
       {/* Moderation: kick, ban */}
       {/** TODO: #287 timeout users */}
-      <Show when={props.member && (canKick() || canBan())}>
+      <Show
+        when={
+          canRemoveMemberFromGroup() ||
+          (props.member && (canKick() || canBan()))
+        }
+      >
         <ContextMenuDivider />
+        <Show when={canRemoveMemberFromGroup()}>
+          <ContextMenuButton
+            icon={MdPersonRemove}
+            onClick={removeMember}
+            destructive
+          >
+            <Trans>Remove Member</Trans>
+          </ContextMenuButton>
+        </Show>
         <Show when={canKick()}>
           <ContextMenuButton
             icon={MdPersonRemove}
@@ -435,15 +450,6 @@ export function UserContextMenu(props: {
             <Trans>Ban member</Trans>
           </ContextMenuButton>
         </Show>
-      </Show>
-      <Show when={canRemoveMemberFromGroup()}>
-        <ContextMenuButton
-          icon={MdPersonRemove}
-          onClick={removeMember}
-          destructive
-        >
-          <Trans>Remove Member</Trans>
-        </ContextMenuButton>
       </Show>
       <Show when={canBanNonMember()}>
         <ContextMenuDivider />

--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -293,7 +293,7 @@ export function UserContextMenu(props: {
     return (
       props.channel?.type === "Group" &&
       !props.user.self &&
-      !(props.channel.owner?.id !== props.user.id) &&
+      props.channel.owner?.id !== props.user.id &&
       (props.channel.havePermission("ManageChannel") ||
         props.channel.owner?.self)
     );
@@ -463,8 +463,6 @@ export function UserContextMenu(props: {
       </Show>
 
       {/* Safety: remove friend, block, report */}
-      <ContextMenuDivider />
-
       <Show when={!props.user.self}>
         <ContextMenuDivider />
         <Show when={props.user.relationship === "Friend"}>


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes the remove member from group option because it was not showing up correctly due to faulty logic. Also moves the menu option into the correct position.

## How was this PR tested?

<!-- What did you do to test your changes? -->
- [x] Was able to see the option when user is the owner of the channel and is not targeting self or the owner.
<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
N/a
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable (N/a)
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary (N/a)
- [ ] I have written tests for new code (if applicable) (N/a)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
none this time around
