### PR TITLE
chore: Enable PWA in dev mode for testing

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -33,6 +33,9 @@ export default defineConfig({
       injectManifest: {
         maximumFileSizeToCacheInBytes: 4000000,
       },
+      devOptions: {
+        enabled: true,
+      },
       manifest: {
         name: "Stoat",
         short_name: "Stoat",


### PR DESCRIPTION
Split from #835

Enables Vite PWA in dev build for easier testing of PRs that need testing in PWA mode without requiring a full rebuild for every change to run in production mode.

- `main` <!-- branch-stack -->
  - \#1300 :point\_left:
