### PR TITLE
feat: make AUP more obviously clickable

### DIFF
--- a/packages/client/components/modal/modals/CreateBot.tsx
+++ b/packages/client/components/modal/modals/CreateBot.tsx
@@ -58,7 +58,14 @@ export function CreateBotModal(
           <Text>
             <Trans>
               By creating this bot, you agree to the{" "}
-              <a href="https://stoat.chat/aup" target="_blank" rel="noreferrer">
+              <a
+                href="https://stoat.chat/aup"
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  color: "var(--md-sys-color-primary",
+                }}
+              >
                 <Trans>Acceptable Use Policy</Trans>
               </a>
               .

--- a/packages/client/components/modal/modals/CreateServer.tsx
+++ b/packages/client/components/modal/modals/CreateServer.tsx
@@ -60,7 +60,14 @@ export function CreateServerModal(
           <Text>
             <Trans>
               By creating this server, you agree to the{" "}
-              <a href="https://stoat.chat/aup" target="_blank" rel="noreferrer">
+              <a
+                href="https://stoat.chat/aup"
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  color: "var(--md-sys-color-primary",
+                }}
+              >
                 <Trans>Acceptable Use Policy</Trans>
               </a>
               .


### PR DESCRIPTION
Makes the "Acceptable Use Policy" more noticeable, as previously it was the same colour as the text. Which made it hard to tell It was something you can click.

## How was this PR tested?

Tested locally 

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Before:
<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/74b35333-7f64-4ffd-b641-3aebe9e768cd" />

After:
<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/7184ddd0-7b52-4a4b-b1ff-8923523da56a" />


</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
