### PR TITLE
fix: add missing onSuccess to DeleteRole.tsx

### DIFF
--- a/packages/client/components/modal/modals/DeleteRole.tsx
+++ b/packages/client/components/modal/modals/DeleteRole.tsx
@@ -17,6 +17,7 @@ export function DeleteRoleModal(
   const deleteRole = useMutation(() => ({
     mutationFn: () => props.role.delete(),
     onError: showError,
+    onSuccess: () => props.cb(),
   }));
 
   return (


### PR DESCRIPTION
This PR adds the missing onSuccess to DeleteRole.tsx. Now successfully pushes the user back to the main roles window.

Fixes #1137 

## How was this PR tested?

Locally tested via making a role called "Test" and deleting it.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
