### PR TITLE
fix: Off-center loading progress wheel is now nice n centered

### DIFF
--- a/packages/client/components/ui/components/design/LoadingProgress.tsx
+++ b/packages/client/components/ui/components/design/LoadingProgress.tsx
@@ -1,4 +1,6 @@
 import "mdui/components/circular-progress.js";
+import { cva } from "styled-system/css";
+import { styled } from "styled-system/jsx";
 
 /**
  * Progress indicators express an unspecified wait time or display the duration of a process
@@ -7,5 +9,28 @@ import "mdui/components/circular-progress.js";
  * @specification https://m3.material.io/components/progress-indicators
  */
 export function CircularProgress() {
-  return <mdui-circular-progress />;
+  return (
+    <Base>
+      <mdui-circular-progress class={loader()} />
+    </Base>
+  );
 }
+
+const Base = styled("div", {
+  base: {
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    minWidth: "40px",
+    minHeight: "40px",
+  },
+});
+
+const loader = cva({
+  base: {
+    position: "absolute",
+    left: "50%",
+    top: "50%",
+    transform: "translate(-50%, -50%)",
+  },
+});


### PR DESCRIPTION
Split off from #835
Fixes #1140

This solution is tested and working for proper centering at the root level (initial app load), in the login box while logging in, and inside modals. The `minWidth` and `minHeight` ensure that whatever element contains it won't get smaller than the loading wheel itself, which would obviously look cursed lol

<img src="https://github.com/user-attachments/assets/e060d5e8-1150-48b9-a836-d58b659b10a3" />

<img src="https://github.com/user-attachments/assets/bd11487b-bcf5-4461-b9ee-e86895823e12" />

- `main` <!-- branch-stack -->
  - \#1200 :point\_left:
