### PR TITLE
feat: Device resize hooks (prep for Mobile/Tablet UI)

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -25,3 +25,6 @@
       - [Reference Guide](./components/ui/themes/reference.md)
     - [Tools]()
       - [Form2](./components/ui/tools/form2.md)
+- [Responsive]()
+  - [Device](./responsive/device.md)
+  - [Feature Detection](./responsive/feature-detection.md)

--- a/doc/src/responsive/device.md
+++ b/doc/src/responsive/device.md
@@ -1,0 +1,34 @@
+# Device
+
+The Device hook located in the `@revolt/common` package contains all information needed to be responsive to the device. When you must change UI or settings based on device size or orientation, use the Device hook.
+
+## Using the useDevice hook
+
+The `useDevice` hook returns a Device object that contains a `layout` accessor which returns if the device is on a phone, tablet, or desktop layout based on screen size. It also contains an `isMobile` boolean, but this relies on the user agent and should not be used unless neccesary.
+
+**Do not rely on screen size to determine if the device supports touch or is a phone.**
+
+```typescript
+import { Show } from "solid-js";
+
+import { useDevice } from "@revolt/common";
+
+function ComponentThatUsesDevice() {
+  const { device } = useDevice();
+
+  return (
+    <Show when={device.layout() === "desktop"}>
+      This is a large screen!
+    </Show>
+    <Show when={device.layout() === "tablet"}>
+      This is a medium screen!
+    </Show>
+    <Show when={device.layout() === "phone"}>
+      This is a small screen!
+    </Show>
+    <Show when={device.layout() !== "phone"}>
+      This is not a small screen!
+    </Show>
+  )
+}
+```

--- a/doc/src/responsive/feature-detection.md
+++ b/doc/src/responsive/feature-detection.md
@@ -1,0 +1,7 @@
+# Feature Detection
+
+Any feature that may not be present on all platforms should have a feature detection added to the Device hook if it will be used in more than one location. A few examples of feature detection:
+
+- Notifications are only supported on desktop browsers
+- Touch is only supported on devices with touch
+- On screen keyboard management is only supported on newer Chrome based browsers on mobile

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -46,7 +46,7 @@ export class Device {
 
     this.pMedia = matchMedia(`(max-width: ${this.phoneMaxWidth})`);
     this.tMedia = matchMedia(`(max-width: ${this.tabletMaxWidth})`);
-    (this.pMedia.onchange = this.tMedia.onchange = this.onLayout)();
+    (this.pMedia.onchange = this.tMedia.onchange = this.onLayout.bind(this))();
   }
 
   onLayout() {

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -1,4 +1,5 @@
 import {
+  Accessor,
   createContext,
   createSignal,
   JSX,
@@ -25,13 +26,13 @@ export class Device {
   readonly tabletMaxWidth = style.getPropertyValue("--tablet-max-width");
 
   /** Layout type based on viewport size */
-  readonly layout;
+  readonly layout: Accessor<Layout>;
 
   /** Mobile device detection based on User Agent.
 
    * **Warning:** Don't use unless absolutely necessary.
    * Granular feature-detection is preferred when possible. */
-  readonly isMobile;
+  readonly isMobile: boolean;
 
   private pMedia;
   private tMedia;

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -11,11 +11,7 @@ import { isMobileBrowser } from "@livekit/components-core";
 
 const style = getComputedStyle(document.body);
 
-export enum Layout {
-  DESKTOP = 1,
-  PHONE,
-  TABLET,
-}
+export type Layout = "desktop" | "tablet" | "phone";
 
 /** Device type and compatibility info */
 export class Device {
@@ -41,7 +37,7 @@ export class Device {
   constructor() {
     this.isMobile = isMobileBrowser();
 
-    const [lo, setLo] = createSignal<Layout>(Layout.DESKTOP);
+    const [lo, setLo] = createSignal<Layout>("desktop");
     this.layout = lo;
     this.setLayout = setLo;
 
@@ -53,10 +49,10 @@ export class Device {
   onLayout() {
     this.setLayout(
       this.pMedia.matches
-        ? Layout.PHONE
+        ? "phone"
         : this.tMedia.matches
-          ? Layout.TABLET
-          : Layout.DESKTOP,
+          ? "tablet"
+          : "desktop",
     );
   }
 

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -1,0 +1,78 @@
+import {
+  createContext,
+  createSignal,
+  JSX,
+  onCleanup,
+  useContext,
+} from "solid-js";
+
+import { isMobileBrowser } from "@livekit/components-core";
+
+const style = getComputedStyle(document.body);
+
+export enum Layout {
+  DESKTOP = 1,
+  PHONE,
+  TABLET,
+}
+
+/** Device type and compatibility info */
+export class Device {
+  /** Max width for phone layout */
+  readonly phoneMaxWidth = style.getPropertyValue("--phone-max-width");
+
+  /** Max width for tablet layout */
+  readonly tabletMaxWidth = style.getPropertyValue("--tablet-max-width");
+
+  /** Layout type based on viewport size */
+  readonly layout;
+
+  /** Mobile device detection based on User Agent.
+
+   * **Warning:** Don't use unless absolutely necessary.
+   * Granular feature-detection is preferred when possible. */
+  readonly isMobile;
+
+  private pMedia;
+  private tMedia;
+  private setLayout;
+
+  constructor() {
+    this.isMobile = isMobileBrowser();
+
+    const [lo, setLo] = createSignal<Layout>(Layout.DESKTOP);
+    this.layout = lo;
+    this.setLayout = setLo;
+
+    this.pMedia = matchMedia(`(max-width: ${this.phoneMaxWidth})`);
+    this.tMedia = matchMedia(`(max-width: ${this.tabletMaxWidth})`);
+    (this.pMedia.onchange = this.tMedia.onchange = this.onLayout)();
+  }
+
+  onLayout() {
+    this.setLayout(
+      this.pMedia.matches
+        ? Layout.PHONE
+        : this.tMedia.matches
+          ? Layout.TABLET
+          : Layout.DESKTOP,
+    );
+  }
+
+  destroy() {
+    this.pMedia.onchange = this.tMedia.onchange = null;
+  }
+}
+
+const deviceCtx = createContext<Device>(null! as Device);
+
+/** Mount device context */
+export function DeviceContext(props: { children: JSX.Element }) {
+  const dev = new Device();
+  onCleanup(dev.destroy);
+
+  return <deviceCtx.Provider value={dev}>{props.children}</deviceCtx.Provider>;
+}
+
+/** Device type and compatibility info */
+export const useDevice = () => useContext(deviceCtx);

--- a/packages/client/components/common/index.tsx
+++ b/packages/client/components/common/index.tsx
@@ -1,3 +1,4 @@
+export * from "./Device";
 export { debounce } from "./lib/debounce";
 export { default as CONFIGURATION } from "./lib/env";
 export { insecureUniqueId } from "./lib/unique";

--- a/packages/client/components/ui/styles.css
+++ b/packages/client/components/ui/styles.css
@@ -10,7 +10,7 @@
 
 :root {
   --phone-max-width: 600px;
-  --tablet-max-width: 900px;
+  --tablet-max-width: 960px;
 }
 
 body {

--- a/packages/client/components/ui/styles.css
+++ b/packages/client/components/ui/styles.css
@@ -6,8 +6,11 @@
 @import "@fontsource/inter/800";
 @import "@fontsource/jetbrains-mono";
 
-* {
-  box-sizing: border-box;
+* { box-sizing: border-box; }
+
+:root {
+  --phone-max-width: 600px;
+  --tablet-max-width: 900px;
 }
 
 body {

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -23,6 +23,7 @@ import FlowResend from "@revolt/auth/src/flows/FlowResend";
 import FlowReset from "@revolt/auth/src/flows/FlowReset";
 import FlowVerify from "@revolt/auth/src/flows/FlowVerify";
 import { ClientContext, useClient } from "@revolt/client";
+import { DeviceContext } from "@revolt/common";
 import { I18nProvider } from "@revolt/i18n";
 import { KeybindContext } from "@revolt/keybinds";
 import { ModalContext, ModalRenderer, useModals } from "@revolt/modal";
@@ -150,40 +151,42 @@ function MountContext(props: { children?: JSX.Element }) {
 
 render(
   () => (
-    <StateContext>
-      <Router root={MountContext}>
-        <Route path="/login" component={AuthPage as never}>
-          <Route path="/delete/:token" component={FlowDeleteAccount} />
-          <Route path="/check" component={FlowCheck} />
-          <Route path="/create" component={FlowCreate} />
-          <Route path="/create/:code" component={FlowCreate} />
-          <Route path="/auth" component={FlowLogin} />
-          <Route path="/resend" component={FlowResend} />
-          <Route path="/reset" component={FlowReset} />
-          <Route path="/verify/:token" component={FlowVerify} />
-          <Route path="/reset/:token" component={FlowConfirmReset} />
-          <Route path="/*" component={FlowHome} />
-        </Route>
-        <Route path="/" component={Interface as never}>
-          <Route path="/pwa" component={PWARedirect} />
-          <Route path="/dev" component={DevelopmentPage} />
-          <Route path="/discover/*" component={Discover} />
-          <Route path="/settings" component={SettingsRedirect} />
-          <Route path="/invite/:code" component={InviteRedirect} />
-          <Route path="/bot/:code" component={BotRedirect} />
-          <Route path="/friends" component={Friends} />
-          <Route path="/server/:server/*">
-            <Route path="/channel/:channel/*" component={ChannelPage} />
-            <Route path="/*" component={ServerHome} />
+    <DeviceContext>
+      <StateContext>
+        <Router root={MountContext}>
+          <Route path="/login" component={AuthPage as never}>
+            <Route path="/delete/:token" component={FlowDeleteAccount} />
+            <Route path="/check" component={FlowCheck} />
+            <Route path="/create" component={FlowCreate} />
+            <Route path="/create/:code" component={FlowCreate} />
+            <Route path="/auth" component={FlowLogin} />
+            <Route path="/resend" component={FlowResend} />
+            <Route path="/reset" component={FlowReset} />
+            <Route path="/verify/:token" component={FlowVerify} />
+            <Route path="/reset/:token" component={FlowConfirmReset} />
+            <Route path="/*" component={FlowHome} />
           </Route>
-          <Route path="/channel/:channel/*" component={ChannelPage} />
-          <Route path="/*" component={HomePage} />
-        </Route>
-      </Router>
+          <Route path="/" component={Interface as never}>
+            <Route path="/pwa" component={PWARedirect} />
+            <Route path="/dev" component={DevelopmentPage} />
+            <Route path="/discover/*" component={Discover} />
+            <Route path="/settings" component={SettingsRedirect} />
+            <Route path="/invite/:code" component={InviteRedirect} />
+            <Route path="/bot/:code" component={BotRedirect} />
+            <Route path="/friends" component={Friends} />
+            <Route path="/server/:server/*">
+              <Route path="/channel/:channel/*" component={ChannelPage} />
+              <Route path="/*" component={ServerHome} />
+            </Route>
+            <Route path="/channel/:channel/*" component={ChannelPage} />
+            <Route path="/*" component={HomePage} />
+          </Route>
+        </Router>
 
-      <LoadTheme />
-      {/* <ReportBug /> */}
-    </StateContext>
+        <LoadTheme />
+        {/* <ReportBug /> */}
+      </StateContext>
+    </DeviceContext>
   ),
   document.getElementById("root") as HTMLElement,
 );


### PR DESCRIPTION
In preparation for Mobile/Tablet UI, we need to add a centralized place for reactive hooks for layout changes and feature detection.

For best performance for the resize hooks, I went with a hybrid approach that uses native CSS media queries and forwards them to reactive variables. From my testing this performs better than a resize observer (though either is obviously way better than brute-force polling).

This will become a prerequisite for <https://github.com/stoatchat/for-web/pull/835> which will use the hooks here.

- `main` <!-- branch-stack -->
  - \#1196 :point\_left:
