### PR TITLE
fix: Persist 'member' prop from preview card to full profile view

### DIFF
--- a/packages/client/components/modal/modals/UserProfile.tsx
+++ b/packages/client/components/modal/modals/UserProfile.tsx
@@ -27,6 +27,7 @@ export function UserProfileModal(
         <Profile.Banner
           width={3}
           user={props.user}
+          member={props.member}
           bannerUrl={query.data?.animatedBannerURL}
           onClick={
             query.data?.banner
@@ -43,11 +44,12 @@ export function UserProfileModal(
           }}
         />
 
-        <Profile.Actions user={props.user} width={3} />
+        <Profile.Actions user={props.user} member={props.member} width={3} />
+        <Profile.Roles member={props.member} />
         <Profile.Status user={props.user} />
         <Profile.Badges user={props.user} />
-        <Profile.Joined user={props.user} />
-        <Profile.Mutuals user={props.user} />
+        <Profile.Joined user={props.user} member={props.member} />
+        <Profile.Mutuals user={props.user} member={props.member} />
         <Profile.Bio content={query.data?.content} full />
       </Grid>
     </Dialog>

--- a/packages/client/components/modal/modals/UserProfileMutualFriends.tsx
+++ b/packages/client/components/modal/modals/UserProfileMutualFriends.tsx
@@ -24,7 +24,13 @@ export function UserProfileMutualFriendsModal(
         <For each={props.users}>
           {(user) => (
             <List.Item
-              onClick={() => openModal({ type: "user_profile", user })}
+              onClick={() =>
+                openModal({
+                  type: "user_profile",
+                  user,
+                  member: props.server?.getMember(user.id),
+                })
+              }
             >
               <Avatar
                 slot="icon"

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -282,6 +282,7 @@ export type Modals =
       user: User;
       isPlaceholder?: boolean;
       placeholderProfile?: API.UserProfile;
+      member?: ServerMember;
     }
   | {
       type: "user_profile_roles";
@@ -290,6 +291,7 @@ export type Modals =
   | {
       type: "user_profile_mutual_friends";
       users: User[];
+      server?: Server;
     }
   | {
       type: "user_profile_mutual_groups";

--- a/packages/client/components/ui/components/features/profiles/ProfileMutuals.tsx
+++ b/packages/client/components/ui/components/features/profiles/ProfileMutuals.tsx
@@ -1,7 +1,7 @@
 import { For, Show } from "solid-js";
 
 import { useQuery } from "@tanstack/solid-query";
-import { User } from "stoat.js";
+import { ServerMember, User } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
@@ -12,7 +12,7 @@ import { dismissFloatingElements } from "../../floating";
 
 import { ProfileCard } from "./ProfileCard";
 
-export function ProfileMutuals(props: { user: User }) {
+export function ProfileMutuals(props: { user: User; member?: ServerMember }) {
   const client = useClient();
   const { openModal } = useModals();
 
@@ -54,6 +54,7 @@ export function ProfileMutuals(props: { user: User }) {
     openModal({
       type: "user_profile_mutual_friends",
       users: query.data!.users,
+      server: props.member?.server,
     });
 
     dismissFloatingElements();

--- a/packages/client/components/ui/components/floating/UserCard.tsx
+++ b/packages/client/components/ui/components/floating/UserCard.tsx
@@ -40,7 +40,7 @@ export function UserCard(
   }));
 
   function openFull() {
-    openModal({ type: "user_profile", user: props.user });
+    openModal({ type: "user_profile", user: props.user, member: props.member });
     props.onClose();
   }
 


### PR DESCRIPTION
Fixes an inconsistency where the mini user card preview shows extra controls for users when in a server, but when opening the full profile view those controls disappear.

## How was this PR tested?

Opening user card preview, then full profile view on servers, in mutual friends list, in DMs, and in friends list

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

100% naturally Raichu-powered

- `main` <!-- branch-stack -->
  - \#1216 :point\_left:
