### PR TITLE
fix: Pass atEnd as a signal to fix acks when clicking on a channel

### DIFF
--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -4,6 +4,7 @@ import {
   JSX,
   Match,
   Show,
+  Signal,
   Switch,
   batch,
   createEffect,
@@ -90,11 +91,7 @@ interface Props {
    */
   jumpToBottomRef?: (fn: (nearby?: string) => void) => void;
 
-  /**
-   * Bind the atEnd signal to the parent component
-   * @param fn Function
-   */
-  atEndRef?: (fn: () => boolean) => void;
+  atEnd?: Signal<boolean>;
 }
 
 /**
@@ -120,7 +117,8 @@ export function Messages(props: Props) {
   /**
    * Whether we've reached the end of the conversation
    */
-  const [atEnd, setEnd] = createSignal(true);
+  // eslint-disable-next-line solid/reactivity
+  const [atEnd, setEnd] = props.atEnd ?? createSignal(true);
 
   /**
    * The current direction of fetching
@@ -606,7 +604,6 @@ export function Messages(props: Props) {
   // Setup references if they exists
   onMount(() => {
     props.jumpToBottomRef?.(jumpToBottom);
-    props.atEndRef?.(atEnd);
   });
 
   /**

--- a/packages/client/src/interface/channels/text/TextChannel.tsx
+++ b/packages/client/src/interface/channels/text/TextChannel.tsx
@@ -76,8 +76,7 @@ export function TextChannel(props: ChannelPageProps) {
   // Get a reference to the message box's load latest function
   let jumpToBottomRef: ((nearby?: string) => void) | undefined;
 
-  // Get a reference to the message list's "end status"
-  let atEndRef: (() => boolean) | undefined;
+  const [atEnd, setEnd] = createSignal(true);
 
   // Store last unread message id
   createEffect(
@@ -96,7 +95,7 @@ export function TextChannel(props: ChannelPageProps) {
   createEffect(
     on(
       // must be at the end of the conversation
-      () => props.channel.unread && (atEndRef ? atEndRef() : true),
+      () => props.channel.unread && atEnd(),
       (unread) => {
         if (unread) {
           if (document.hasFocus()) {
@@ -116,7 +115,7 @@ export function TextChannel(props: ChannelPageProps) {
 
   // Mark as read on re-focus
   function onFocus() {
-    if (props.channel.unread && (atEndRef ? atEndRef() : true)) {
+    if (props.channel.unread && atEnd()) {
       props.channel.ack();
     }
   }
@@ -202,8 +201,8 @@ export function TextChannel(props: ChannelPageProps) {
             }
             highlightedMessageId={highlightMessageId}
             clearHighlightedMessage={() => navigate(".")}
-            atEndRef={(ref) => (atEndRef = ref)}
             jumpToBottomRef={(ref) => (jumpToBottomRef = ref)}
+            atEnd={[atEnd, setEnd]}
           />
 
           <MessageComposition


### PR DESCRIPTION
Fixes issue where atEnd acks weren't working. Previous solution to this problem was non-reactive, therefore it never worked when atEnd changed.

- `main` <!-- branch-stack -->
  - \#1281 :point\_left:
