### PR TITLE
feat: add gif providers regex to detect gif providers

### DIFF
--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -1,7 +1,11 @@
 import { For, Match, Show, Switch, createSignal, onMount } from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
-import { Message as MessageInterface, WebsiteEmbed } from "stoat.js";
+import {
+  ImageEmbed,
+  Message as MessageInterface,
+  WebsiteEmbed,
+} from "stoat.js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 import { decodeTime } from "ulid";
@@ -37,6 +41,11 @@ import { EditMessage } from "./EditMessage";
  */
 const RE_URL =
   /[(http(s)?)://(www.)?a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
+
+/**
+ * Regex for matching gif providers
+ */
+const GIF_PROVIDERS_REGEX = /^https:\/\/(tenor\.com|gifbox\.me|giphy\.com)/;
 
 interface Props {
   /**
@@ -82,11 +91,17 @@ export function Message(props: Props) {
   const isOnlyGIF = () =>
     props.message.embeds &&
     props.message.embeds.length === 1 &&
-    props.message.embeds[0].type === "Website" &&
-    ((props.message.embeds[0] as WebsiteEmbed).specialContent?.type === "GIF" ||
-      (props.message.embeds[0] as WebsiteEmbed).originalUrl?.startsWith(
-        "https://tenor.com",
-      )) &&
+    ((props.message.embeds[0].type === "Website" &&
+      ((props.message.embeds[0] as WebsiteEmbed).specialContent?.type ===
+        "GIF" ||
+        !!(
+          (props.message.embeds[0] as WebsiteEmbed).originalUrl ||
+          (props.message.embeds[0] as WebsiteEmbed).url
+        )?.match(GIF_PROVIDERS_REGEX))) ||
+      (props.message.embeds[0].type === "Image" &&
+        !!(props.message.embeds[0] as ImageEmbed).url?.match(
+          GIF_PROVIDERS_REGEX,
+        ))) &&
     props.message.content &&
     !props.message.content.replace(RE_URL, "").length;
 


### PR DESCRIPTION
<!-- Describe your changes -->

Adds a regex to detect multiple providers to render them properly
Fixes # (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Sent a gifbox only link to see if it showed up

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None used

- `main` <!-- branch-stack -->
  - \#1243 :point\_left:
