### PR TITLE
fix: Sync settings on login instead of on load

### DIFF
--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -1,4 +1,4 @@
-import { Accessor, Setter, createSignal } from "solid-js";
+import { Accessor, Setter, createMemo, createSignal } from "solid-js";
 
 import { detect } from "detect-browser";
 import { API, Client, ConnectionState } from "stoat.js";
@@ -446,6 +446,11 @@ export default class ClientController {
   readonly state: ApplicationState;
 
   /**
+   * A memo to prevent isLoggedIn from bouncing when reconnecting
+   */
+  private isLoggedInState: Accessor<boolean>;
+
+  /**
    * Construct new client controller
    */
   constructor(state: ApplicationState) {
@@ -462,6 +467,16 @@ export default class ClientController {
     this.isLoggedIn = this.isLoggedIn.bind(this);
     this.isError = this.isError.bind(this);
 
+    this.isLoggedInState = createMemo(() =>
+      [
+        State.Connecting,
+        State.Connected,
+        State.Disconnected,
+        State.Offline,
+        State.Reconnecting,
+      ].includes(this.lifecycle.state()),
+    );
+
     const session = state.auth.getSession();
     if (session) {
       this.lifecycle.transition({
@@ -476,13 +491,7 @@ export default class ClientController {
   }
 
   isLoggedIn() {
-    return [
-      State.Connecting,
-      State.Connected,
-      State.Disconnected,
-      State.Offline,
-      State.Reconnecting,
-    ].includes(this.lifecycle.state());
+    return this.isLoggedInState();
   }
 
   isError() {

--- a/packages/client/components/state/SyncWorker.tsx
+++ b/packages/client/components/state/SyncWorker.tsx
@@ -42,8 +42,8 @@ export function SyncWorker() {
   // sync LOCAL->REMOTE settings
   createEffect(
     on(
-      () => state.sync.shouldSync,
-      (shouldSync) => shouldSync && state.sync.save(client()),
+      [() => state.sync.shouldSync, isLoggedIn],
+      (input) => input[0] && input[1] && state.sync.save(client()),
     ),
   );
 

--- a/packages/client/components/state/SyncWorker.tsx
+++ b/packages/client/components/state/SyncWorker.tsx
@@ -43,7 +43,8 @@ export function SyncWorker() {
   createEffect(
     on(
       [() => state.sync.shouldSync, isLoggedIn],
-      (input) => input[0] && input[1] && state.sync.save(client()),
+      ([shouldSync, isLoggedIn]) =>
+        shouldSync && isLoggedIn && state.sync.save(client()),
     ),
   );
 

--- a/packages/client/components/state/SyncWorker.tsx
+++ b/packages/client/components/state/SyncWorker.tsx
@@ -2,7 +2,7 @@ import { createEffect, on, onCleanup } from "solid-js";
 
 import { ProtocolV1 } from "stoat.js/lib/events/v1";
 
-import { useClient } from "@revolt/client";
+import { useClient, useClientLifecycle } from "@revolt/client";
 
 import { useState } from ".";
 
@@ -12,6 +12,7 @@ import { useState } from ".";
 export function SyncWorker() {
   const state = useState();
   const client = useClient();
+  const { isLoggedIn } = useClientLifecycle();
 
   /**
    * Handle incoming events
@@ -26,13 +27,13 @@ export function SyncWorker() {
   // sync REMOTE->LOCAL settings
   createEffect(
     on(
-      () => client(),
-      (client) => {
-        if (client) {
-          state.sync.initialSync(client);
+      () => isLoggedIn(),
+      (isLoggedIn) => {
+        if (isLoggedIn) {
+          state.sync.initialSync(client());
 
-          client.events.addListener("event", handleEvent);
-          onCleanup(() => client.events.removeListener("event", handleEvent));
+          client().events.addListener("event", handleEvent);
+          onCleanup(() => client().events.removeListener("event", handleEvent));
         }
       },
     ),


### PR DESCRIPTION
Currently, settings are synced immediately on page load  instead of on login. This PR makes the settings sync after the client is logged in.

Right now, the changelog will show on a fresh login on every device. This fixes that.

This PR also includes a memo for the isLoggedIn function as it was causing bounce issues.

Fixes #746 

## How was this PR tested?
Tested multiple different situations of wiping cache and logging in across multiple browsers.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None