### PR TITLE
fix: use u200B instead of uF800

### DIFF
--- a/packages/client/components/markdown/sanitise.ts
+++ b/packages/client/components/markdown/sanitise.ts
@@ -28,7 +28,7 @@ const RE_PLUS = /^\s*\+(?:$|[^+])/gm;
  * Regex for matching non-breaking spaces in code blocks
  */
 const RE_CODEBLOCK_EMPTY_LINE_FIX =
-  /(?<=`{3}[\s\S]*)\n\uF800\n(?=[\s\S]*`{3})/gm;
+  /(?<=`{3}[\s\S]*)\n\u200B\n(?=[\s\S]*`{3})/gm;
 
 /**
  * Sanitise Markdown input before rendering
@@ -44,17 +44,17 @@ export function sanitise(content: string) {
       // Append empty character if string starts with html tag
       // This is to avoid inconsistencies in rendering Markdown inside/after HTML tags
       // https://github.com/revoltchat/revite/issues/733
-      .replace(RE_HTML_TAGS, (match) => `\uF800${match}`)
+      .replace(RE_HTML_TAGS, (match) => `\u200B${match}`)
 
       // Append empty character if line starts with a plus
       // which would usually open a new list but we want
       // to avoid that behaviour in our case.
-      .replace(RE_PLUS, (match) => `\uF800${match}`)
+      .replace(RE_PLUS, (match) => `\u200B${match}`)
 
       // Replace empty lines with non-breaking space
       // because remark renderer is collapsing empty
       // or otherwise whitespace-only lines of text
-      .replace(RE_EMPTY_LINE, "\n\uF800\n")
+      .replace(RE_EMPTY_LINE, "\n\u200B\n")
 
       // Reverts previous empty line operation specifically for codeblocks.
       // Hacky solution, I know, but so far I haven't found a more elegant
@@ -67,7 +67,7 @@ export function sanitise(content: string) {
 }
 
 /**
- * Replace \uF800 with break elements
+ * Replace \u200B with break elements
  */
 export function remarkInsertBreaks() {
   return (tree: import("hast").Root) => {
@@ -80,7 +80,7 @@ export function remarkInsertBreaks() {
       element: Record<string, unknown> & { children: unknown[] },
     ): unknown {
       if (element.type === "text") {
-        if (element.value === "\uF800") {
+        if (element.value === "\u200B") {
           return {
             type: "element",
             tagName: "br",


### PR DESCRIPTION
Swaps to `u200B` instead of `uF800` for sanitization. `uF800` isn't rendered by the majority of browsers and can cause some rendering weirdness when used (e.g. showing up as a glyph). This PR switches it to `u200B`, which is the more commonly used zero-width character and is generally handled cleanly without any rendering issues.

## How was this PR tested?

Tested all other markdowns to make sure formatting isn't broken, and remains as expected.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Before:
<img width="256" height="120" alt="image" src="https://github.com/user-attachments/assets/9a3540cd-12f7-4c3e-8183-c1060eb9c1f4" />
<br />
After:
<img width="256" height="120" alt="image" src="https://github.com/user-attachments/assets/4ce0c3a6-c1a5-4f29-9dd7-17317078233f" />

</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
