### PR TITLE
fix(settings): prevent form revert after save in Profile/Bot edit

### DIFF
--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -61,6 +61,12 @@ export function UserProfileEditor(props: Props) {
     on(
       () => profile.data,
       (profileData) => {
+        // Skip overwriting form controls while the operator has uncommitted edits.
+        // Without this guard, a post-save background refetch of the ["profile", user.id]
+        // query (triggered by queryClient.setQueryData below + WS UserUpdate event) re-runs
+        // this effect and clobbers in-flight bio/banner edits with the pre-save snapshot,
+        // producing the "Save reverts on first click" symptom in Settings → My Bots.
+        if (editGroup.isDirty) return;
         if (profileData) {
           editGroup.controls.banner.setValue(
             profileData.animatedBannerURL || null,

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -461,8 +461,26 @@ function useSubmitHandler(
 
     try {
       await handler();
+      // Do NOT call onReset?.() on successful submit. onReset is the operator's
+      // "discard my changes, restore server state" path (FormResetButton). On a
+      // successful submit the just-typed control values ARE the new server state,
+      // so re-running onReset would overwrite them with stale `props.*` / `query.data`
+      // values (the WS UserUpdate / TanStack refetch may not have settled yet).
+      //
+      // Concretely for UserProfileEditor: the bio is rendered by Form2.TextEditor
+      // whose `initialValue={initialBio()}` accessor is driven by a signal that
+      // onReset re-seeds from `profile.data.content`. Calling onReset post-save
+      // makes initialBio() flip to the stale pre-save value, which the TextEditor
+      // createEffect dispatches into CodeMirror as a `replaceSelection`, producing
+      // a visible "form briefly reverts to old text" stutter even though the
+      // server-side persistence succeeded. Skipping onReset here keeps the
+      // visible form == the just-submitted values; the subsequent createEffect
+      // (in the parent) updates the form to the canonical server value once the
+      // refetch settles, which is a no-op when the server echoes back what we sent.
+      //
+      // resetGeneric(group, true) only clears dirty/touched flags — it does NOT
+      // touch control.value — so the Save button correctly grays out post-submit.
       resetGeneric(group, true);
-      onReset?.();
     } catch (err) {
       group.setErrors({
         error: err,


### PR DESCRIPTION
## Fixes

Fixes #1211

Related (likely-same-root-cause user reports):
- #756, #869, #1063 — open
- #513, #644, #915, #800 — closed without a fix

## Summary

On `for-web` v0.6.0 and current `main`, submitting profile/bot edit forms (Settings → Profile, Settings → My Bots → [bot] → Edit) causes the visible form state to briefly revert to the pre-save values immediately after Save, even though the server-side persistence succeeds. A page reload shows the correct new values.

The reverting frame is caused by `useSubmitHandler`'s success branch calling `onReset?.()`, which the `UserProfileEditor` uses to flip the `initialBio` signal back to `profile.data.content` — but at that point `profile.data.content` is still the stale pre-save snapshot (the TanStack refetch hasn't landed). The `Form2.TextEditor` `initialValue` effect then dispatches `replaceSelection` into CodeMirror, and the operator sees the bio briefly revert.

This matches the diagnosis in closed issue #513 (`profile.data getting reset without getting new data beforehand`), with the extra detail that the visible mechanism is the `initialValue` → CodeMirror dispatch chain.

A secondary path exists via `UserProfileEditor.tsx`'s `createEffect(on(() => profile.data, ...))`: a post-save background refetch (triggered by `queryClient.setQueryData` + the WebSocket `UserUpdate` event) re-runs this effect and can clobber in-flight edits if the operator is still typing.

## Change

- `Form2.tsx`: remove the `onReset?.()` call from `useSubmitHandler`'s success branch. On a *successful* submit, the form's control values ARE the new server state — there is no need to fire the "discard changes" pathway. `onReset` continues to fire on the explicit discard path (e.g., `FormResetButton`).
- `UserProfileEditor.tsx`: add `if (editGroup.isDirty) return;` at the top of the `createEffect(on(() => profile.data, ...))` so an in-flight refetch can't clobber active user edits.

Effective code delta: **+2 / −1 lines**. The patch file is longer because of explanatory comments at each change site.

## Test plan

- Manual operator UAT in a self-hosted Stoat instance with a custom for-web image built from this branch (overlay pattern wrapping the upstream Dockerfile, ARM64).
- Verified: Save persists bio + icon + banner on **first click**; no visual revert; persists across browser reload AND across `docker compose restart web`.
- REST API cross-check (`GET /users/<id>/profile` against the bot) confirms server-side persistence matches the visible form.
- Adjacent forms exercised: all 5 settings-form `useSubmitHandler` call sites (`server/Overview`, `server/roles/ServerRoleEditor`, `server/emojis/EmojiList`, `channel/Overview`, `channel/webhooks/ViewWebhook`) still behave correctly post-submit; their `onReset` bodies all `setValue` from `props.X` (live mutable client store data already updated by the WS event), so re-running them post-save was redundant at best and stale at worst.
- The 20+ modal call sites in `components/modal/modals/*` do not pass `onReset`, so they are unaffected.
- No automated test suite for the Solid.js client code in this overlay; the change is small and the reasoning is well-defined, so the risk of regression in adjacent forms is low.

## Compatibility

Backward-compatible at the API surface. The semantic change is: `onReset` no longer fires after a *successful* submit. If any downstream form was relying on this side-effect for non-discard cleanup, it should move that logic into a post-`handler()` callback or similar — but this would have been a fragile design anyway (it was firing after every successful submit, regardless of intent, in addition to the explicit discard path).

## DCO

- Developer: `Signed-off-by: Orin <baileyorin@gmail.com>`
- Submitter: `Signed-off-by: Magiomakes <114195802+Magiomakes@users.noreply.github.com>`

## Notes

AI assistance (Claude Code) was used for initial investigation; the patch was reviewed and verified manually by the operator.
