### PR TITLE
fix: Make the message box fetch messages on reconnect

### DIFF
--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -713,7 +713,7 @@ export function Messages(props: Props) {
         if (
           state === State.Connected &&
           atEnd() &&
-          !props.highlightedMessageId
+          !props.highlightedMessageId()
         ) {
           caseInitialLoad();
         }


### PR DESCRIPTION
I can't believe this was such a dumb bug. Messages were not fetching on reconnect, resulting in a subpar experience on mobile. This pr fixes that by calling the highlightedMessageId function instead of checking if the function is undefined (it's always defined)

Closes #912 


- `main` <!-- branch-stack -->
  - \#1305 :point\_left:
