### PR TITLE
fix: prevent all invites from disappearing on deletion

### DIFF
--- a/packages/client/components/app/interface/settings/server/invites/ListServerInvites.tsx
+++ b/packages/client/components/app/interface/settings/server/invites/ListServerInvites.tsx
@@ -37,7 +37,7 @@ export function ListServerInvites(props: { server: Server }) {
       await invite.delete();
       client.setQueryData(
         ["invites", props.server.id],
-        query.data!.filter((entry) => entry.id !== entry.id),
+        query.data!.filter((entry) => entry.id !== invite.id),
       );
     } catch (error) {
       showError(error);


### PR DESCRIPTION
Fixes an error in deleteInvite where entry.id was compared against itself, resulting in an empty array after deleting any invite.

Fixes #763 

## How was this PR tested?

Tested locally via deleting an invite in a server.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
