### PR TITLE
fix: bypass canSend() check if passing `useContent` for gifbox

### DIFF
--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -177,7 +177,7 @@ export function MessageComposition(props: Props) {
    * @param useContent Content to send
    */
   async function sendMessage(useContent?: unknown) {
-    if (!canSend()) {
+    if (!canSend() && typeof useContent !== "string") {
       return;
     }
     stopTyping();


### PR DESCRIPTION
Fixes regression caused by #1131 that broke gifs

## How was this PR tested?
Sent gif before and after fix

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
