### PR TITLE
fix: collected messages array staying on preemt breaking chat

### DIFF
--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -234,7 +234,10 @@ export function Messages(props: Props) {
       }
 
       // Cancel if we've been pre-empted
-      if (preempted()) return;
+      if (preempted()) {
+        collectedMessages = undefined;
+        return;
+      }
 
       // Assume we are not at the end if we jumped to a message
       // NB. we set this late to not display the "jump to bottom" bar
@@ -485,7 +488,10 @@ export function Messages(props: Props) {
         });
 
         // Cancel if we've been pre-empted
-        if (preempted()) return;
+        if (preempted()) {
+          collectedMessages = undefined;
+          return;
+        }
 
         // Check if we're at the start of the conversation
         // NB. this may be counter-intuitive because we are in history but,


### PR DESCRIPTION
Another regression from the collected messages change. If the messages were preempted the chat you're in would break forever (until it reloaded for some reason) because it would be collecting infinitely.

This fixes that hopefully by setting the `collectedMessages` array to undefined on preempt.

- `main` <!-- branch-stack -->
  - \#1310 :point\_left:
