### PR TITLE
fix: Update resize observer implementation in VoiceCallCard

### DIFF
--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "solid-js";
 import { Portal } from "solid-js/web";
 
-import { makeResizeObserver } from "@solid-primitives/resize-observer";
+import {createResizeObserver, makeResizeObserver } from "@solid-primitives/resize-observer";
 import { Channel } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
@@ -198,14 +198,13 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
 
   createEffect(updateInfo);
 
-  //Observe resize of parent
-  let obs: ReturnType<typeof makeResizeObserver>;
   onMount(() => {
-    obs = makeResizeObserver(updateInfo);
-    obs.observe(ref!.parentElement!);
+    const target = ref?.parentElement;
+    if (!target) return;
+
+    createResizeObserver(target, updateInfo);
   });
   onCleanup(() => {
-    obs.unobserve(ref!.parentElement!);
     setInfo();
   });
 

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "solid-js";
 import { Portal } from "solid-js/web";
 
-import {createResizeObserver, makeResizeObserver } from "@solid-primitives/resize-observer";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 import { Channel } from "stoat.js";
 import { styled } from "styled-system/jsx";
 


### PR DESCRIPTION
<!-- Describe your changes -->

onCleanup ran before onMount causing obs to be undefined and crashing the entire client, createResizeObserver implements it's own clean up see [here](https://github.com/solidjs-community/solid-primitives/blob/main/packages/resize-observer/src/index.ts) using the function instead of manually cleaning it fixes this issue
Fixes # (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Wasn't able to open up any channels before, this fixed it

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None used

- `main` <!-- branch-stack -->
  - \#1218 :point\_left:
