### PR TITLE
fix: Force touch keyboard to resize content window on mobile

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, interactive-widget=resizes-content">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="theme-color" content="#000000">
     <link
       rel="shortcut icon"

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -1,13 +1,10 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, user-scalable=no"
-    />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="theme-color" content="#000000" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, interactive-widget=resizes-content">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#000000">
     <link
       rel="shortcut icon"
       type="image/png"
@@ -19,7 +16,6 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <div id="floating"></div>
-
     <script src="/src/index.tsx" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
Split off from #835

- Replace deprecated meta 'apple-mobile-web-app-capable' with 'mobile-web-app-capable'
- Viewport interactive-widget specifier to force keyboard to resize content window instead of awkwardly panning it

## How was this PR tested?

Tested as part of PR 835's testing.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
Before & After TODO
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

I'm here to chew gum and displace LLM's jobs, and I'm all outta gum

- `main` <!-- branch-stack -->
  - \#1253 :point\_left:
