### PR TITLE
feat: allow opening system context menu with double right click

### DIFF
--- a/packages/client/components/ui/directives/floating.ts
+++ b/packages/client/components/ui/directives/floating.ts
@@ -118,6 +118,12 @@ export function floating(element: HTMLElement, accessor: Accessor<Props>) {
    * Handle context menu click
    */
   function onContextMenu(event: MouseEvent) {
+    // allow opening system context menu by invoking context menu again while context menu is already open
+    if (show()?.contextMenu) {
+      setShow(undefined);
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();


### PR DESCRIPTION
<!-- Describe your changes -->

When the app's custom context menu is open, invoking the context menu again causes the system context menu to be invoked instead. This way users can bypass the custom context menu to access the browser's own controls.

### Prior art

Works similar to the YouTube player context menu for example.

Some other websites use `ctrl`/`shift`/`alt` + context menu to open the native one instead of the custom one. For example, Google Docs uses `shift`+right-click. This has the benefit of being able to immediately invoke the intended context menu. The downside is that it requires a keyboard and thus doesn't work on devices with virtual keyboards or none at all, hence why I went with the design described above.

## How was this PR tested?

- [x] recruited İspik to test it for me, who confirmed it functions as stated

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] ~~I have confirmed that any new dependencies are strictly necessary~~ no ne deps
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No
