### PR TITLE
style: use macos native traffic lights

### DIFF
--- a/packages/client/components/app/interface/desktop/Titlebar.tsx
+++ b/packages/client/components/app/interface/desktop/Titlebar.tsx
@@ -17,6 +17,8 @@ import MdMinimize from "@material-symbols/svg-400/outlined/minimize.svg?componen
 import Wordmark from "../../../../public/assets/web/wordmark.svg?component-solid";
 import { pendingUpdate } from "../../../../src/serviceWorkerInterface";
 
+const isMacOS = navigator.platform.startsWith("Mac");
+
 export function Titlebar() {
   const [isMaximised, setIsMaximised] = createSignal(
     window.native ? window.desktopConfig.get().windowState.isMaximised : false,
@@ -52,6 +54,7 @@ export function Titlebar() {
         >
           <Base disconnected={isDisconnected()}>
             <Title
+              macos={isMacOS}
               style={{
                 "-webkit-user-select": "none",
                 "-webkit-app-region": "drag",
@@ -68,6 +71,7 @@ export function Titlebar() {
               </Show>
             </Title>
             <DragHandle
+              macos={isMacOS}
               style={{
                 "-webkit-user-select": "none",
                 "-webkit-app-region": "drag",
@@ -122,7 +126,7 @@ export function Titlebar() {
                 </div>
               </Show>
             </DragHandle>
-            <Show when={window.native}>
+            <Show when={window.native && !isMacOS}>
               <Action onClick={window.native.minimise}>
                 <Ripple />
                 <MdMinimize {...symbolSize(20)} />
@@ -183,6 +187,14 @@ const Title = styled("div", {
     color: "var(--md-sys-color-on-surface)",
     ...typography.raw({ class: "title", size: "small" }),
   },
+  variants: {
+    macos: {
+      true: {
+        order: 1,
+        paddingInlineEnd: "var(--gap-md)",
+      },
+    },
+  },
 });
 
 const DragHandle = styled("div", {
@@ -196,6 +208,13 @@ const DragHandle = styled("div", {
     paddingInlineStart: "var(--gap-md)",
 
     ...typography.raw({ class: "label", size: "large" }),
+  },
+  variants: {
+    macos: {
+      true: {
+        marginInlineStart: "70px",
+      },
+    },
   },
 });
 


### PR DESCRIPTION
The macOS app uses its own controls in the title bar. Because many macOS apps uses native "trafic lights" in the top-left of the window, it can possibly be seen inconsistent.

This PR changes title bar UI and these changes only apply in macOS.

Because both `for-web` and `for-desktop` need to be updated, **you have to merge both requests at the same time**. (https://github.com/stoatchat/for-web/pull/1274, https://github.com/stoatchat/for-desktop/pull/220)

Thanks.

### Original version:
<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 10 04 AM" src="https://github.com/user-attachments/assets/e8552b0e-b272-4588-8a19-60cba32c672d" />

<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 16 02 AM" src="https://github.com/user-attachments/assets/3763ea30-fa65-4bac-b7ae-1c397280bcd4" />


### Updated version:
<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 10 25 AM" src="https://github.com/user-attachments/assets/3fa5a915-be07-43b6-a1cd-73056719ed42" />

<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 15 40 AM" src="https://github.com/user-attachments/assets/3a427e2b-b515-469a-8d0a-94d3b4e57bbd" />
