### PR TITLE
fix: slowmode timer goes to 0 now, and shows up above replies

### DIFF
--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -64,8 +64,8 @@ export function MessageComposition(props: Props) {
     const entry = currentSlowmode();
     if (!entry) return;
     const receivedAt = entry.receivedAt ?? Date.now();
-    // Add 1 second so we can show 0:00 to users.
-    const targetTs = receivedAt + (entry.retry_after + 1) * 1000;
+    // Add 100 ms here so the countdown has a bit to render
+    const targetTs = receivedAt + 100 + entry.retry_after * 1000;
     return createCountdownFromNow(targetTs);
   });
 
@@ -90,11 +90,8 @@ export function MessageComposition(props: Props) {
   });
 
   const slowmodeText = createMemo(() => {
-    let s = cooldownRemaining();
+    const s = cooldownRemaining();
     if (!s) return "";
-
-    // Subtract 1 from s to account for 1 added above
-    s--;
 
     const h = Math.floor(s / 3600);
     const m = Math.floor((s % 3600) / 60);

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -64,7 +64,8 @@ export function MessageComposition(props: Props) {
     const entry = currentSlowmode();
     if (!entry) return;
     const receivedAt = entry.receivedAt ?? Date.now();
-    const targetTs = receivedAt + entry.retry_after * 1000;
+    // Add 1 second so we can show 0:00 to users.
+    const targetTs = receivedAt + (entry.retry_after + 1) * 1000;
     return createCountdownFromNow(targetTs);
   });
 
@@ -89,8 +90,11 @@ export function MessageComposition(props: Props) {
   });
 
   const slowmodeText = createMemo(() => {
-    const s = cooldownRemaining();
+    let s = cooldownRemaining();
     if (!s) return "";
+
+    // Subtract 1 from s to account for 1 added above
+    s--;
 
     const h = Math.floor(s / 3600);
     const m = Math.floor((s % 3600) / 60);
@@ -378,6 +382,24 @@ export function MessageComposition(props: Props) {
 
   return (
     <>
+      <Show when={props.channel.slowmode}>
+        <SlowmodeContainer>
+          <Tooltip
+            content={t`Members can send one message every ${slowmodeWaitTime()}.`}
+            placement="top"
+          >
+            <SlowmodeRow>
+              <Symbol style={{ "font-size": "1rem" }}>schedule</Symbol>
+              <SlowmodeText>
+                <Switch fallback={t`Slowmode is enabled.`}>
+                  <Match when={isSlowmodeExempt()}>{t`Slowmode Immune`}</Match>
+                  <Match when={cooldownRemaining() > 0}>{slowmodeText()}</Match>
+                </Switch>
+              </SlowmodeText>
+            </SlowmodeRow>
+          </Tooltip>
+        </SlowmodeContainer>
+      </Show>
       <Show when={state.draft.hasAdditionalElements(props.channel.id)}>
         <Keybind
           keybind={KeybindAction.CHAT_REMOVE_COMPOSITION_ELEMENT}
@@ -419,24 +441,6 @@ export function MessageComposition(props: Props) {
           );
         }}
       </For>
-      <Show when={props.channel.slowmode}>
-        <SlowmodeContainer>
-          <Tooltip
-            content={t`Members can send one message every ${slowmodeWaitTime()}.`}
-            placement="top"
-          >
-            <SlowmodeRow>
-              <Symbol style={{ "font-size": "1rem" }}>schedule</Symbol>
-              <SlowmodeText>
-                <Switch fallback={t`Slowmode is enabled.`}>
-                  <Match when={isSlowmodeExempt()}>{t`Slowmode Immune`}</Match>
-                  <Match when={cooldownRemaining() > 0}>{slowmodeText()}</Match>
-                </Switch>
-              </SlowmodeText>
-            </SlowmodeRow>
-          </Tooltip>
-        </SlowmodeContainer>
-      </Show>
       <MessageBox
         initialValue={initialValue()}
         nodeReplacement={nodeReplacement()}


### PR DESCRIPTION
Fixes issue with slowmode timer where it disapeared a second too early and sometimes skipped numbers.

Also made replies show up below the countdown isntead of above.

## How was this PR tested?

Did a slowmode

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Before:

[Screencast from 2026-06-19 22-12-52.webm](https://github.com/user-attachments/assets/4fe31f37-f843-42d0-a612-e0e51bd9967f)

After:

[Screencast from 2026-06-19 22-26-41.webm](https://github.com/user-attachments/assets/aef4d19c-5962-450e-905f-6f83258509ad)


</details>

- `main` <!-- branch-stack -->
  - \#1282 :point\_left:
