### PR TITLE
fix: Config fixes for TSConfig root dir & VSCode search ignores

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,11 @@
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   // Nix environment settings
-  "nixEnvSelector.nixFile": "${workspaceFolder}/default.nix"
+  "nixEnvSelector.nixFile": "${workspaceFolder}/default.nix",
+  "search.exclude": {
+    "**/coverage": true,
+    "**/dist": true,
+    "**/i18n": true,
+    "**/styled-system": true
+  }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,9 +16,11 @@ export default defineConfig([
       "**/dist/**",
       "**/styled-system/**",
     ],
+  },
+  {
     languageOptions: {
       parserOptions: {
-        tsconfigRootDir: import.meta.dirname + "/packages/client",
+        tsconfigRootDir: import.meta.dirname,
       },
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,11 @@ export default defineConfig([
       "**/dist/**",
       "**/styled-system/**",
     ],
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname + "/packages/client",
+      },
+    },
   },
   eslint.configs.recommended,
   tseslint.configs.recommended,


### PR DESCRIPTION
Just two small config improvements made due to annoyance dealing with these issues lol.

- Add the ignores from gitignore to vscode search exclusion to speed up search (Exclusions can be manually overriden in the search panel if need be)
- Add tsconfigRootDir to eslint to fix multiple TS config candidates warning in vscode/eslint that pops up sometimes