### PR TITLE
fix: message replies with attachments

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
@@ -95,6 +95,7 @@ const Attachments = styled("em", {
  */
 const Link = styled("a", {
   base: {
+    display: "flex",
     minWidth: 0,
     alignItems: "center",
     gap: "var(--gap-md)",


### PR DESCRIPTION
Fixes the misalignment when an attachment was in reply. Noticed It was pointed out in stoat dev and thought I'd take a quick peep when I got out of bed :P

Fixes #1241 

## How was this PR tested?

Tested locally made sure It doesn't screw with normal replies.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<img width="400" height="71" alt="image" src="https://github.com/user-attachments/assets/54974ac1-5caf-4557-8a59-d27cfe595106" />

</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
