### PR TITLE
fix: cache material symbols to prevent them from breaking on bad conn

### DIFF
--- a/packages/client/fontpreload.plugin.ts
+++ b/packages/client/fontpreload.plugin.ts
@@ -1,0 +1,51 @@
+import type { HtmlTagDescriptor, Plugin } from "vite";
+
+// This plugin was based on the following Stack Overflow answer
+// https://stackoverflow.com/a/79671988/5709936
+
+export function addFontPreload(): Plugin {
+  const extractTags = (src: string): HtmlTagDescriptor[] => {
+    const tags: HtmlTagDescriptor[] = [];
+    const reg =
+      /src:url\(['"]?(.+?\/material-symbols-.+?\.woff2)['"]?\)\s+format\(\s*['"]woff2['"]\s*\)/g;
+    let match: RegExpExecArray | null;
+    while ((match = reg.exec(src))) {
+      const href = match[1];
+      tags.push({
+        injectTo: "head-prepend",
+        tag: "link",
+        attrs: {
+          rel: "preload",
+          as: "font",
+          type: "font/woff2",
+          href: href,
+          crossorigin: true,
+        },
+      });
+    }
+    return tags;
+  };
+
+  return {
+    name: "vite-add-font-preload",
+    transformIndexHtml: {
+      order: "post",
+      handler: (_, ctx) => {
+        if (ctx.bundle == null) {
+          return [];
+        }
+        const tags: HtmlTagDescriptor[] = [];
+        for (const [k, v] of Object.entries(ctx.bundle)) {
+          if (
+            v.type === "asset" &&
+            typeof v.source === "string" &&
+            k.endsWith(".css")
+          ) {
+            tags.push(...extractTags(v.source));
+          }
+        }
+        return tags;
+      },
+    },
+  };
+}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
       filename: "serviceWorker.ts",
       strategies: "injectManifest",
       injectManifest: {
-        maximumFileSizeToCacheInBytes: 4000000,
+        maximumFileSizeToCacheInBytes: 8000000,
+        globPatterns: ["**/*.{js,css,html}", "**/material-symbols-*.woff2"],
       },
       devOptions: {
         enabled: true,

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -10,6 +10,7 @@ import solidPlugin from "vite-plugin-solid";
 import solidSvg from "vite-plugin-solid-svg";
 
 import codegenPlugin from "./codegen.plugin";
+import { addFontPreload } from "./fontpreload.plugin";
 
 const base = process.env.BASE_PATH ?? "/";
 const pwaScope = process.env.PWA_SCOPE || base;
@@ -26,6 +27,7 @@ export default defineConfig({
     solidSvg({
       defaultAsComponent: false,
     }),
+    addFontPreload(),
     VitePWA({
       srcDir: "src",
       registerType: "autoUpdate",


### PR DESCRIPTION
Add the material symbols to the service worker cache so that mobile connections don't result in the fonts messing up

Also adds a preload to the index.html via a vite plugin, meaning you shouldn't ever see the fonts messing up again (but it mnight take a bit longer to load the app sometimes)

- `main` <!-- branch-stack -->
  - \#1303 :point\_left:
