### PR TITLE
fix: Make collected messages only collect if channel matches

### DIFF
--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -650,12 +650,14 @@ export function Messages(props: Props) {
    * @param message Message object
    */
   function onMessage(message: MessageInterface) {
-    if (collectedMessages) {
-      collectedMessages.push(message);
-      return;
-    }
-    if (message.channelId === props.channel.id && atEnd()) {
-      setMessages([message, ...messages()]);
+    if (message.channelId === props.channel.id) {
+      if (collectedMessages) {
+        collectedMessages.push(message);
+        return;
+      }
+      if (atEnd()) {
+        setMessages([message, ...messages()]);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes regression from #1286 where if a message came in for a different channel while fetching messages that message would show on the message list until refresh.

- `main` <!-- branch-stack -->
  - \#1294 :point\_left:
