### PR TITLE
fix: use override switch for server wide role permissions

### DIFF
--- a/packages/client/components/app/interface/settings/channel/permissions/ChannelPermissionsEditor.tsx
+++ b/packages/client/components/app/interface/settings/channel/permissions/ChannelPermissionsEditor.tsx
@@ -457,7 +457,13 @@ export function ChannelPermissionsEditor(props: Props) {
                 />
               }
             >
-              <Match when={props.type.startsWith("channel_")}>
+              <Match
+                when={[
+                  "channel_default",
+                  "channel_role",
+                  "server_role",
+                ].includes(props.type)}
+              >
                 <ChannelPermissionOverride
                   key={entry.key}
                   title={entry.title}


### PR DESCRIPTION
Fixes the server role settings ui to use the override switch instead of a permission toggle, allowing for users to  deny permissions for a given role.

## How was this PR tested?

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
before:
<img width="2032" height="1162" alt="CleanShot 2026-06-29 at 05 04 39" src="https://github.com/user-attachments/assets/2c45ec38-3907-4882-9787-03bdf0a19557" />
after:
<img width="2032" height="1162" alt="CleanShot 2026-06-29 at 05 04 02" src="https://github.com/user-attachments/assets/d4a3e01b-5e41-4b5b-9413-7be0783a63e8" />

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

n/a

- `main` <!-- branch-stack -->
  - \#1313 :point\_left:
