### PR TITLE
fix: use correct length check for mutual groups

### DIFF
--- a/packages/client/components/ui/components/features/profiles/ProfileMutuals.tsx
+++ b/packages/client/components/ui/components/features/profiles/ProfileMutuals.tsx
@@ -88,7 +88,7 @@ export function ProfileMutuals(props: { user: User }) {
           </Grid>
         </ProfileCard>
       </Show>
-      <Show when={query.data?.users.length}>
+      <Show when={query.data?.groups.length}>
         <ProfileCard isLink onClick={openGroups}>
           <Ripple />
 


### PR DESCRIPTION
Fixes an incorrect length check where `users.length` was used instead of the correct `groups.length`, resulting in a lack of any mutual groups displaying if you have no mutual friends.

Noticed this issue when helping someone in support finding mutuals :P

## How was this PR tested?

Tested on localhost


## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
