### PR TITLE
feat: Add backend server emoji limit

### DIFF
--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -28,8 +28,17 @@ export function EmojiList(props: { server: Server }) {
   const client = useClient();
   const { openModal } = useModals();
 
+  const maxEmoji = () => {
+    const cl = client();
+    if (!cl.configured()) return CONFIGURATION.MAX_EMOJI;
+    return (
+      cl.configuration?.features.limits.global.server_emoji ??
+      CONFIGURATION.MAX_EMOJI
+    );
+  };
+
   function isDisabled() {
-    return props.server.emojis.length >= CONFIGURATION.MAX_EMOJI;
+    return props.server.emojis.length >= maxEmoji();
   }
 
   const editGroup = createFormGroup(
@@ -102,8 +111,8 @@ export function EmojiList(props: { server: Server }) {
                 <Switch
                   fallback={
                     <Trans>
-                      {CONFIGURATION.MAX_EMOJI - props.server.emojis.length}{" "}
-                      emoji slots remaining
+                      {maxEmoji() - props.server.emojis.length} emoji slots
+                      remaining
                     </Trans>
                   }
                 >

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -64,16 +64,14 @@ export default {
    */
   MAX_ATTACHMENTS: (import.meta.env.VITE_CFG_MAX_ATTACHMENTS as number) ?? 5,
   /**
-   * Maximum number of emoji a server can have
+   * Default maximum number of emoji a server can have
    */
-  MAX_EMOJI: (import.meta.env.VITE_CFG_MAX_EMOJI as number) ?? 100,
+  MAX_EMOJI: 100,
   /**
-   * Max file size allowed for uploads (in bytes)
+   * Default max file size allowed for uploads (in bytes)
    * 20 MB = 20 * 1024 * 1024 = 20,971,520 bytes
-   * I kinda wonder if this should be a setting, or something fetched from the backend dynamically.
    */
-  MAX_FILE_SIZE:
-    (import.meta.env.VITE_CFG_MAX_FILE_SIZE as number) ?? 20_000_000,
+  MAX_FILE_SIZE: 20_000_000,
   /**
    * RNNoise worklet CDN host location. Defaults to blank, which uses the url provided by the livekit-rnnoise-processor package.
    */


### PR DESCRIPTION
Add the backend limit for server emojis.

Useful for self host.

Partially addresses #1133

## How was this PR tested?

Set emoji limit to 1000 in my self host

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<img width="454" height="368" alt="image" src="https://github.com/user-attachments/assets/29fed0bb-a669-4504-93e7-31b14f404fcd" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1312 :point\_left:
