### PR TITLE
feat: add NFKC normalization to autocomplete

### DIFF
--- a/packages/client/components/ui/components/features/texteditor/codeMirrorAutoCompleteSource.ts
+++ b/packages/client/components/ui/components/features/texteditor/codeMirrorAutoCompleteSource.ts
@@ -71,7 +71,7 @@ export function codeMirrorAutoCompleteSource(
 
       return {
         type: "user",
-        label: "@" + entry.displayName,
+        label: ("@" + entry.displayName).normalize("NFKC"),
         displayLabel: entry.displayName,
         detail:
           entry.displayName !== user.username
@@ -89,7 +89,7 @@ export function codeMirrorAutoCompleteSource(
         (entry) =>
           ({
             type: "role",
-            label: "%" + entry.name,
+            label: ("%" + entry.name).normalize("NFKC"),
             displayLabel: entry.name,
             apply: `<%${entry.id}> `,
             colour: entry.colour,
@@ -103,7 +103,8 @@ export function codeMirrorAutoCompleteSource(
       (entry) =>
         ({
           type: "channel",
-          label: "#" + entry.name,
+          label: ("#" + entry.name).normalize("NFKC"),
+          displayLabel: "#" + entry.name,
           apply: `<#${entry.id}> `,
         }) as Completion,
     ),
@@ -116,7 +117,9 @@ export function codeMirrorAutoCompleteSource(
     }
 
     const token = context.matchBefore(RE_match);
-    switch (token?.text[0]) {
+    if (!token) return null;
+    const normalizedText = token.text.normalize("NFKC");
+    switch (normalizedText[0]) {
       case ":":
         return {
           from: token.from,


### PR DESCRIPTION
Adds NFKC normalization to autocomplete, so things such as "𝑨𝒔𝒓𝒂𝒚𝒆" will show up in user mentions, or "𝑪𝒉𝒆𝒆𝒔𝒆" in channel/role mentions.

We only have to normalize the `label`, we keep display label as the formatted text as It gives a better user-feedback. 

<details><summary><h4> What Is NFKC? </h4></summary>
Thought I'd add this section, as a lot of people don't know the beautiful thing of NFKC!

NFKC stands for "Normalization Form Compatibility Composition". It's an unicode normalization form that converts text into a standardized representation by applying compatibility mappings and then recomposing characters where possible :P

This is good as it means that many accented or otherwise stylized unicode characters are converted into more standard equivalents, for example: `𝑪𝒉𝒆𝒆𝒔𝒆` becomes `Cheese` and `①` becomes `1`

We can use NFKC here as it helps autocomplete work more consistently with accented or stylized text. Compared to NFC (Normalization Form Canonical Composition), NFKC is more aggressive and normalizes a wider range of visually similar characters, which is better suited for this usage.

</details>


## How was this PR tested?

Tested locally with all autocompletes.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<img width="217" height="132" alt="image" src="https://github.com/user-attachments/assets/88e0a799-0125-4b1a-975d-a45ec1376575" />
<img width="254" height="130" alt="image" src="https://github.com/user-attachments/assets/d6105ebf-dfb3-49fc-9d6c-273d244f4a9a" />
<img width="266" height="159" alt="image" src="https://github.com/user-attachments/assets/2333ab3b-6aca-4e83-975a-2c317fd9ef1f" />


</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
