### PR TITLE
fix: stop system messages from being reportable

### DIFF
--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -254,7 +254,9 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
             <Trans>Delete message</Trans>
           </ContextMenuButton>
         </Show>
-        <Show when={!props.message!.author?.self}>
+        <Show
+          when={!props.message!.author?.self && !props.message!.systemMessage}
+        >
           <ContextMenuButton icon={MdReport} onClick={report} destructive>
             <Trans>Report message</Trans>
           </ContextMenuButton>


### PR DESCRIPTION
Stops system messages (welcome messages, pins, etc.) from being reportable in the context menu. 

## How was this PR tested?

Tested locally to assure It's **only** system messages that get affected, and that other behaviour works as expected.

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
