### PR TITLE
feat: Add new user limits access strategy

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Components]()
   - [Client]()
     - [Session Lifecycle](./components/client/session-lifecycle.md)
+    - [User Limits](./components/client/user-limits.md)
   - [@revolt/i18n]()
     - [Using Lingui](./components/i18n/using-lingui.md)
     - [Using Dayjs](./components/i18n/using-dayjs.md)

--- a/doc/src/components/client/user-limits.md
+++ b/doc/src/components/client/user-limits.md
@@ -4,7 +4,7 @@ Many interactions a user can have with Stoat are limited by the backend. Any act
 
 ## Using Limits
 
-To use the limits for the logged in user, call `.getLimits()` on the client. This returns a limits object that has all backend limits that apply to the logged in user, and it takes into account if the user is new, or in the future, any other type of user that has different limits.
+The client contains a limit object at `client.limits`. This returns a limits object that has all backend limits that apply to the logged in user, and it takes into account if the user is new, or in the future, any other type of user that has different limits.
 
 Limits can only be accessed by the client, which can only be accessed inside a solid component. If access to the limits is needed outside a solid component, the limits must be passed as function parameters.
 
@@ -22,8 +22,8 @@ export function ExampleComponent() {
     // The configured signal returns whether the client has been configured. Configuring is asynchronous so it may not happen for a few milliseconds after the client is initially created in the client lifecycle. If the client is not configured, return the default defined in the Stoat limits config in the stoatchat repo.
     if (!cl.configured()) return 2000;
     // getLimits returns the limits object for the logged in user, taking into account their user type. It may return undefined if the client is unconfigured.
-    // The message_length limit is present on the limits object. The ?? 2000 safeguard is for if getLimits() returns undefined. Use the defaults defined in the Stoat limits config in the stoatchat repo.
-    return cl.getLimits()?.message_length ?? 2000;
+    // The message_length limit is present on the limits object. The ?? 2000 safeguard is for if limits returns undefined. Use the defaults defined in the Stoat limits config in the stoatchat repo.
+    return cl.limits?.message_length ?? 2000;
   };
 
   createEffect(() => {

--- a/doc/src/components/client/user-limits.md
+++ b/doc/src/components/client/user-limits.md
@@ -1,0 +1,35 @@
+# User Limits
+
+Many interactions a user can have with Stoat are limited by the backend. Any action that has a backend limit should have a matching limit in for-web.
+
+## Using Limits
+
+To use the limits for the logged in user, call `.getLimits()` on the client. This returns a limits object that has all backend limits that apply to the logged in user, and it takes into account if the user is new, or in the future, any other type of user that has different limits.
+
+Limits can only be accessed by the client, which can only be accessed inside a solid component. If access to the limits is needed outside a solid component, the limits must be passed as function parameters.
+
+When using limits, safeguard for them to be undefined or for the client to be unconfigured. The following is an example of fully safeguarded limit usage:
+
+```typescript
+import { createEffect } from "solid-js";
+import { useClient } from "@revolt/client";
+
+export function ExampleComponent() {
+  const client = useClient();
+
+  const maxMessageLength = () => {
+    const cl = client();
+    // The configured signal returns whether the client has been configured. Configuring is asynchronous so it may not happen for a few milliseconds after the client is initially created in the client lifecycle. If the client is not configured, return the default defined in the Stoat limits config in the stoatchat repo.
+    if (!cl.configured()) return 2000;
+    // getLimits returns the limits object for the logged in user, taking into account their user type. It may return undefined if the client is unconfigured.
+    // The message_length limit is present on the limits object. The ?? 2000 safeguard is for if getLimits() returns undefined. Use the defaults defined in the Stoat limits config in the stoatchat repo.
+    return cl.getLimits()?.message_length ?? 2000;
+  };
+
+  createEffect(() => {
+    // If the client has not yet been initialized (ie. lifecycle has not fully executed) this will print 2000, then the actual limit.
+    // If the client has been initialized already this will print the actual limit once.
+    console.log(maxMessageLength());
+  });
+}
+```

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -350,7 +350,7 @@ class Voice {
     };
 
     if (this.getClient().configured()) {
-      const limit = this.getClient().getLimits()?.video_resolution;
+      const limit = this.getClient().limits?.video_resolution;
 
       // TODO: Add more resolutions to stream from if they're enabled. May tie into premium users in the future?
       if (limit) {
@@ -368,7 +368,7 @@ class Voice {
           originalResolution.frameRate = 5;
           originalResolution.aspectRatio = 0;
           if (this.getClient().configured()) {
-            const limit = this.getClient().getLimits()?.video_resolution;
+            const limit = this.getClient().limits?.video_resolution;
             if (limit) {
               originalResolution.width = limit[0];
               originalResolution.height = limit[1];

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -350,10 +350,7 @@ class Voice {
     };
 
     if (this.getClient().configured()) {
-      // TODO: Use new user limits if the user is new - I don't think there's a way to do that now?
-      const limit =
-        this.getClient().configuration?.features.limits.default
-          .video_resolution;
+      const limit = this.getClient().getLimits()?.video_resolution;
 
       // TODO: Add more resolutions to stream from if they're enabled. May tie into premium users in the future?
       if (limit) {
@@ -371,10 +368,7 @@ class Voice {
           originalResolution.frameRate = 5;
           originalResolution.aspectRatio = 0;
           if (this.getClient().configured()) {
-            // TODO: Use new user limits if the user is new - I don't think there's a way to do that now?
-            const limit =
-              this.getClient().configuration?.features.limits.default
-                .video_resolution;
+            const limit = this.getClient().getLimits()?.video_resolution;
             if (limit) {
               originalResolution.width = limit[0];
               originalResolution.height = limit[1];

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -143,7 +143,7 @@ export function MessageComposition(props: Props) {
   const maxMessageLength = () => {
     const cl = client();
     if (!cl.configured()) return 2000;
-    return cl.getLimits()?.message_length ?? 2000;
+    return cl.limits?.message_length ?? 2000;
   };
 
   const isAlmostTooLong = () => messageLength() > maxMessageLength() - 200;
@@ -294,7 +294,7 @@ export function MessageComposition(props: Props) {
     const validFiles: File[] = [];
 
     const maxSize = client().configured()
-      ? (client().getLimits()?.file_upload_size_limits.attachments ??
+      ? (client().limits?.file_upload_size_limits.attachments ??
         CONFIGURATION.MAX_FILE_SIZE)
       : CONFIGURATION.MAX_FILE_SIZE;
 

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -142,7 +142,8 @@ export function MessageComposition(props: Props) {
 
   const maxMessageLength = () => {
     const cl = client();
-    return cl.configured() ? (cl.getLimits()?.message_length ?? 2000) : 2000;
+    if (!cl.configured()) return 2000;
+    return cl.getLimits()?.message_length ?? 2000;
   };
 
   const isAlmostTooLong = () => messageLength() > maxMessageLength() - 200;

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -142,9 +142,7 @@ export function MessageComposition(props: Props) {
 
   const maxMessageLength = () => {
     const cl = client();
-    return cl.configured()
-      ? (cl.configuration?.features.limits.default.message_length ?? 2000)
-      : 2000;
+    return cl.configured() ? (cl.getLimits()?.message_length ?? 2000) : 2000;
   };
 
   const isAlmostTooLong = () => messageLength() > maxMessageLength() - 200;
@@ -295,8 +293,8 @@ export function MessageComposition(props: Props) {
     const validFiles: File[] = [];
 
     const maxSize = client().configured()
-      ? (client().configuration?.features.limits.default.file_upload_size_limits
-          .attachments ?? CONFIGURATION.MAX_FILE_SIZE)
+      ? (client().getLimits()?.file_upload_size_limits.attachments ??
+        CONFIGURATION.MAX_FILE_SIZE)
       : CONFIGURATION.MAX_FILE_SIZE;
 
     for (const file of files) {


### PR DESCRIPTION
This PR allows access to user limits via the stoat.js client.

Add documentation for new user limits functionality.

This PR also updates stoat.js

## How was this PR tested?

I made sure the limits in my self host (which are different than Stoat official) were respected, as well as Stoat official's limits.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1309 :point\_left:
