### PR TITLE
fix: defean typo

### DIFF
--- a/packages/client/components/state/stores/Voice.ts
+++ b/packages/client/components/state/stores/Voice.ts
@@ -356,7 +356,7 @@ export class Voice extends AbstractStore<"voice", TypeVoice> {
   }
 
   /**
-   * Set defean status
+   * Set deafen status
    */
   set deafen(value: boolean) {
     this.set("deafen", value);

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -64,8 +64,8 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
             placement: "top",
             content: voice.listenPermission
               ? voice.deafen()
-                ? t`Listen`
-                : t`Defean`
+                ? t`Undeafen`
+                : t`Deafen`
               : t`Missing permission`,
           },
         }}


### PR DESCRIPTION
Fixes `defean` and replaces it with the correct spelling. Also replaces `listen` with `undeafen` as requested by ui/ux

- `main` <!-- branch-stack -->
  - \#1285 :point\_left:
