### PR TITLE
fix: Fix regression for member side bar caching

### DIFF
--- a/packages/client/src/interface/channels/text/MemberSidebar.tsx
+++ b/packages/client/src/interface/channels/text/MemberSidebar.tsx
@@ -207,7 +207,9 @@ export function ServerMemberSidebar(props: Props) {
       }
 
       for (const member of role.members) {
-        const memberElement = objectCache.get(member.id.user);
+        const memberElement = objectCache.get(
+          `${member.id.server}-${member.id.user}`,
+        );
         if (memberElement) {
           elements.push(memberElement);
         } else {
@@ -227,7 +229,10 @@ export function ServerMemberSidebar(props: Props) {
       if (element.t === 0) {
         objectCache.set(element.name + element.count, element);
       } else {
-        objectCache.set(element.member.id.user, element);
+        objectCache.set(
+          `${element.member.id.server}-${element.member.id.user}`,
+          element,
+        );
       }
     }
 


### PR DESCRIPTION
Fixes member sidebar regression introduced in #1202

## How was this PR tested?

Flip flopped between lounge and dev stoat. Before fixing, my role would persist as the first server's role. After fixing, my role updates correctly.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1220 :point\_left:
