### PR TITLE
fix: Mute users when they deafen

### DIFF
--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -102,7 +102,7 @@ class Voice {
     this.#setState = setState;
 
     this.deafen = () => voiceSettings.deafen;
-    this.microphone = () => voiceSettings.micOn;
+    this.microphone = () => voiceSettings.micOn && !voiceSettings.deafen;
 
     const [video, setVideo] = createSignal(false);
     this.video = video;
@@ -211,11 +211,29 @@ class Voice {
     }
   }
 
-  async toggleDeafen() {
-    this.#settings.deafen = !this.#settings.deafen;
+  async toggleDeafen(fromMute?: boolean) {
+    try {
+      const room = this.room();
+      if (!room) throw "invalid state";
+      await room.localParticipant.setMicrophoneEnabled(
+        (this.#settings.micOn || !!fromMute) &&
+          !room.localParticipant.isMicrophoneEnabled,
+      );
+
+      if (fromMute) {
+        this.#settings.micOn = room.localParticipant.isMicrophoneEnabled;
+      }
+      this.#settings.deafen = !this.#settings.deafen;
+    } catch (e) {
+      this.onErr(e);
+    }
   }
 
   async toggleMute() {
+    if (this.#settings.deafen) {
+      this.toggleDeafen(true);
+      return;
+    }
     try {
       const room = this.room();
       if (!room) throw "invalid state";


### PR DESCRIPTION
This PR makes users mute when they deafen. The behavior is as follows:

* Muting mutes the microphone
* Deafening mutes the microphone and other users
* Undeafening when the microphone was muted before will leave the microphone muted
* Undeafening when the microphone was unmuted before will unmute the microphone
* Unmuting when deafened will undeafen and unmute

Fixes (partially) #1208 

## How was this PR tested?
Checked every iteration of muting and deafening.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
