### PR TITLE
fix: play GIFs inline on iOS instead of forcing fullscreen

### DIFF
--- a/packages/client/components/modal/modals/ImageViewer.tsx
+++ b/packages/client/components/modal/modals/ImageViewer.tsx
@@ -166,6 +166,7 @@ export function ImageViewerModal(
                 <Match when={props.gif}>
                   <Video
                     ref={setRef}
+                    playsinline
                     loop
                     muted
                     autoplay

--- a/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
@@ -263,6 +263,7 @@ const GifItem = (props: {
 
   return (
     <Gif
+      playsinline
       loop
       autoplay
       muted

--- a/packages/client/components/ui/components/features/messaging/elements/Attachment.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Attachment.tsx
@@ -68,6 +68,7 @@ export function Attachment(props: { file: File; message?: Message }) {
           </Show>
           <video
             controls
+            playsinline
             preload="metadata"
             src={props.file.originalUrl}
             use:floating={{

--- a/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
@@ -67,6 +67,7 @@ export function Embed(props: { embed: MessageEmbed }) {
       <Match when={video()}>
         <SizedContent width={video()!.width} height={video()!.height}>
           <video
+            playsinline
             loop={isGIF()}
             muted={isGIF()}
             autoplay={isGIF()}

--- a/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
@@ -153,6 +153,7 @@ export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
               >
                 <video
                   controls
+                  playsinline
                   preload="metadata"
                   src={(props.embed as WebsiteEmbed).video!.proxiedURL}
                 />


### PR DESCRIPTION
Adds the `playsinline` attribute to GIF/video render paths so videos play inline
on iOS instead of being forced into native fullscreen by WebKit.

Fixes #1245

## How was this PR tested?

- [x] Ran the dev client on a physical iPhone (iOS 18, Safari + Brave) and
  confirmed Tenor GIFs in the message feed now play inline instead of
  hijacking the screen on load
- [x] Confirmed tapping a GIF opens the in-app image viewer (also inline), and
  that GIF picker previews no longer trigger fullscreen
- [x] `prettier --check`, `eslint`, and `tsc --noEmit` all pass

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No LLM's Were used in making of this PR.

- `main` <!-- branch-stack -->
  - \#1290 :point\_left:
