### PR TITLE
feat: shift click to quick mention a user

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -19,7 +19,6 @@ Context menu needs to be more broadly available (in interface package?)
 - style the user card
 - not sure whether to polish up all message components
 - fix all the auth flows
-- shift + click mention user
 
 # Done
 
@@ -39,6 +38,7 @@ Context menu needs to be more broadly available (in interface package?)
 - Modals "delete X", "leave server", "delete channel"
 - Fix colours for offline members in list
 - Fix colours for hovering / mentions messages in chat
+- shift + click mention user
 
 BUGS:
 

--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -109,6 +109,7 @@ export function Message(props: Props) {
       username={
         <div use:floating={floatingUserMenusFromMessage(props.message)}>
           <Username
+            userId={props.message.authorId}
             username={
               props.message.masquerade?.name ??
               props.message.member?.nickname ??

--- a/packages/client/components/state/stores/Draft.ts
+++ b/packages/client/components/state/stores/Draft.ts
@@ -115,6 +115,11 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
   _setNodeReplacement?: Setter<readonly [string | "_focus"] | undefined>;
 
   /**
+   * Method to safely append a mention
+   */
+  _appendMention?: (mentionText: string) => void;
+
+  /**
    * Construct store
    * @param state State
    */

--- a/packages/client/components/ui/components/features/legacy/Username.tsx
+++ b/packages/client/components/ui/components/features/legacy/Username.tsx
@@ -2,13 +2,16 @@ import { splitProps } from "solid-js";
 
 import { typography } from "../../design/Text";
 import { ColouredText } from "../../utils/ColouredText";
-
+import { useState } from "@revolt/state";
 type Props = {
   /**
    * Username
    */
   username?: string;
-
+  /**
+   * User ID
+   */
+  userId?: string;
   /**
    * Text colour
    */
@@ -18,13 +21,36 @@ type Props = {
 /**
  * Username
  *
- * @deprecated this seems unideal
  */
 export function Username(props: Props) {
-  const [local, remote] = splitProps(props, ["username", "colour"]);
+  const [local, remote] = splitProps(props, ["username", "colour", "userId"]);
+  const state = useState();
 
   return (
-    <span {...remote} class={typography({ class: "label", size: "large" })}>
+    <span
+      {...remote}
+      class={typography({ class: "label", size: "large" })}
+      style={{ cursor: "pointer", "user-select": "none" }}
+      on:pointerdown={(e) => {
+        if (e.shiftKey) {
+          e.stopPropagation();
+        }
+      }}
+      on:click={(e) => {
+        if (e.shiftKey) {
+          e.preventDefault();
+          e.stopPropagation();
+
+          if (local.userId) {
+            const mentionText = `<@${local.userId}> `;
+
+            if (typeof state.draft._appendMention === "function") {
+              state.draft._appendMention(mentionText);
+            }
+          }
+        }
+      }}
+    >
       <ColouredText colour={local.colour!}>{local.username}</ColouredText>
     </span>
   );

--- a/packages/client/components/ui/components/features/legacy/Username.tsx
+++ b/packages/client/components/ui/components/features/legacy/Username.tsx
@@ -1,8 +1,8 @@
 import { splitProps } from "solid-js";
 
+import { useState } from "@revolt/state";
 import { typography } from "../../design/Text";
 import { ColouredText } from "../../utils/ColouredText";
-import { useState } from "@revolt/state";
 type Props = {
   /**
    * Username

--- a/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
@@ -129,6 +129,7 @@ export function MessageReply(props: Props) {
             <NonBreakingText>
               <Username
                 colour={props.message!.roleColour!}
+                userId={props.message.authorId}
                 username={(props.mention ? "@" : "") + props.message!.username}
               />
             </NonBreakingText>

--- a/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
@@ -129,7 +129,7 @@ export function MessageReply(props: Props) {
             <NonBreakingText>
               <Username
                 colour={props.message!.roleColour!}
-                userId={props.message.authorId}
+                userId={props.message?.authorId}
                 username={(props.mention ? "@" : "") + props.message!.username}
               />
             </NonBreakingText>

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -182,6 +182,22 @@ export function MessageComposition(props: Props) {
   state.draft._setNodeReplacement = setNodeReplacement;
   onCleanup(() => (state.draft._setNodeReplacement = undefined));
 
+  // Safely insert a mention
+  state.draft._appendMention = (mentionText: string) => {
+    const currentContent = draft()?.content ?? "";
+    const separator =
+      currentContent.endsWith(" ") || currentContent === "" ? "" : " ";
+    const newContent = currentContent + separator + mentionText;
+
+    setContent(newContent);
+    setInitialValue([newContent]);
+    setNodeReplacement(["_focus"]);
+  };
+
+  onCleanup(() => {
+    state.draft._setNodeReplacement = undefined;
+    state.draft._appendMention = undefined;
+  });
   createEffect(
     on(
       () => props.channel,

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -198,6 +198,7 @@ export function MessageComposition(props: Props) {
     state.draft._setNodeReplacement = undefined;
     state.draft._appendMention = undefined;
   });
+  
   createEffect(
     on(
       () => props.channel,

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -198,7 +198,7 @@ export function MessageComposition(props: Props) {
     state.draft._setNodeReplacement = undefined;
     state.draft._appendMention = undefined;
   });
-  
+
   createEffect(
     on(
       () => props.channel,

--- a/packages/client/src/interface/channels/text/MemberSidebar.tsx
+++ b/packages/client/src/interface/channels/text/MemberSidebar.tsx
@@ -463,7 +463,11 @@ function Member(props: {
       >
         <NameStatusStack>
           <OverflowingText>
-            <Username username={user().username} colour={user().colour!} />
+            <Username
+              userId={props.member?.id.user ?? props.user?.id}
+              username={user().username}
+              colour={user().colour!}
+            />
           </OverflowingText>
           <Show when={status()}>
             <Tooltip


### PR DESCRIPTION
Adds an easy way to mention a user by pressing shift + click, on a username. Whether they're in the sidebar, a reply origin or just a general message! 

Saw this in the "NOTES" and thought I'd take a crack, I tried a few different ways and found this to be the best approach with the least required changes and the least jank.

- Undepreciated: "Username", as we now use it to pass the UserId and handle the logic

## How was this PR tested?

Tested locally with all edited areas (E.G: Replies, sidebar and messages - As seen in video)

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

https://github.com/user-attachments/assets/a407bfef-4a95-405d-8a1a-fe066f60e31e

</details>

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None; Just staying up past my sleepy time (I was meant to sleep 3 hours ago, I've spent 3 hours on this..)
...

###### Remember to Squash this into one commit... It took me two tries to fix lint.