### PR TITLE
chore: Separate markdown packages into a manual chunk

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -76,6 +76,21 @@ export default defineConfig({
     target: "esnext",
     rollupOptions: {
       external: ["hast"],
+      output: {
+        manualChunks: {
+          markdown: [
+            "lowlight",
+            "rehype-highlight",
+            "rehype-katex",
+            "remark-breaks",
+            "remark-gfm",
+            "remark-math",
+            "remark-parse",
+            "remark-rehype",
+            "vfile",
+          ],
+        },
+      },
     },
     sourcemap: true,
   },


### PR DESCRIPTION
The sound PR has brought the build artifact to over 4MB. Rather than increase the cachable size of the app, this PR creates a manual chunk of all of the markdown dependencies so they aren't output into the main build artifact. These dependencies are over 1.5MB by themselves, and they are all loaded in the markdown component.

## How was this PR tested?

Built it and used the app as normal

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1215 :point\_left:
