### PR TITLE
fix: Add lingui extract to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN pnpm --filter stoat.js build && \
   pnpm --filter client exec node scripts/copyAssets.mjs && \
   pnpm --filter client exec panda codegen
 
+RUN pnpm --filter client exec lingui extract
 RUN pnpm --filter client exec lingui compile --typescript
 
 # Build the client with placeholder env vars for runtime injection 


### PR DESCRIPTION
When I added lingui to the docker build process, I forgot to call extract. This PR adds it and should make beta have translations hopefully.

- `main` <!-- branch-stack -->
  - \#1291 :point\_left:
