### PR TITLE
feat: pin message modal

### DIFF
--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -88,6 +88,24 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
   }
 
   /**
+   * Pin/unpin the message
+   */
+  function pinMessage(ev: MouseEvent) {
+    if (ev.shiftKey) {
+      if (props.message!.pinned) {
+        props.message!.unpin().catch(showError);
+      } else {
+        props.message!.pin().catch(showError);
+      }
+    } else {
+      openModal({
+        type: "pin_message",
+        message: props.message!,
+      });
+    }
+  }
+
+  /**
    * Open message in Stoat Admin Panel
    */
   function openAdminPanel() {
@@ -182,16 +200,7 @@ export function MessageContextMenu(props: { message?: Message; file?: File }) {
             props.message!.channel?.havePermission("ManageMessages")
           }
         >
-          <ContextMenuButton
-            icon={MdPin}
-            onClick={() => {
-              if (props.message!.pinned) {
-                props.message!.unpin().catch(showError);
-              } else {
-                props.message!.pin().catch(showError);
-              }
-            }}
-          >
+          <ContextMenuButton icon={MdPin} onClick={pinMessage}>
             <Switch fallback={<Trans>Pin message</Trans>}>
               <Match when={props.message!.pinned}>
                 <Trans>Unpin message</Trans>

--- a/packages/client/components/modal/modals.tsx
+++ b/packages/client/components/modal/modals.tsx
@@ -60,6 +60,7 @@ import { UserProfileModal } from "./modals/UserProfile";
 import { UserProfileMutualFriendsModal } from "./modals/UserProfileMutualFriends";
 import { UserProfileMutualGroupsModal } from "./modals/UserProfileMutualGroups";
 import { UserProfileRolesModal } from "./modals/UserProfileRoles";
+import { PinMessageModal } from "./modals/PinMessage";
 
 /**
  * Render the modal
@@ -188,6 +189,8 @@ export function RenderModal(props: ActiveModal & { onClose: () => void }) {
       return <EditCategoryModal {...modalProps} />;
     case "remove_member":
       return <RemoveMemberModal {...modalProps} />;
+    case "pin_message":
+      return <PinMessageModal {...modalProps} />;
 
     case "screen_share_settings":
       return <ScreenShareSettingsModal {...modalProps} />;

--- a/packages/client/components/modal/modals.tsx
+++ b/packages/client/components/modal/modals.tsx
@@ -44,6 +44,7 @@ import { MFAEnableTOTPModal } from "./modals/MFAEnableTOTP";
 import { MFAFlowModal } from "./modals/MFAFlow";
 import { MFARecoveryModal } from "./modals/MFARecovery";
 import { OnboardingModal } from "./modals/Onboarding";
+import { PinMessageModal } from "./modals/PinMessage";
 import { PolicyChangeModal } from "./modals/PolicyChange";
 import { RemoveMemberModal } from "./modals/RemoveMember";
 import { RenameSessionModal } from "./modals/RenameSession";
@@ -60,7 +61,6 @@ import { UserProfileModal } from "./modals/UserProfile";
 import { UserProfileMutualFriendsModal } from "./modals/UserProfileMutualFriends";
 import { UserProfileMutualGroupsModal } from "./modals/UserProfileMutualGroups";
 import { UserProfileRolesModal } from "./modals/UserProfileRoles";
-import { PinMessageModal } from "./modals/PinMessage";
 
 /**
  * Render the modal

--- a/packages/client/components/modal/modals/PinMessage.tsx
+++ b/packages/client/components/modal/modals/PinMessage.tsx
@@ -1,0 +1,49 @@
+import { Trans } from "@lingui-solid/solid/macro";
+import { useMutation } from "@tanstack/solid-query";
+
+import { Dialog, DialogProps } from "@revolt/ui";
+
+import { useModals } from "..";
+import { Modals } from "../types";
+
+/**
+ * Modal to pin or unpin a message
+ */
+export function PinMessageModal(
+  props: DialogProps & Modals & { type: "pin_message" },
+) {
+  const { showError } = useModals();
+
+  const isPinned = () => props.message.pinned;
+
+  const togglePin = useMutation(() => ({
+    mutationFn: () =>
+      isPinned() ? props.message.unpin() : props.message.pin(),
+    onError: showError,
+    onSuccess: () => props.onClose(),
+  }));
+
+  return (
+    <Dialog
+      show={props.show}
+      onClose={props.onClose}
+      title={
+        isPinned() ? <Trans>Unpin message</Trans> : <Trans>Pin message</Trans>
+      }
+      actions={[
+        { text: <Trans>Cancel</Trans> },
+        {
+          text: isPinned() ? <Trans>Unpin</Trans> : <Trans>Pin</Trans>,
+          onClick: () => togglePin.mutateAsync(),
+        },
+      ]}
+      isDisabled={togglePin.isPending}
+    >
+      {isPinned() ? (
+        <Trans>Are you sure you want to unpin this message?</Trans>
+      ) : (
+        <Trans>Are you sure you want to pin this message?</Trans>
+      )}
+    </Dialog>
+  );
+}

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -128,6 +128,10 @@ export type Modals =
       message: Message;
     }
   | {
+      type: "pin_message";
+      message: Message;
+    }
+  | {
       type: "delete_server";
       server: Server;
     }


### PR DESCRIPTION
Adds a modal for the pin/unpin message, based on the delete message modal.

## How was this PR tested?

Tested locally with pinning/unpinning. As well as shift pin/unpin

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<img width="292" height="170" alt="image" src="https://github.com/user-attachments/assets/ac8af8f4-a2d7-4947-adce-429d57bb3f7e" />

</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None
...
