### PR TITLE
fix: Don't show video option if video is off

### DIFF
--- a/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
+++ b/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
@@ -1,8 +1,9 @@
-import { createMemo } from "solid-js";
+import { createMemo, Show } from "solid-js";
 import { useMediaDeviceSelect } from "solid-livekit-components";
 
 import { Trans } from "@lingui-solid/solid/macro";
 
+import { CONFIGURATION } from "@revolt/common";
 import { useState } from "@revolt/state";
 import {
   CategoryButton,
@@ -22,7 +23,9 @@ export function VoiceInputOptions() {
       <CategoryButton.Group>
         <SelectInput kind="audioinput" />
         <SelectInput kind="audiooutput" />
-        <SelectInput kind="videoinput" />
+        <Show when={CONFIGURATION.ENABLE_VIDEO}>
+          <SelectInput kind="videoinput" />
+        </Show>
       </CategoryButton.Group>
       <VolumeSliders />
     </Column>


### PR DESCRIPTION
Fixes the video option showing up if video is off

## How was this PR tested?

Tested launching in dev with and without video flag

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1219 :point\_left:
