### PR TITLE
feat: Client endpoint for reporting backend API to other instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "stoat-for-web",
   "version": "0.9.1",
   "description": "Stoat for Web: frontend software for Stoat",
+  "dependencies": {
+    "dotenv": "^17.4.2"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "eslint": "^9.26.0",

--- a/packages/client/app-config.plugin.ts
+++ b/packages/client/app-config.plugin.ts
@@ -1,0 +1,25 @@
+import { ViteDevServer } from "vite";
+
+//Load .env file
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
+
+import CONFIGURATION, { AppConfig } from "./components/common/lib/env";
+
+//Data for public config endpoint
+const appCfg: AppConfig = {
+  api: CONFIGURATION.DEFAULT_API_URL,
+  gifbox: CONFIGURATION.DEFAULT_GIFBOX_URL,
+};
+
+export default function appConfigPlugin() {
+  return {
+    name: "app-config",
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use("/.stoat-config", (_, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(appCfg));
+      });
+    },
+  };
+}

--- a/packages/client/app-config.plugin.ts
+++ b/packages/client/app-config.plugin.ts
@@ -1,4 +1,4 @@
-import { ViteDevServer } from "vite";
+import { PluginOption } from "vite";
 
 //Load .env file
 import dotenv from "dotenv";
@@ -7,18 +7,32 @@ dotenv.config({ quiet: true });
 import CONFIGURATION, { AppConfig } from "./components/common/lib/env";
 
 //Data for public config endpoint
-const appCfg: AppConfig = {
+const appCfg = JSON.stringify({
   api: CONFIGURATION.DEFAULT_API_URL,
   gifbox: CONFIGURATION.DEFAULT_GIFBOX_URL,
-};
+} as AppConfig);
 
-export default function appConfigPlugin() {
+export default function appConfigPlugin(): PluginOption {
   return {
     name: "app-config",
-    configureServer(server: ViteDevServer) {
-      server.middlewares.use("/.stoat-config", (_, res) => {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(appCfg));
+    //For dev / serve mode
+    configureServer(server) {
+      server.middlewares.use("/stoat-config.json", (_, res) => {
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        });
+        res.end(appCfg);
+      });
+    },
+    //For static build
+    buildStart() {
+      //TODO: This throws warning "context method emitFile() is not supported in serve mode. This plugin is likely not vite-compatible."
+      //Need to add a conditional and detect serve mode somehow
+      this.emitFile({
+        fileName: "stoat-config.json",
+        source: appCfg,
+        type: "asset",
       });
     },
   };

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -1,7 +1,19 @@
+export const STOAT_API = "https://api.stoat.chat";
+
+//Run in NodeJS mode
+if (!("env" in import.meta))
+  (import.meta as { env: NodeJS.ProcessEnv }).env = process.env;
+
+/** App `/.stoat-config` endpoint response */
+export interface AppConfig {
+  api: string;
+  gifbox: string;
+}
+
 const DEFAULT_API_URL =
   (import.meta.env.DEV ? import.meta.env.VITE_DEV_API_URL : undefined) ??
   (import.meta.env.VITE_API_URL as string) ??
-  "https://stoat.chat/api";
+  STOAT_API;
 
 export default {
   /**
@@ -22,6 +34,7 @@ export default {
     "https://revolt.chat/api",
     // ... and now:
     "https://stoat.chat/api",
+    STOAT_API,
   ].includes(DEFAULT_API_URL),
   /**
    * What WS server to connect to by default.

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -9,6 +9,7 @@ import { VitePWA } from "vite-plugin-pwa";
 import solidPlugin from "vite-plugin-solid";
 import solidSvg from "vite-plugin-solid-svg";
 
+import appConfigPlugin from "./app-config.plugin";
 import codegenPlugin from "./codegen.plugin";
 
 const base = process.env.BASE_PATH ?? "/";
@@ -19,6 +20,7 @@ export default defineConfig({
     Inspect(),
     devtools(),
     codegenPlugin(),
+    appConfigPlugin(),
     babelMacrosPlugin(),
     linguiSolidPlugin(),
     solidPlugin(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -4415,6 +4419,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -11772,6 +11780,8 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
Fixes #1293

Required for:

- \#999

Adds a `/.stoat-config` endpoint to the client Vite server. Currently this has the API and Gifbox endpoint (other endpoints can already be fetched via backend API, as is done in multiuser PR.)

Response example:

```json
{
    "api": "https://api.stoat.chat",
    "gifbox": "https://api.gifbox.me"
}
```

## How was this PR tested?

Ran client & tested endpoint.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

LLMs and their "world models" can't keep up with me, I'm fast as f\*\*k boiiiii
*Athletic dodging*

- `main` <!-- branch-stack -->
  - \#1308 :point\_left:
