### PR TITLE
fix: More efficient CSS breakpoints & adjusted breakpoints to match Material specs

### DIFF
--- a/doc/src/responsive/device.md
+++ b/doc/src/responsive/device.md
@@ -4,29 +4,51 @@ The Device hook located in the `@revolt/common` package contains all information
 
 ## Using the useDevice hook
 
-The `useDevice` hook returns a Device object that contains a `layout` accessor which returns if the device is on a phone, tablet, or desktop layout based on screen size. It also contains an `isMobile` boolean, but this relies on the user agent and should not be used unless neccesary.
+The `useDevice` hook returns a Device object that contains a `layout` accessor which returns if the device is on a phone, tablet, or desktop layout based on screen size. It also contains an `isMobile` boolean, but this relies on the user agent and should not be used unless necessary.
 
 **Do not rely on screen size to determine if the device supports touch or is a phone.**
 
 ```typescript
 import { Show } from "solid-js";
+import { styled } from "styled-system/jsx";
 
 import { useDevice } from "@revolt/common";
 
+//Example component using the PandaCSS breakpoints (preferred when only CSS changes are needed)
+const DynamicBox = styled("div", {
+  base: {
+    width: "400px",
+    height: "200px",
+    background: "red",
+
+    //Activates on tablet AND phone breakpoints
+    _tablet: {
+      background: "red",
+    },
+
+    //Activates on phone breakpoint
+    _phone: {
+      width: "400px",
+      height: "200px",
+    },
+  },
+});
+
+//Example component using the reactive layout var
 function ComponentThatUsesDevice() {
-  const { device } = useDevice();
+  const { layout } = useDevice();
 
   return (
-    <Show when={device.layout() === "desktop"}>
+    <Show when={layout() === "desktop"}>
       This is a large screen!
     </Show>
-    <Show when={device.layout() === "tablet"}>
+    <Show when={layout() === "tablet"}>
       This is a medium screen!
     </Show>
-    <Show when={device.layout() === "phone"}>
+    <Show when={layout() === "phone"}>
       This is a small screen!
     </Show>
-    <Show when={device.layout() !== "phone"}>
+    <Show when={layout() !== "phone"}>
       This is not a small screen!
     </Show>
   )

--- a/packages/client/components/common/Breakpoint.ts
+++ b/packages/client/components/common/Breakpoint.ts
@@ -1,0 +1,7 @@
+export default {
+  /** Media query for phone layout breakpoint */
+  phone: "(max-width: 600px)",
+
+  /** Media query for tablet layout breakpoint */
+  tablet: "(max-width: 840px), (max-height: 600px)",
+};

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -8,20 +8,16 @@ import {
 } from "solid-js";
 
 import { isMobileBrowser } from "@livekit/components-core";
-
-const style = getComputedStyle(document.body);
+import Breakpoint from "./Breakpoint";
 
 export type Layout = "desktop" | "tablet" | "phone";
 
 /** Device type and compatibility info */
 export class Device {
-  /** Max width for phone layout */
-  readonly phoneMaxWidth = style.getPropertyValue("--phone-max-width");
+  /** Layout type based on viewport size
 
-  /** Max width for tablet layout */
-  readonly tabletMaxWidth = style.getPropertyValue("--tablet-max-width");
-
-  /** Layout type based on viewport size */
+   * **Note:** This is for advanced reactivity. If you only need to
+   * adjust CSS, use the `_phone` and `_tablet` PandaCSS breakpoints. */
   readonly layout: Accessor<Layout>;
 
   /** Mobile device detection based on User Agent.
@@ -41,8 +37,8 @@ export class Device {
     this.layout = lo;
     this.setLayout = setLo;
 
-    this.pMedia = matchMedia(`(max-width: ${this.phoneMaxWidth})`);
-    this.tMedia = matchMedia(`(max-width: ${this.tabletMaxWidth})`);
+    this.pMedia = matchMedia(Breakpoint.phone);
+    this.tMedia = matchMedia(Breakpoint.tablet);
     (this.pMedia.onchange = this.tMedia.onchange = this.onLayout.bind(this))();
   }
 

--- a/packages/client/components/ui/styles.css
+++ b/packages/client/components/ui/styles.css
@@ -6,11 +6,8 @@
 @import "@fontsource/inter/800";
 @import "@fontsource/jetbrains-mono";
 
-* { box-sizing: border-box; }
-
-:root {
-  --phone-max-width: 600px;
-  --tablet-max-width: 960px;
+* {
+  box-sizing: border-box;
 }
 
 body {

--- a/packages/client/panda.config.ts
+++ b/packages/client/panda.config.ts
@@ -1,4 +1,12 @@
 import { defineConfig } from "@pandacss/dev";
+import Breakpoint from "./components/common/Breakpoint";
+
+const condExt: Record<string, string> = {};
+
+//Load breakpoint conditions
+for (const bp in Breakpoint) {
+  condExt[bp] = `@media ${Breakpoint[bp as keyof typeof Breakpoint]}`;
+}
 
 export default defineConfig({
   // Whether to use css reset
@@ -7,8 +15,7 @@ export default defineConfig({
   // Where to look for your css declarations
   include: ["./src/**/*.{js,jsx,ts,tsx}", "./components/**/*.{js,jsx,ts,tsx}"],
 
-  // Files to exclude
-  exclude: [],
+  conditions: { extend: condExt },
 
   // Useful for theme customization
   theme: {


### PR DESCRIPTION
- Adjust breakpoints to better align with [Material guidelines](https://m3.material.io/foundations/layout/breakpoints/overview)
- Move breakpoints to own file to ensure central source-of-truth
- Trigger tablet breakpoint on phone max-height to catch devices with >840px width in landscape but very narrow height (eg. Galaxy S Ultra, iPhone Pro Max)
- Import breakpoints as [PandaCSS conditions](https://panda-css.com/docs/customization/conditions), enabling more efficient code than the reactive vars for pure CSS changes

## How was this PR tested?

Tested new PandaCSS breakpoints system to ensure it reacts to display and orientation changes and ensure autocomplete works. In process of adapting #835 to use it where possible.

*No UI/UX changes to screenshot, this is behind-the-scenes stuff.*

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Only icky squishy organic language models have been used

- `main` <!-- branch-stack -->
  - \#1273 :point\_left:
