### PR TITLE
fix: Mobile-friendly changes for emoji picker

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
@@ -131,6 +131,7 @@ function Picker(
     if (rect.right > innerWidth || rect.bottom > innerHeight) setFixed(true);
   }
   onMount(() => {
+    (document.activeElement as HTMLElement)?.blur(); //Hide keyboard
     addEventListener("mousedown", onMouseDown);
     addEventListener("resize", onResize);
     setTimeout(onResize, 1);

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -5,6 +5,7 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  onMount,
   useContext,
 } from "solid-js";
 
@@ -13,16 +14,17 @@ import { Emoji, Server } from "stoat.js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { useClient } from "@revolt/client";
+import { useDevice } from "@revolt/common";
 import { UnicodeEmoji } from "@revolt/markdown/emoji";
 import { UNICODE_EMOJI_PACK_PUA } from "@revolt/markdown/emoji/UnicodeEmoji";
 import { useState } from "@revolt/state";
 import { Avatar, Ripple, TextField } from "@revolt/ui/components/design";
 import { Row } from "@revolt/ui/components/layout";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 
 import emojiMapping from "../../../../../emojiMapping.json";
-
-import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import {
   CompositionMediaPickerContext,
   compositionContent,
@@ -65,21 +67,30 @@ type Item =
       text: string;
     };
 
-const COLUMNS = 9;
-
 const [hoveredItem, setHoveredItem] = createSignal<Item | null>(null);
 
 export function EmojiPicker() {
   const client = useClient();
   const { ordering, settings } = useState();
+  const { isMobile } = useDevice();
   const { t } = useLingui();
 
   const [filter, setFilter] = createSignal("");
+  const [colCount, setColCount] = createSignal(0);
 
   let serverScrollTargetElement!: HTMLDivElement;
   let emojiScrollTargetElement!: HTMLDivElement;
 
+  onMount(() =>
+    createResizeObserver(emojiScrollTargetElement, ({ width }) =>
+      setColCount(Math.floor(width / 40)),
+    ),
+  );
+
   const items = createMemo(() => {
+    const cols = colCount();
+    if (!cols) return [];
+
     const filterText = filter().toLowerCase();
 
     if (filterText) {
@@ -109,7 +120,7 @@ export function EmojiPicker() {
         server,
       });
 
-      while (items.length % COLUMNS) {
+      while (items.length % cols) {
         items.push({ t: 1 });
       }
 
@@ -117,7 +128,7 @@ export function EmojiPicker() {
         items.push({ t: 2, emoji });
       }
 
-      while (items.length % COLUMNS) {
+      while (items.length % cols) {
         items.push({ t: 1 });
       }
     }
@@ -127,7 +138,7 @@ export function EmojiPicker() {
       title: "Default",
     });
 
-    while (items.length % COLUMNS) {
+    while (items.length % cols) {
       items.push({ t: 1 });
     }
 
@@ -151,15 +162,10 @@ export function EmojiPicker() {
   return (
     <Stack>
       <TextField
-        autoFocus
+        autoFocus={!isMobile}
         variant="outlined"
         placeholder="Search for emojis..."
         value={filter()}
-        onMouseDown={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          e.stopImmediatePropagation();
-        }}
         onInput={(e) => setFilter(e.currentTarget.value)}
       />
       <Row gap={"none"} class={compositionContent()}>
@@ -187,7 +193,7 @@ export function EmojiPicker() {
                   );
                   if (idx !== -1 && emojiScrollTargetElement) {
                     emojiScrollTargetElement.scrollTop =
-                      Math.floor(idx / COLUMNS) * 40;
+                      Math.floor(idx / colCount()) * 40;
                   }
                 }}
               />
@@ -206,7 +212,7 @@ export function EmojiPicker() {
               items={items()}
               scrollTarget={emojiScrollTargetElement}
               itemSize={{ height: 40, width: 40 }}
-              crossAxisCount={() => COLUMNS}
+              crossAxisCount={colCount}
             >
               {EmojiItem}
             </VirtualContainer>
@@ -330,12 +336,10 @@ const ServerItem = (props: {
     style={props.style as never}
     tabIndex={props.tabIndex}
     role="listitem"
-    onMouseDown={(e) => {
-      e.preventDefault();
+    onClick={(e) => {
       e.stopPropagation();
-      e.stopImmediatePropagation();
+      props.onClick(e);
     }}
-    onClick={props.onClick}
   >
     <Avatar
       size={32}

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -5,6 +5,7 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  onMount,
   useContext,
 } from "solid-js";
 
@@ -13,16 +14,17 @@ import { Emoji, Server } from "stoat.js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
+import { Trans, useLingui } from "@lingui/solid/macro";
 import { useClient } from "@revolt/client";
+import { useDevice } from "@revolt/common";
 import { UnicodeEmoji } from "@revolt/markdown/emoji";
 import { UNICODE_EMOJI_PACK_PUA } from "@revolt/markdown/emoji/UnicodeEmoji";
 import { useState } from "@revolt/state";
 import { Avatar, Ripple, TextField } from "@revolt/ui/components/design";
 import { Row } from "@revolt/ui/components/layout";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 
 import emojiMapping from "../../../../../emojiMapping.json";
-
-import { Trans, useLingui } from "@lingui/solid/macro";
 import {
   CompositionMediaPickerContext,
   compositionContent,
@@ -65,21 +67,30 @@ type Item =
       text: string;
     };
 
-const COLUMNS = 9;
-
 const [hoveredItem, setHoveredItem] = createSignal<Item | null>(null);
 
 export function EmojiPicker() {
   const client = useClient();
   const { ordering, settings } = useState();
+  const { isMobile } = useDevice();
   const { t } = useLingui();
 
   const [filter, setFilter] = createSignal("");
+  const [colCount, setColCount] = createSignal(0);
 
   let serverScrollTargetElement!: HTMLDivElement;
   let emojiScrollTargetElement!: HTMLDivElement;
 
+  onMount(() =>
+    createResizeObserver(emojiScrollTargetElement, ({ width }) =>
+      setColCount(Math.floor(width / 40)),
+    ),
+  );
+
   const items = createMemo(() => {
+    const cols = colCount();
+    if (!cols) return [];
+
     const filterText = filter().toLowerCase();
 
     if (filterText) {
@@ -109,7 +120,7 @@ export function EmojiPicker() {
         server,
       });
 
-      while (items.length % COLUMNS) {
+      while (items.length % cols) {
         items.push({ t: 1 });
       }
 
@@ -117,7 +128,7 @@ export function EmojiPicker() {
         items.push({ t: 2, emoji });
       }
 
-      while (items.length % COLUMNS) {
+      while (items.length % cols) {
         items.push({ t: 1 });
       }
     }
@@ -127,7 +138,7 @@ export function EmojiPicker() {
       title: "Default",
     });
 
-    while (items.length % COLUMNS) {
+    while (items.length % cols) {
       items.push({ t: 1 });
     }
 
@@ -151,15 +162,10 @@ export function EmojiPicker() {
   return (
     <Stack>
       <TextField
-        autoFocus
+        autoFocus={!isMobile}
         variant="outlined"
         placeholder="Search for emojis..."
         value={filter()}
-        onMouseDown={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          e.stopImmediatePropagation();
-        }}
         onInput={(e) => setFilter(e.currentTarget.value)}
       />
       <Row gap={"none"} class={compositionContent()}>
@@ -187,7 +193,7 @@ export function EmojiPicker() {
                   );
                   if (idx !== -1 && emojiScrollTargetElement) {
                     emojiScrollTargetElement.scrollTop =
-                      Math.floor(idx / COLUMNS) * 40;
+                      Math.floor(idx / colCount()) * 40;
                   }
                 }}
               />
@@ -206,7 +212,7 @@ export function EmojiPicker() {
               items={items()}
               scrollTarget={emojiScrollTargetElement}
               itemSize={{ height: 40, width: 40 }}
-              crossAxisCount={() => COLUMNS}
+              crossAxisCount={colCount}
             >
               {EmojiItem}
             </VirtualContainer>
@@ -330,12 +336,10 @@ const ServerItem = (props: {
     style={props.style as never}
     tabIndex={props.tabIndex}
     role="listitem"
-    onMouseDown={(e) => {
-      e.preventDefault();
+    onClick={(e) => {
       e.stopPropagation();
-      e.stopImmediatePropagation();
+      props.onClick(e);
     }}
-    onClick={props.onClick}
   >
     <Avatar
       size={32}

--- a/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
@@ -27,6 +27,7 @@ import {
 } from "@revolt/ui/components/design";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
+import { useDevice } from "@revolt/common";
 import { CompositionMediaPickerContext } from "./CompositionMediaPicker";
 
 /**
@@ -54,8 +55,8 @@ type GifResult = {
 const FilterContext = createContext<(value: string) => void>();
 
 export function GifPicker() {
+  const { isMobile } = useDevice();
   const [filter, setFilter] = createSignal("");
-
   const fliterLowercase = () => filter().toLowerCase();
 
   return (
@@ -80,15 +81,10 @@ export function GifPicker() {
           </span>
         </Show>
         <TextField
-          autoFocus
+          autoFocus={!isMobile}
           variant="outlined"
           placeholder="Search for GIFs..."
           value={filter()}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            e.stopImmediatePropagation();
-          }}
           onChange={(e) => setFilter(e.currentTarget.value)}
         />
       </SearchArea>

--- a/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
+++ b/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
@@ -225,13 +225,14 @@ export function TextEditor2(props: Props) {
       () => props.nodeReplacement,
       (value) => {
         if (value) {
-          view.focus();
-
           const text = value[0];
           if (text !== "_focus") {
+            if (!isMobile) view.focus();
             view.dispatch(view.state.replaceSelection(text));
             if (text) props.onTyping?.();
             props.onChange(view.state.doc.toString());
+          } else {
+            view.focus();
           }
         }
       },


### PR DESCRIPTION
Split off from #835

- The GIF/emoji picker effectively "takes the place" of the touch-keyboard until you explicitly open it by tapping the search bar, like on Discord.
  - Don't autofocus search input in GIF/emoji picker on mobile because it causes unwanted touch keyboard deployment
  - Don't refocus the message box element still hidden behind picker after tapping an Emoji, for same reason
- Shrink emoji picker when screen is too small (reactively calculates row count depending on picker width)
- Prevent picker height from exceeding screen height
- Fix overflow hidden clipping emoji autocorrect dropdown when editing a message

* `main` <!-- branch-stack -->
  - \#1301 :point\_left:
