### PR TITLE
feat: implement server sidebar in EmojiPicker

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
@@ -103,9 +103,7 @@ function Picker(
     middleware: [offset(5), flip(), shift()],
   });
 
-  function onMouseDown(e: MouseEvent) {
-    if (floating()?.contains(e.target as Node)) return;
-
+  function onMouseDown() {
     props.setShow();
   }
 

--- a/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
@@ -103,7 +103,9 @@ function Picker(
     middleware: [offset(5), flip(), shift()],
   });
 
-  function onMouseDown() {
+  function onMouseDown(e: MouseEvent) {
+    if (floating()?.contains(e.target as Node)) return;
+
     props.setShow();
   }
 

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -63,7 +63,7 @@ type Item =
       text: string;
     };
 
-const COLUMNS = 9;
+const COLUMNS = 10;
 
 export function EmojiPicker() {
   const client = useClient();
@@ -176,7 +176,7 @@ export function EmojiPicker() {
                   );
                   if (idx !== -1 && emojiScrollTargetElement) {
                     emojiScrollTargetElement.scrollTop =
-                      Math.floor(idx / COLUMNS) * 40;
+                      Math.floor(idx / COLUMNS) * 35;
                   }
                 }}
               />
@@ -192,7 +192,7 @@ export function EmojiPicker() {
           <VirtualContainer
             items={items()}
             scrollTarget={emojiScrollTargetElement}
-            itemSize={{ height: 40, width: 40 }}
+            itemSize={{ height: 35, width: 35 }}
             crossAxisCount={() => COLUMNS}
           >
             {EmojiItem}
@@ -208,6 +208,7 @@ const Stack = styled("div", {
     minHeight: 0,
     display: "flex",
     flexDirection: "column",
+    gap: "var(--gap-md)",
   },
 });
 
@@ -219,8 +220,9 @@ const scrollContainer = cva({
         display: "flex",
         flexDirection: "column",
         flexShrink: 0,
-        width: "40px",
+        width: "44px",
         gap: "var(--gap-sm)",
+        paddingLeft: "4px",
       },
       emoji: {
         flexGrow: 1,
@@ -256,6 +258,8 @@ const ServerOption = styled("div", {
   base: {
     width: "100%",
     cursor: "pointer",
+    display: "flex",
+    justifyContent: "center",
   },
 });
 

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -349,6 +349,9 @@ const EmojiOption = styled("div", {
         "& img": {
           width: "100%",
           height: "100%",
+          maxHeight: "32px",
+          maxWidth: "32px",
+          margin: "auto",
           objectFit: "contain",
         },
       },

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -63,7 +63,7 @@ type Item =
       text: string;
     };
 
-const COLUMNS = 10;
+const COLUMNS = 9;
 
 export function EmojiPicker() {
   const client = useClient();
@@ -159,11 +159,28 @@ export function EmojiPicker() {
           }}
         >
           <VirtualContainer
-            items={[1, 2, 3]}
+            items={state.ordering
+              .orderedServers(client())
+              .filter((s) => s.emojis.length > 0)}
             scrollTarget={serverScrollTargetElement}
             itemSize={{ height: 40 }}
           >
-            {ServerItem}
+            {(props) => (
+              <ServerItem
+                style={props.style}
+                tabIndex={props.tabIndex}
+                item={props.item}
+                onClick={() => {
+                  const idx = items().findIndex(
+                    (item) => item.t === 0 && item.server.id === props.item.id,
+                  );
+                  if (idx !== -1 && emojiScrollTargetElement) {
+                    emojiScrollTargetElement.scrollTop =
+                      Math.floor(idx / COLUMNS) * 40;
+                  }
+                }}
+              />
+            )}
           </VirtualContainer>
         </div>
         <div
@@ -176,11 +193,7 @@ export function EmojiPicker() {
             items={items()}
             scrollTarget={emojiScrollTargetElement}
             itemSize={{ height: 40, width: 40 }}
-            crossAxisCount={(measurements) =>
-              Math.floor(
-                measurements.container.cross / measurements.itemSize.cross,
-              )
-            }
+            crossAxisCount={() => COLUMNS}
           >
             {EmojiItem}
           </VirtualContainer>
@@ -203,9 +216,11 @@ const scrollContainer = cva({
   variants: {
     component: {
       serverRail: {
-        display: "none",
-        // flexShrink: 0,
-        // width: "40px",
+        display: "flex",
+        flexDirection: "column",
+        flexShrink: 0,
+        width: "40px",
+        gap: "var(--gap-sm)",
       },
       emoji: {
         flexGrow: 1,
@@ -217,20 +232,30 @@ const scrollContainer = cva({
 const ServerItem = (props: {
   style: unknown;
   tabIndex: number;
-  item: number;
+  item: Server;
+  onClick: (e: MouseEvent) => void;
 }) => (
   <ServerOption
     style={props.style as never}
     tabIndex={props.tabIndex}
     role="listitem"
+    onClick={(e) => {
+      e.stopPropagation();
+      props.onClick(e);
+    }}
   >
-    {props.item}
+    <Avatar
+      size={32}
+      src={props.item.animatedIconURL}
+      fallback={props.item.name}
+    />
   </ServerOption>
 );
 
 const ServerOption = styled("div", {
   base: {
     width: "100%",
+    cursor: "pointer",
   },
 });
 
@@ -298,10 +323,13 @@ const EmojiOption = styled("div", {
     {
       type: [0, 3],
       css: {
+        position: "absolute",
+        left: 0,
+        width: "100% !important",
         display: "flex",
         alignItems: "center",
         paddingInline: "var(--gap-md)",
-        width: `calc(40px * ${COLUMNS}) !important`,
+        zIndex: 1,
       },
     },
     {
@@ -314,7 +342,6 @@ const EmojiOption = styled("div", {
         borderRadius: "var(--borderRadius-sm)",
 
         "--emoji-size": "100%",
-
         "& img": {
           width: "100%",
           height: "100%",

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -63,7 +63,7 @@ type Item =
       text: string;
     };
 
-const COLUMNS = 10;
+const COLUMNS = 8;
 
 export function EmojiPicker() {
   const client = useClient();
@@ -192,7 +192,7 @@ export function EmojiPicker() {
           <VirtualContainer
             items={items()}
             scrollTarget={emojiScrollTargetElement}
-            itemSize={{ height: 35, width: 35 }}
+            itemSize={{ height: 42, width: 42 }}
             crossAxisCount={() => COLUMNS}
           >
             {EmojiItem}

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -141,7 +141,7 @@ export function EmojiPicker() {
     <Stack>
       <TextField
         autoFocus
-        variant="filled"
+        variant="outlined"
         placeholder="Search for emojis..."
         value={filter()}
         onMouseDown={(e) => {
@@ -241,10 +241,12 @@ const ServerItem = (props: {
     style={props.style as never}
     tabIndex={props.tabIndex}
     role="listitem"
-    onClick={(e) => {
+    onMouseDown={(e) => {
+      e.preventDefault();
       e.stopPropagation();
-      props.onClick(e);
+      e.stopImmediatePropagation();
     }}
+    onClick={props.onClick}
   >
     <Avatar
       size={32}

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -63,11 +63,11 @@ type Item =
       text: string;
     };
 
-const COLUMNS = 8;
+const COLUMNS = 9;
 
 export function EmojiPicker() {
   const client = useClient();
-  const state = useState();
+  const { ordering } = useState();
 
   const [filter, setFilter] = createSignal("");
 
@@ -79,7 +79,7 @@ export function EmojiPicker() {
 
     if (filterText) {
       return [
-        ...state.ordering
+        ...ordering
           .orderedServers(client())
           .flatMap((server) =>
             server.emojis
@@ -94,7 +94,7 @@ export function EmojiPicker() {
 
     const items: Item[] = [];
 
-    for (const server of state.ordering.orderedServers(client())) {
+    for (const server of ordering.orderedServers(client())) {
       const emojis = server.emojis;
 
       if (emojis.length === 0) continue;
@@ -151,7 +151,7 @@ export function EmojiPicker() {
         }}
         onInput={(e) => setFilter(e.currentTarget.value)}
       />
-      <Row class={compositionContent()}>
+      <Row gap={"none"} class={compositionContent()}>
         <div
           ref={serverScrollTargetElement}
           use:invisibleScrollable={{
@@ -159,7 +159,7 @@ export function EmojiPicker() {
           }}
         >
           <VirtualContainer
-            items={state.ordering
+            items={ordering
               .orderedServers(client())
               .filter((s) => s.emojis.length > 0)}
             scrollTarget={serverScrollTargetElement}
@@ -176,7 +176,7 @@ export function EmojiPicker() {
                   );
                   if (idx !== -1 && emojiScrollTargetElement) {
                     emojiScrollTargetElement.scrollTop =
-                      Math.floor(idx / COLUMNS) * 35;
+                      Math.floor(idx / COLUMNS) * 40;
                   }
                 }}
               />
@@ -192,7 +192,7 @@ export function EmojiPicker() {
           <VirtualContainer
             items={items()}
             scrollTarget={emojiScrollTargetElement}
-            itemSize={{ height: 42, width: 42 }}
+            itemSize={{ height: 40, width: 40 }}
             crossAxisCount={() => COLUMNS}
           >
             {EmojiItem}
@@ -220,9 +220,8 @@ const scrollContainer = cva({
         display: "flex",
         flexDirection: "column",
         flexShrink: 0,
-        width: "44px",
+        width: "40px",
         gap: "var(--gap-sm)",
-        paddingLeft: "4px",
       },
       emoji: {
         flexGrow: 1,
@@ -351,9 +350,6 @@ const EmojiOption = styled("div", {
         "& img": {
           width: "100%",
           height: "100%",
-          maxHeight: "32px",
-          maxWidth: "32px",
-          margin: "auto",
           objectFit: "contain",
         },
       },


### PR DESCRIPTION
Uses the non-functional server sidebar, and makes it functional.

- Changed the section headers `(type: [0, 3])` to use `position: "absolute"` and `width: "100%"`. Without this, the virtualizer kept trying to treat the headers like emojis (lol)
- crossAxisCount needed to change or else everything rendered off-centre. Column's being ten didn't fit correctly (honestly, could work better as `const COLUMNS = 8;`
- `CompositionMediaPicker.tsx` change was needed to prevent the window closing when selecting a server
    - Similiar changes to prevent window closing were made on `L:242`
    ```ts
        onClick={(e) => {
      e.stopPropagation();
      props.onClick(e);
    }}
    ```
     

Closes #979 

## How was this PR tested?



<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

https://github.com/user-attachments/assets/86e6b291-df8e-4667-9881-90f58e5288e7

</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
