### PR TITLE
fix: Add base path to service worker registration check

### DIFF
--- a/packages/client/components/client/NotificationsController.ts
+++ b/packages/client/components/client/NotificationsController.ts
@@ -136,7 +136,9 @@ async function setUpServiceWorkerSubscription(client: Client) {
     throw "Client not configured";
   }
 
-  const registration = await navigator.serviceWorker.getRegistration();
+  const registration = await navigator.serviceWorker.getRegistration(
+    import.meta.env.BASE_URL ?? undefined,
+  );
   if (!registration) {
     throw "Failed to get service worker";
   }
@@ -182,7 +184,9 @@ export async function killServiceWorkerSubscription(
     return;
   }
 
-  const registration = await navigator.serviceWorker.getRegistration();
+  const registration = await navigator.serviceWorker.getRegistration(
+    import.meta.env.BASE_URL ?? undefined,
+  );
   if (!registration) return;
   const subscription = await registration.pushManager.getSubscription();
   if (await subscription?.unsubscribe()) {


### PR DESCRIPTION
Fixes issue in production where the service worker registration cannot be fetched.

Thanks @amycatgirl for help finding the root cause of this issue.

- `main` <!-- branch-stack -->
  - \#1279 :point\_left:
