### PR TITLE
fix: Messages should now show up if you send a message viewing history

### DIFF
--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -271,7 +271,7 @@ export function Messages(props: Props) {
       }
 
       // Stop collecting messages
-      collectedMessages = [];
+      collectedMessages = undefined;
 
       // Mark as fetching has ended
       setFetching();
@@ -507,7 +507,7 @@ export function Messages(props: Props) {
         );
 
         // Stop collecting messages
-        collectedMessages = [];
+        collectedMessages = undefined;
 
         // Animate scroll to bottom
         setTimeout(() => {
@@ -650,6 +650,10 @@ export function Messages(props: Props) {
    * @param message Message object
    */
   function onMessage(message: MessageInterface) {
+    if (collectedMessages) {
+      collectedMessages.push(message);
+      return;
+    }
     if (message.channelId === props.channel.id && atEnd()) {
       setMessages([message, ...messages()]);
     }


### PR DESCRIPTION
There already existed a fix for this bug, but it was not fully implemented. This PR completes the implementation.

Fixes #1257

## How was this PR tested?

Scrolling really far up in history and sending a message. Tested on both Firefox and Chromium-based.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Before:

[Screencast from 2026-06-20 12-25-03.webm](https://github.com/user-attachments/assets/26594fd1-d056-4076-bd0b-78c74339a51e)

After:

[Screencast from 2026-06-20 12-27-18.webm](https://github.com/user-attachments/assets/69f8873d-e715-49b4-a614-ee36a61c7011)

</details>

- `main` <!-- branch-stack -->
  - \#1286 :point\_left:
