### PR TITLE
feat: Instance context to enable routes and reactivity w/ consistent interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ RUN pnpm --filter client exec lingui compile --typescript
 # these are replaced by inject.js at container run startup
 ENV VITE_HOST=__VITE_HOST__
 ENV VITE_API_URL=__VITE_API_URL__
+ENV VITE_DEV_WS_URL=__VITE_WS_URL__
+ENV VITE_DEV_MEDIA_URL=__VITE_MEDIA_URL__
+ENV VITE_DEV_PROXY_URL=__VITE_PROXY_URL__
+ENV VITE_DEV_GIFBOX_URL=__VITE_GIFBOX_URL__
 ENV VITE_RNNOISE_WORKLET_CDN_URL=__VITE_RNNOISE_WORKLET_CDN_URL__
 
 ARG BASE_PATH=/
@@ -63,7 +67,12 @@ COPY --from=builder /build/packages/client/dist ./dist
 EXPOSE 5000
 
 # Runtime env vars (overridden by Helm chart / docker run)
+ENV VITE_HOST=""
 ENV VITE_API_URL=""
+ENV VITE_DEV_WS_URL=""
+ENV VITE_DEV_MEDIA_URL=""
+ENV VITE_DEV_PROXY_URL=""
+ENV VITE_DEV_GIFBOX_URL=""
 ENV VITE_RNNOISE_WORKLET_CDN_URL=""
 
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,13 +35,8 @@ RUN pnpm --filter client exec lingui compile --typescript
 
 # Build the client with placeholder env vars for runtime injection 
 # these are replaced by inject.js at container run startup
+ENV VITE_HOST=__VITE_HOST__
 ENV VITE_API_URL=__VITE_API_URL__
-ENV VITE_WS_URL=__VITE_WS_URL__
-ENV VITE_MEDIA_URL=__VITE_MEDIA_URL__
-ENV VITE_PROXY_URL=__VITE_PROXY_URL__
-ENV VITE_HCAPTCHA_SITEKEY=__VITE_HCAPTCHA_SITEKEY__
-ENV VITE_CFG_ENABLE_VIDEO=__VITE_CFG_ENABLE_VIDEO__
-ENV VITE_GIFBOX_URL=__VITE_GIFBOX_URL__
 ENV VITE_RNNOISE_WORKLET_CDN_URL=__VITE_RNNOISE_WORKLET_CDN_URL__
 
 ARG BASE_PATH=/
@@ -69,12 +64,6 @@ EXPOSE 5000
 
 # Runtime env vars (overridden by Helm chart / docker run)
 ENV VITE_API_URL=""
-ENV VITE_WS_URL=""
-ENV VITE_MEDIA_URL=""
-ENV VITE_PROXY_URL=""
-ENV VITE_HCAPTCHA_SITEKEY=""
-ENV VITE_CFG_ENABLE_VIDEO=""
-ENV VITE_GIFBOX_URL=""
 ENV VITE_RNNOISE_WORKLET_CDN_URL=""
 
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ If you want the client to connect to the official hosted backend instead, open t
 ```env
 # connect to local Stoat instance
 #VITE_API_URL=http://localhost:14702
-#VITE_WS_URL=ws://localhost:14703
-#VITE_MEDIA_URL=http://localhost:14704
-#VITE_PROXY_URL=http://localhost:14705
-
 ```
 
 When these variables are not set, the client automatically falls back to the official backend. (See https://github.com/stoatchat/for-web/blob/main/packages/client/components/common/lib/env.ts)

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Components]()
   - [Client]()
     - [Session Lifecycle](./components/client/session-lifecycle.md)
+    - [User Limits](./components/client/user-limits.md)
   - [@revolt/i18n]()
     - [Using Lingui](./components/i18n/using-lingui.md)
     - [Using Dayjs](./components/i18n/using-dayjs.md)

--- a/doc/src/components/client/user-limits.md
+++ b/doc/src/components/client/user-limits.md
@@ -1,0 +1,26 @@
+# User Limits
+
+Many interactions a user can have with Stoat are limited by the backend. Any action that has a backend limit should have a matching limit in for-web.
+
+## Using Limits
+
+The client contains a limit object at `client.limits`. The recommended way to access this is through the memoized and null-guarded reactive accessor, `instance.limits()`. This returns a limits object that has all backend limits that apply to the logged in user, and it takes into account if the user is new, or in the future, any other type of user that has different limits.
+
+Limits can only be accessed from within the Instance context, which close to the root level of the solid context hierarchy. If access to the limits is needed outside a solid component, they must be passed as function parameters.
+
+```ts
+import { useInstance } from "@revolt/instance";
+import { createEffect, Show } from "solid-js";
+
+export function ExampleComponent() {
+  const { limits } = useInstance();
+
+  createEffect(() => {
+    //Prints the instance's default limit before login is complete, then prints the limit for the current user.
+    console.log(limits().message_length);
+  });
+
+  //Shows the message when video is enabled on this instance and for this user.
+  return <Show when={limits().video}>Video is enabled!</Show>;
+}
+```

--- a/docker/inject.js
+++ b/docker/inject.js
@@ -16,6 +16,10 @@ const OUT_DIR = "dist_injected";
 const REPLACEMENTS = {
   __VITE_HOST__: process.env.VITE_HOST || "",
   __VITE_API_URL__: process.env.VITE_API_URL || "",
+  __VITE_WS_URL__: process.env.VITE_DEV_WS_URL || "",
+  __VITE_MEDIA_URL__: process.env.VITE_DEV_MEDIA_URL || "",
+  __VITE_PROXY_URL__: process.env.VITE_DEV_PROXY_URL || "",
+  __VITE_GIFBOX_URL__: process.env.VITE_DEV_GIFBOX_URL || "",
   __VITE_RNNOISE_WORKLET_CDN_URL__:
     process.env.VITE_RNNOISE_WORKLET_CDN_URL || "",
 };

--- a/docker/inject.js
+++ b/docker/inject.js
@@ -14,14 +14,10 @@ const OUT_DIR = "dist_injected";
 // At build time, Vite replaces import.meta.env.VITE_X with the literal string value.
 // We build with placeholder values like "__VITE_API_URL__" so they appear in the output.
 const REPLACEMENTS = {
+  __VITE_HOST__: process.env.VITE_HOST || "",
   __VITE_API_URL__: process.env.VITE_API_URL || "",
-  __VITE_WS_URL__: process.env.VITE_WS_URL || "",
-  __VITE_MEDIA_URL__: process.env.VITE_MEDIA_URL || "",
-  __VITE_PROXY_URL__: process.env.VITE_PROXY_URL || "",
-  __VITE_HCAPTCHA_SITEKEY__: process.env.VITE_HCAPTCHA_SITEKEY || "",
-  __VITE_CFG_ENABLE_VIDEO__: process.env.VITE_CFG_ENABLE_VIDEO || "",
-  __VITE_GIFBOX_URL__: process.env.VITE_GIFBOX_URL || "",
-  __VITE_RNNOISE_WORKLET_CDN_URL__: process.env.VITE_RNNOISE_WORKLET_CDN_URL || "",
+  __VITE_RNNOISE_WORKLET_CDN_URL__:
+    process.env.VITE_RNNOISE_WORKLET_CDN_URL || "",
 };
 
 console.log("Preparing injected build...");

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,16 +1,13 @@
 # connect to local Stoat instance
+VITE_HOST=localhost:4173
 VITE_API_URL=http://localhost:14702
-VITE_WS_URL=ws://localhost:14703
-VITE_MEDIA_URL=http://localhost:14704
-VITE_PROXY_URL=http://localhost:14705
-VITE_GIFBOX_URL=http://localhost:14706
 
-# specify hCaptcha sitekey
-VITE_HCAPTCHA_SITEKEY=
+# Dev server overrides (applies to default instance)
+# VITE_DEV_WS_URL=ws://localhost:14703
+# VITE_DEV_MEDIA_URL=http://localhost:14704
+# VITE_DEV_PROXY_URL=http://localhost:14705
+# VITE_DEV_GIFBOX_URL=http://localhost:14706
 
 # specify Sentry DSN
 VITE_SENTRY_DSN=
 VITE_SENTRY_TUNNEL=
-
-# configs
-VITE_CFG_ENABLE_VIDEO=

--- a/packages/client/components/app/interface/settings/UserSettings.tsx
+++ b/packages/client/components/app/interface/settings/UserSettings.tsx
@@ -5,7 +5,7 @@ import { Server } from "stoat.js";
 import { css } from "styled-system/css";
 
 import { useClient, useClientLifecycle } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useUser } from "@revolt/markdown/users";
 import { useModals } from "@revolt/modal";
 import { fetchLatestChangelog } from "@revolt/modal/modals/Changelog";
@@ -114,12 +114,7 @@ const Config: SettingsConfiguration<{ server: Server }> = {
   list(_, onClose) {
     const { pop, openModal } = useModals();
     const { logout } = useClientLifecycle();
-    const client = useClient();
-
-    const legalLinks = () =>
-      client().configured()
-        ? client().configuration?.features.legal_links
-        : undefined;
+    const { limits, config } = useInstance();
 
     return {
       context: null!,
@@ -156,7 +151,7 @@ const Config: SettingsConfiguration<{ server: Server }> = {
               </span>
             </Text>
           </Show>
-          <Show when={legalLinks()}>
+          <Show when={config.features.legal_links}>
             {(links) => (
               <Text class="label">
                 <span
@@ -266,7 +261,7 @@ const Config: SettingsConfiguration<{ server: Server }> = {
             {
               id: "voice",
               icon: <MdMic {...iconSize(20)} />,
-              title: CONFIGURATION.ENABLE_VIDEO ? (
+              title: limits().video ? (
                 <Trans>Voice & Video</Trans>
               ) : (
                 <Trans>Voice</Trans>

--- a/packages/client/components/app/interface/settings/channel/Overview.tsx
+++ b/packages/client/components/app/interface/settings/channel/Overview.tsx
@@ -5,6 +5,7 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import type { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import {
   Button,
@@ -16,7 +17,6 @@ import {
   Text,
 } from "@revolt/ui";
 
-import { useInstance } from "@revolt/instance";
 import { ChannelSettingsProps } from "../ChannelSettings";
 
 /**
@@ -78,16 +78,13 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
         body.append("file", editGroup.controls.icon.value[0]);
 
         const [key, value] = client().authenticationHeader;
-        const data: { id: string } = await fetch(
-          `${instance.mediaUrl}/icons`,
-          {
-            method: "POST",
-            body,
-            headers: {
-              [key]: value,
-            },
+        const data: { id: string } = await fetch(`${instance.mediaUrl}/icons`, {
+          method: "POST",
+          body,
+          headers: {
+            [key]: value,
           },
-        ).then((res) => res.json());
+        }).then((res) => res.json());
 
         changes.icon = data.id;
       }

--- a/packages/client/components/app/interface/settings/channel/Overview.tsx
+++ b/packages/client/components/app/interface/settings/channel/Overview.tsx
@@ -5,7 +5,6 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import type { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useModals } from "@revolt/modal";
 import {
   Button,
@@ -17,6 +16,7 @@ import {
   Text,
 } from "@revolt/ui";
 
+import { useInstance } from "@revolt/instance";
 import { ChannelSettingsProps } from "../ChannelSettings";
 
 /**
@@ -26,6 +26,7 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
   const { t } = useLingui();
   const client = useClient();
   const { openModal } = useModals();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   // we want to take the initial value only
@@ -78,7 +79,7 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
 
         const [key, value] = client().authenticationHeader;
         const data: { id: string } = await fetch(
-          `${CONFIGURATION.DEFAULT_MEDIA_URL}/icons`,
+          `${instance.mediaUrl}/icons`,
           {
             method: "POST",
             body,

--- a/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
+++ b/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
@@ -6,7 +6,6 @@ import { useMutation } from "@tanstack/solid-query";
 import { API, ChannelWebhook } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useModals } from "@revolt/modal";
 import {
   CategoryButton,
@@ -19,6 +18,7 @@ import {
 import MdContentCopy from "@material-design-icons/svg/outlined/content_copy.svg?component-solid";
 import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
 
+import { useInstance } from "@revolt/instance";
 import { useSettingsNavigation } from "../../Settings";
 
 /**
@@ -29,6 +29,7 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
   const client = useClient();
   const { showError } = useModals();
   const { navigate } = useSettingsNavigation();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   const editGroup = createFormGroup({
@@ -63,7 +64,7 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
 
         const [key, value] = client().authenticationHeader;
         const data: { id: string } = await fetch(
-          `${CONFIGURATION.DEFAULT_MEDIA_URL}/avatars`,
+          `${instance.mediaUrl}/avatars`,
           {
             method: "POST",
             body,
@@ -120,7 +121,7 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
           icon={<MdContentCopy />}
           onClick={() =>
             navigator.clipboard.writeText(
-              `${CONFIGURATION.DEFAULT_API_URL}/webhooks/${props.webhook.id}/${props.webhook.token}`,
+              `${instance.apiUrl}/webhooks/${props.webhook.id}/${props.webhook.token}`,
             )
           }
         >

--- a/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
+++ b/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
@@ -6,6 +6,7 @@ import { useMutation } from "@tanstack/solid-query";
 import { API, ChannelWebhook } from "stoat.js";
 
 import { useClient } from "@revolt/client";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import {
   CategoryButton,
@@ -18,7 +19,6 @@ import {
 import MdContentCopy from "@material-design-icons/svg/outlined/content_copy.svg?component-solid";
 import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
 
-import { useInstance } from "@revolt/instance";
 import { useSettingsNavigation } from "../../Settings";
 
 /**
@@ -121,7 +121,9 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
           icon={<MdContentCopy />}
           onClick={() =>
             navigator.clipboard.writeText(
-              `${instance.apiUrl}/webhooks/${props.webhook.id}/${props.webhook.token}`,
+              instance.href(
+                `/webhooks/${props.webhook.id}/${props.webhook.token}`,
+              ),
             )
           }
         >

--- a/packages/client/components/app/interface/settings/server/Overview.tsx
+++ b/packages/client/components/app/interface/settings/server/Overview.tsx
@@ -5,7 +5,6 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import type { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import {
   CircularProgress,
   Column,
@@ -15,6 +14,7 @@ import {
   Text,
 } from "@revolt/ui";
 
+import { useInstance } from "@revolt/instance";
 import { ServerSettingsProps } from "../ServerSettings";
 
 /**
@@ -23,6 +23,7 @@ import { ServerSettingsProps } from "../ServerSettings";
 export default function ServerOverview(props: ServerSettingsProps) {
   const { t } = useLingui();
   const client = useClient();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   const editGroup = createFormGroup({
@@ -144,7 +145,7 @@ export default function ServerOverview(props: ServerSettingsProps) {
         changes.icon = await client().uploadFile(
           "icons",
           editGroup.controls.icon.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
       }
     }
@@ -156,7 +157,7 @@ export default function ServerOverview(props: ServerSettingsProps) {
         changes.banner = await client().uploadFile(
           "banners",
           editGroup.controls.banner.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
       }
     }

--- a/packages/client/components/app/interface/settings/server/Overview.tsx
+++ b/packages/client/components/app/interface/settings/server/Overview.tsx
@@ -5,6 +5,7 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import type { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
+import { useInstance } from "@revolt/instance";
 import {
   CircularProgress,
   Column,
@@ -14,7 +15,6 @@ import {
   Text,
 } from "@revolt/ui";
 
-import { useInstance } from "@revolt/instance";
 import { ServerSettingsProps } from "../ServerSettings";
 
 /**

--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -30,7 +30,7 @@ export function EmojiList(props: { server: Server }) {
   const instance = useInstance();
 
   function isDisabled() {
-    return props.server.emojis.length >= instance.maxEmoji;
+    return props.server.emojis.length >= instance.globalLimits.server_emoji;
   }
 
   const editGroup = createFormGroup(
@@ -50,16 +50,13 @@ export function EmojiList(props: { server: Server }) {
     body.append("file", editGroup.controls.file.value![0]);
 
     const [key, value] = client().authenticationHeader;
-    const data: { id: string } = await fetch(
-      `${instance.mediaUrl}/emojis`,
-      {
-        method: "POST",
-        body,
-        headers: {
-          [key]: value,
-        },
+    const data: { id: string } = await fetch(`${instance.mediaUrl}/emojis`, {
+      method: "POST",
+      body,
+      headers: {
+        [key]: value,
       },
-    ).then((res) => res.json());
+    }).then((res) => res.json());
 
     await props.server.createEmoji(data.id, {
       name: editGroup.controls.name.value,
@@ -110,7 +107,8 @@ export function EmojiList(props: { server: Server }) {
                 <Switch
                   fallback={
                     <Trans>
-                      {instance.maxEmoji - props.server.emojis.length}{" "}
+                      {instance.globalLimits.server_emoji -
+                        props.server.emojis.length}{" "}
                       emoji slots remaining
                     </Trans>
                   }

--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -6,8 +6,8 @@ import { Server } from "stoat.js";
 import { css } from "styled-system/css";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useError } from "@revolt/i18n";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import {
   Avatar,
@@ -27,9 +27,10 @@ export function EmojiList(props: { server: Server }) {
   const { t } = useLingui();
   const client = useClient();
   const { openModal } = useModals();
+  const instance = useInstance();
 
   function isDisabled() {
-    return props.server.emojis.length >= CONFIGURATION.MAX_EMOJI;
+    return props.server.emojis.length >= instance.maxEmoji;
   }
 
   const editGroup = createFormGroup(
@@ -50,7 +51,7 @@ export function EmojiList(props: { server: Server }) {
 
     const [key, value] = client().authenticationHeader;
     const data: { id: string } = await fetch(
-      `${CONFIGURATION.DEFAULT_MEDIA_URL}/emojis`,
+      `${instance.mediaUrl}/emojis`,
       {
         method: "POST",
         body,
@@ -109,7 +110,7 @@ export function EmojiList(props: { server: Server }) {
                 <Switch
                   fallback={
                     <Trans>
-                      {CONFIGURATION.MAX_EMOJI - props.server.emojis.length}{" "}
+                      {instance.maxEmoji - props.server.emojis.length}{" "}
                       emoji slots remaining
                     </Trans>
                   }

--- a/packages/client/components/app/interface/settings/server/roles/ServerRoleEditor.tsx
+++ b/packages/client/components/app/interface/settings/server/roles/ServerRoleEditor.tsx
@@ -1,9 +1,12 @@
+import { For, Show, createMemo, createSignal } from "solid-js";
+
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
-import MdContentCopy from "@material-design-icons/svg/outlined/content_copy.svg?component-solid";
-import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
-import MDPalette from "@material-design-icons/svg/outlined/palette.svg?component-solid";
+import { createFormControl, createFormGroup } from "solid-forms";
+import { API, Server, ServerRole } from "stoat.js";
+import { styled } from "styled-system/jsx";
+
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import {
   Button,
@@ -15,10 +18,11 @@ import {
   Row,
   Text,
 } from "@revolt/ui";
-import { createFormControl, createFormGroup } from "solid-forms";
-import { For, Show, createMemo, createSignal } from "solid-js";
-import { API, Server, ServerRole } from "stoat.js";
-import { styled } from "styled-system/jsx";
+
+import MdContentCopy from "@material-design-icons/svg/outlined/content_copy.svg?component-solid";
+import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
+import MDPalette from "@material-design-icons/svg/outlined/palette.svg?component-solid";
+
 import { useSettingsNavigation } from "../../Settings";
 import { ChannelPermissionsEditor } from "../../channel/permissions/ChannelPermissionsEditor";
 
@@ -30,6 +34,7 @@ export function ServerRoleEditor(props: { context: Server; roleId: string }) {
   const client = useClient();
   const { openModal } = useModals();
   const { navigate } = useSettingsNavigation();
+  const instance = useInstance();
 
   const role = createMemo(
     () =>
@@ -65,7 +70,7 @@ export function ServerRoleEditor(props: { context: Server; roleId: string }) {
         changes.icon = await client().uploadFile(
           "icons",
           editGroup.controls.icon.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
       }
     }

--- a/packages/client/components/app/interface/settings/user/Feedback.tsx
+++ b/packages/client/components/app/interface/settings/user/Feedback.tsx
@@ -11,7 +11,7 @@ import MdFormatListNumbered from "@material-design-icons/svg/outlined/format_lis
 import MdStar from "@material-design-icons/svg/outlined/star_outline.svg?component-solid";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { CategoryButton, Column, iconSize } from "@revolt/ui";
 
@@ -22,8 +22,9 @@ export function Feedback() {
   const { openModal, pop } = useModals();
   const navigate = useNavigate();
   const client = useClient();
+  const instance = useInstance();
 
-  const showLoungeButton = CONFIGURATION.IS_STOAT;
+  const showLoungeButton = instance.isStoat;
   const isInLounge =
     client()!.servers.get("01F7ZSBSFHQ8TA81725KQCSDDP") !== undefined;
 

--- a/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
+++ b/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
@@ -2,6 +2,7 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { Bot } from "stoat.js";
 
 import { createProfileResource } from "@revolt/client/resources";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import {
   CategoryButton,
@@ -29,6 +30,7 @@ export function ViewBot(props: { bot: Bot }) {
   // `bot` will never change, so we don't care about reactivity here
   // eslint-disable-next-line solid/reactivity
   const profile = createProfileResource(props.bot.user!);
+  const instance = useInstance();
   const { openModal } = useModals();
   const snackbar = useSnackbar();
   const { t } = useLingui();
@@ -98,9 +100,8 @@ export function ViewBot(props: { bot: Bot }) {
           action="copy"
           onClick={() => {
             navigator.clipboard.writeText(
-              new URL(`/bot/${props.bot.id}`, window.origin).toString(),
+              instance.href(`/bot/${props.bot.id}`),
             );
-
             snackbar.show({
               message: t`Invite URL copied to clipboard`,
               placement: "bottom",

--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/solid-query";
 import { API, User, UserProfile } from "stoat.js";
 
 import { useClient } from "@revolt/client";
+import { useInstance } from "@revolt/instance";
 import {
   CategoryButton,
   CircularProgress,
@@ -17,7 +18,6 @@ import {
 
 import MdBadge from "@material-design-icons/svg/filled/badge.svg?component-solid";
 
-import { useInstance } from "@revolt/instance";
 import { useSettingsNavigation } from "../../Settings";
 
 interface Props {

--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -6,7 +6,6 @@ import { useQueryClient } from "@tanstack/solid-query";
 import { API, User, UserProfile } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import {
   CategoryButton,
   CircularProgress,
@@ -18,6 +17,7 @@ import {
 
 import MdBadge from "@material-design-icons/svg/filled/badge.svg?component-solid";
 
+import { useInstance } from "@revolt/instance";
 import { useSettingsNavigation } from "../../Settings";
 
 interface Props {
@@ -29,6 +29,7 @@ export function UserProfileEditor(props: Props) {
   const { t } = useLingui();
   const client = useClient();
   const queryClient = useQueryClient();
+  const instance = useInstance();
   const { navigate } = useSettingsNavigation();
 
   /* eslint-disable solid/reactivity */
@@ -93,7 +94,7 @@ export function UserProfileEditor(props: Props) {
         changes.avatar = await client().uploadFile(
           "avatars",
           editGroup.controls.avatar.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
       }
     }
@@ -125,10 +126,10 @@ export function UserProfileEditor(props: Props) {
         changes.profile.background = await client().uploadFile(
           "backgrounds",
           editGroup.controls.banner.value[0],
-          CONFIGURATION.DEFAULT_MEDIA_URL,
+          instance.mediaUrl,
         );
 
-        newBannerUrl = `${CONFIGURATION.DEFAULT_MEDIA_URL}/backgrounds/${changes.profile.background}`;
+        newBannerUrl = `${instance.mediaUrl}/backgrounds/${changes.profile.background}`;
       } else {
         newBannerUrl = editGroup.controls.banner.value;
       }

--- a/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
+++ b/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
@@ -3,7 +3,7 @@ import { useMediaDeviceSelect } from "solid-livekit-components";
 
 import { Trans } from "@lingui-solid/solid/macro";
 
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useState } from "@revolt/state";
 import {
   CategoryButton,
@@ -18,12 +18,14 @@ import { Symbol } from "@revolt/ui/components/utils/Symbol";
  * Input options
  */
 export function VoiceInputOptions() {
+  const { limits } = useInstance();
+
   return (
     <Column>
       <CategoryButton.Group>
         <SelectInput kind="audioinput" />
         <SelectInput kind="audiooutput" />
-        <Show when={CONFIGURATION.ENABLE_VIDEO}>
+        <Show when={limits().video}>
           <SelectInput kind="videoinput" />
         </Show>
       </CategoryButton.Group>

--- a/packages/client/components/app/interface/settings/user/voice/VoiceSettings.tsx
+++ b/packages/client/components/app/interface/settings/user/voice/VoiceSettings.tsx
@@ -1,20 +1,23 @@
 import { Show } from "solid-js";
 
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { Column } from "@revolt/ui";
 
 import { ScreenShareOptions } from "./ScreenShareOptions";
 import { VoiceInputOptions } from "./VoiceInputOptions";
 import { VoiceProcessingOptions } from "./VoiceProcessingOptions";
+
 /**
  * Configure voice options
  */
 export function VoiceSettings() {
+  const { limits } = useInstance();
+
   return (
     <Column gap="lg">
       <VoiceInputOptions />
       <VoiceProcessingOptions />
-      <Show when={CONFIGURATION.ENABLE_VIDEO}>
+      <Show when={limits().video}>
         <ScreenShareOptions />
       </Show>
     </Column>

--- a/packages/client/components/app/menus/ChannelContextMenu.tsx
+++ b/packages/client/components/app/menus/ChannelContextMenu.tsx
@@ -3,6 +3,7 @@ import { Match, Show, Switch } from "solid-js";
 import { Trans } from "@lingui-solid/solid/macro";
 import { Channel } from "stoat.js";
 
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
 
@@ -28,6 +29,7 @@ import { NotificationContextMenu } from "./shared/NotificationContextMenu";
  */
 export function ChannelContextMenu(props: { channel: Channel }) {
   const state = useState();
+  const instance = useInstance();
   const { openModal } = useModals();
 
   /**
@@ -111,9 +113,11 @@ export function ChannelContextMenu(props: { channel: Channel }) {
    */
   function copyLink() {
     navigator.clipboard.writeText(
-      `${location.origin}${
-        props.channel.server ? `/server/${props.channel.server?.id}` : ""
-      }/channel/${props.channel.id}`,
+      instance.href(
+        `${
+          props.channel.server ? `/server/${props.channel.server?.id}` : ""
+        }/channel/${props.channel.id}`,
+      ),
     );
   }
 

--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -4,6 +4,7 @@ import { Trans } from "@lingui-solid/solid/macro";
 import { File, Message } from "stoat.js";
 
 import { useClient, useUser } from "@revolt/client";
+import { useInstance } from "@revolt/instance";
 import { CustomEmoji, UnicodeEmoji } from "@revolt/markdown/emoji";
 import { useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
@@ -45,6 +46,7 @@ export function MessageContextMenu(props: {
 }) {
   const user = useUser();
   const state = useState();
+  const instance = useInstance();
   const client = useClient();
   const { openModal, showError } = useModals();
 
@@ -127,9 +129,11 @@ export function MessageContextMenu(props: {
    */
   function copyMessageLink() {
     navigator.clipboard.writeText(
-      `${location.origin}${
-        props.message!.server ? `/server/${props.message!.server?.id}` : ""
-      }/channel/${props.message!.channelId}/${props.message!.id}`,
+      instance.href(
+        `${
+          props.message!.server ? `/server/${props.message!.server?.id}` : ""
+        }/channel/${props.message!.channelId}/${props.message!.id}`,
+      ),
     );
   }
 

--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -61,7 +61,7 @@ export function UserContextMenu(props: {
    * Open direct message channel
    */
   function openDm() {
-    props.user.openDM().then((channel) => navigate(`/channel/${channel.id}`));
+    props.user.openDM().then((channel) => navigate(channel.path));
     props.onClose?.();
   }
 

--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
 import { useApi, useClient, useClientLifecycle } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { useNavigate, useParams } from "@revolt/routing";
 import { Button, Row, iconSize } from "@revolt/ui";
@@ -23,6 +23,7 @@ export default function FlowCreate() {
   const { code } = useParams();
   const modals = useModals();
   const { login } = useClientLifecycle();
+  const instance = useInstance();
 
   /**
    * Create an account
@@ -70,7 +71,7 @@ export default function FlowCreate() {
       <FlowTitle subtitle={<Trans>Create an account</Trans>} emoji="wave">
         <Trans>Hello!</Trans>
       </FlowTitle>
-      <Form onSubmit={create} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
+      <Form onSubmit={create} captcha={instance.hcaptcha_sitekey}>
         <Fields fields={["email", "new-password"]} />
         <Show when={isInviteOnly()}>
           <Fields fields={[{ field: "invite", value: code }]} />

--- a/packages/client/components/auth/src/flows/FlowCreate.tsx
+++ b/packages/client/components/auth/src/flows/FlowCreate.tsx
@@ -1,14 +1,14 @@
 import { Trans } from "@lingui-solid/solid/macro";
+import { Show } from "solid-js";
 
-import { useApi, useClient, useClientLifecycle } from "@revolt/client";
+import { useApi, useClientLifecycle } from "@revolt/client";
 import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { useNavigate, useParams } from "@revolt/routing";
-import { Button, Row, iconSize } from "@revolt/ui";
+import { Button, iconSize, Row } from "@revolt/ui";
 
 import MdArrowBack from "@material-design-icons/svg/filled/arrow_back.svg?component-solid";
 
-import { Show } from "solid-js";
 import { FlowTitle } from "./Flow";
 import { setFlowCheckEmail } from "./FlowCheck";
 import { Fields, Form } from "./Form";
@@ -18,12 +18,11 @@ import { Fields, Form } from "./Form";
  */
 export default function FlowCreate() {
   const api = useApi();
-  const getClient = useClient();
   const navigate = useNavigate();
   const { code } = useParams();
   const modals = useModals();
   const { login } = useClientLifecycle();
-  const instance = useInstance();
+  const { config } = useInstance();
 
   /**
    * Create an account
@@ -42,8 +41,7 @@ export default function FlowCreate() {
       ...(invite ? { invite } : {}),
     });
 
-    const client = getClient();
-    if (client.configuration && !client.configuration.features.email) {
+    if (!config.features.email) {
       await login(
         {
           email,
@@ -58,22 +56,14 @@ export default function FlowCreate() {
     }
   }
 
-  const isInviteOnly = () => {
-    const client = getClient();
-    if (client.configured()) {
-      return client.configuration?.features.invite_only;
-    }
-    return false;
-  };
-
   return (
     <>
       <FlowTitle subtitle={<Trans>Create an account</Trans>} emoji="wave">
         <Trans>Hello!</Trans>
       </FlowTitle>
-      <Form onSubmit={create} captcha={instance.hcaptcha_sitekey}>
+      <Form onSubmit={create} captcha={config.features.captcha.key}>
         <Fields fields={["email", "new-password"]} />
-        <Show when={isInviteOnly()}>
+        <Show when={config.features.invite_only}>
           <Fields fields={[{ field: "invite", value: code }]} />
         </Show>
         <Row justify>

--- a/packages/client/components/auth/src/flows/FlowResend.tsx
+++ b/packages/client/components/auth/src/flows/FlowResend.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
 import { useApi } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useNavigate } from "@revolt/routing";
 import { Button } from "@revolt/ui";
 
@@ -15,6 +15,7 @@ import { Fields, Form } from "./Form";
 export default function FlowResend() {
   const api = useApi();
   const navigate = useNavigate();
+  const instance = useInstance();
 
   /**
    * Resend email verification
@@ -38,7 +39,7 @@ export default function FlowResend() {
       <FlowTitle>
         <Trans>Resend verification</Trans>
       </FlowTitle>
-      <Form onSubmit={resend} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
+      <Form onSubmit={resend} captcha={instance.hcaptcha_sitekey}>
         <Fields fields={["email"]} />
         <Button type="submit">
           <Trans>Resend</Trans>

--- a/packages/client/components/auth/src/flows/FlowResend.tsx
+++ b/packages/client/components/auth/src/flows/FlowResend.tsx
@@ -15,7 +15,7 @@ import { Fields, Form } from "./Form";
 export default function FlowResend() {
   const api = useApi();
   const navigate = useNavigate();
-  const instance = useInstance();
+  const { config } = useInstance();
 
   /**
    * Resend email verification
@@ -39,7 +39,7 @@ export default function FlowResend() {
       <FlowTitle>
         <Trans>Resend verification</Trans>
       </FlowTitle>
-      <Form onSubmit={resend} captcha={instance.hcaptcha_sitekey}>
+      <Form onSubmit={resend} captcha={config.features.captcha.key}>
         <Fields fields={["email"]} />
         <Button type="submit">
           <Trans>Resend</Trans>

--- a/packages/client/components/auth/src/flows/FlowReset.tsx
+++ b/packages/client/components/auth/src/flows/FlowReset.tsx
@@ -1,13 +1,13 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
 import { useApi } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
 import { useNavigate } from "@revolt/routing";
 import { Button } from "@revolt/ui";
 
 import { FlowTitle } from "./Flow";
 import { setFlowCheckEmail } from "./FlowCheck";
 import { Fields, Form } from "./Form";
+import { useInstance } from "@revolt/instance";
 
 /**
  * Flow for sending password reset
@@ -15,6 +15,7 @@ import { Fields, Form } from "./Form";
 export default function FlowReset() {
   const api = useApi();
   const navigate = useNavigate();
+  const instance = useInstance();
 
   /**
    * Send password reset
@@ -38,7 +39,7 @@ export default function FlowReset() {
       <FlowTitle>
         <Trans>Reset password</Trans>
       </FlowTitle>
-      <Form onSubmit={reset} captcha={CONFIGURATION.HCAPTCHA_SITEKEY}>
+      <Form onSubmit={reset} captcha={instance.hcaptcha_sitekey}>
         <Fields fields={["email"]} />
         <Button type="submit">
           <Trans>Reset</Trans>

--- a/packages/client/components/auth/src/flows/FlowReset.tsx
+++ b/packages/client/components/auth/src/flows/FlowReset.tsx
@@ -1,13 +1,13 @@
 import { Trans } from "@lingui-solid/solid/macro";
 
 import { useApi } from "@revolt/client";
+import { useInstance } from "@revolt/instance";
 import { useNavigate } from "@revolt/routing";
 import { Button } from "@revolt/ui";
 
 import { FlowTitle } from "./Flow";
 import { setFlowCheckEmail } from "./FlowCheck";
 import { Fields, Form } from "./Form";
-import { useInstance } from "@revolt/instance";
 
 /**
  * Flow for sending password reset
@@ -15,7 +15,7 @@ import { useInstance } from "@revolt/instance";
 export default function FlowReset() {
   const api = useApi();
   const navigate = useNavigate();
-  const instance = useInstance();
+  const { config } = useInstance();
 
   /**
    * Send password reset
@@ -39,7 +39,7 @@ export default function FlowReset() {
       <FlowTitle>
         <Trans>Reset password</Trans>
       </FlowTitle>
-      <Form onSubmit={reset} captcha={instance.hcaptcha_sitekey}>
+      <Form onSubmit={reset} captcha={config.features.captcha.key}>
         <Fields fields={["email"]} />
         <Button type="submit">
           <Trans>Reset</Trans>

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -120,7 +120,7 @@ class Lifecycle {
     this.dispose();
   }
 
-  private dispose(logout = true) {
+  private dispose(logout = false) {
     if (logout) this.client.logout();
 
     this.client = this.#controller.instance.newClient();
@@ -172,7 +172,7 @@ class Lifecycle {
         this.#connectionFailures = 0;
         break;
       case State.Dispose:
-        this.dispose();
+        this.dispose(true);
         this.transition({
           type: TransitionType.Ready,
         });
@@ -211,7 +211,7 @@ class Lifecycle {
     console.debug("Received transition", transition.type);
 
     if (transition.type === TransitionType.DisposeOnly) {
-      this.dispose(false);
+      this.dispose();
       return;
     }
 

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -4,10 +4,11 @@ import { detect } from "detect-browser";
 import { API, Client, ConnectionState } from "stoat.js";
 import { ProtocolV1 } from "stoat.js/lib/events/v1";
 
-import { CONFIGURATION } from "@revolt/common";
 import { ModalControllerExtended } from "@revolt/modal";
 import type { State as ApplicationState } from "@revolt/state";
 import type { Session } from "@revolt/state/stores/Auth";
+
+import Instance from "../instance/Instance";
 import { killServiceWorkerSubscription } from "./NotificationsController";
 
 export enum State {
@@ -120,47 +121,15 @@ class Lifecycle {
   }
 
   private dispose(logout = true) {
-    if (this.client && logout) {
-      this.client.logout();
-    }
+    if (logout) this.client.logout();
 
-    this.client = new Client({
-      baseURL: CONFIGURATION.DEFAULT_API_URL,
-      autoReconnect: false,
-      syncUnreads: true,
-      debug: import.meta.env.DEV,
-      channelIsMuted: (channel) =>
-        this.#controller.state.notifications.isMuted(channel),
-      channelExclusiveMuted: (channel) =>
-        this.#controller.state.notifications.isChannelMuted(channel),
-    });
+    this.client = this.#controller.instance.newClient();
 
-    this.client.configuration = {
-      revolt: String(),
-      app: String(),
-      build: {} as never,
-      features: {
-        autumn: {
-          enabled: true,
-          url: CONFIGURATION.DEFAULT_MEDIA_URL,
-        },
-        january: {
-          enabled: true,
-          url: CONFIGURATION.DEFAULT_PROXY_URL,
-        },
-        captcha: {} as never,
-        email: true,
-        invite_only: false,
-        livekit: {
-          enabled: false,
-          nodes: [],
-        },
-        legal_links: {} as never,
-        limits: {} as never,
-      },
-      vapid: String(),
-      ws: CONFIGURATION.DEFAULT_WS_URL,
-    };
+    this.client.options.channelIsMuted = (ch) =>
+      this.#controller.state.notifications.isMuted(ch);
+
+    this.client.options.channelExclusiveMuted = (ch) =>
+      this.#controller.state.notifications.isChannelMuted(ch);
 
     this.client.events.on("state", this.onState);
     this.client.on("ready", this.onReady);
@@ -448,18 +417,19 @@ export default class ClientController {
    */
   readonly state: ApplicationState;
 
-  /**
-   * A memo to prevent isLoggedIn from bouncing when reconnecting
-   */
-  private isLoggedInState: Accessor<boolean>;
+  isLoggedIn: Accessor<boolean>;
+
+  /** Stoat instance the client belongs to. Also accessible via `useInstance()` */
+  readonly instance: Instance;
 
   /**
    * Construct new client controller
    */
-  constructor(state: ApplicationState) {
+  constructor(state: ApplicationState, instance: Instance) {
     this.state = state;
+    this.instance = instance;
     this.api = new API.API({
-      baseURL: CONFIGURATION.DEFAULT_API_URL,
+      baseURL: instance.apiUrl,
     });
 
     this.lifecycle = new Lifecycle(this);
@@ -467,10 +437,10 @@ export default class ClientController {
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
     this.selectUsername = this.selectUsername.bind(this);
-    this.isLoggedIn = this.isLoggedIn.bind(this);
     this.isError = this.isError.bind(this);
 
-    this.isLoggedInState = createMemo(() =>
+    //A memo to prevent isLoggedIn from bouncing when reconnecting
+    this.isLoggedIn = createMemo(() =>
       [
         State.Connecting,
         State.Connected,
@@ -480,25 +450,20 @@ export default class ClientController {
       ].includes(this.lifecycle.state()),
     );
 
-    const session = state.auth.getSession();
-    if (session) {
-      this.lifecycle.transition({
-        type: TransitionType.LoginCached,
-        session,
-      });
-    }
-  }
-
-  getCurrentClient() {
-    return this.lifecycle.client;
-  }
-
-  isLoggedIn() {
-    return this.isLoggedInState();
+    this.loginCached();
   }
 
   isError() {
     return this.lifecycle.state() === State.Error;
+  }
+
+  loginCached() {
+    const session = this.state.auth.getSession();
+    if (!session) return;
+    this.lifecycle.transition({
+      type: TransitionType.LoginCached,
+      session,
+    });
   }
 
   /**
@@ -588,7 +553,7 @@ export default class ClientController {
   }
 
   async selectUsername(username: string) {
-    await this.lifecycle.client.api.post("/onboard/complete", {
+    await this.instance.client.api.post("/onboard/complete", {
       username,
     });
 
@@ -599,7 +564,7 @@ export default class ClientController {
 
   logout() {
     this.state.settings.resetNotificationsState();
-    killServiceWorkerSubscription(this.getCurrentClient(), true);
+    killServiceWorkerSubscription(this.instance.client, true);
     this.state.auth.removeSession();
     this.lifecycle.transition({
       type: TransitionType.Logout,

--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -10,6 +10,7 @@ import {
 
 import type { Client, User } from "stoat.js";
 
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { fetchLatestChangelog } from "@revolt/modal/modals/Changelog";
 import { State } from "@revolt/state";
@@ -28,9 +29,10 @@ const clientContext = createContext(null! as ClientController);
  */
 export function ClientContext(props: { state: State; children: JSXElement }) {
   const { openModal } = useModals();
+  const instance = useInstance();
 
   // eslint-disable-next-line solid/reactivity
-  const controller = new ClientController(props.state);
+  const controller = new ClientController(props.state, instance);
   onCleanup(() => controller.dispose());
 
   let fetchedChangelog = false;

--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -3,7 +3,6 @@ import {
   Accessor,
   createContext,
   createEffect,
-  on,
   onCleanup,
   useContext,
 } from "solid-js";
@@ -13,7 +12,7 @@ import type { Client, User } from "stoat.js";
 import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { fetchLatestChangelog } from "@revolt/modal/modals/Changelog";
-import { State } from "@revolt/state";
+import { useState } from "@revolt/state";
 
 import ClientController from "./Controller";
 
@@ -27,56 +26,44 @@ const clientContext = createContext(null! as ClientController);
 /**
  * Mount the modal controller
  */
-export function ClientContext(props: { state: State; children: JSXElement }) {
+export function ClientContext(props: { children: JSXElement }) {
   const { openModal } = useModals();
+  const state = useState();
   const instance = useInstance();
 
-  // eslint-disable-next-line solid/reactivity
-  const controller = new ClientController(props.state, instance);
+  const controller = new ClientController(state, instance);
   onCleanup(() => controller.dispose());
 
   let fetchedChangelog = false;
-  createEffect(
-    on(
-      () => controller.isLoggedIn(),
-      (loggedIn) => {
-        if (!loggedIn || fetchedChangelog) return;
-        fetchedChangelog = true;
+  createEffect(() => {
+    if (!controller.isLoggedIn() || fetchedChangelog) return;
+    fetchedChangelog = true;
 
-        fetchLatestChangelog().then((changelog) => {
-          if (!changelog) return;
-          if (props.state["release-notes"].lastSeenId === changelog.id) return;
+    fetchLatestChangelog().then((changelog) => {
+      if (!changelog) return;
+      if (state["release-notes"].lastSeenId === changelog.id) return;
 
-          props.state["release-notes"].markSeen(
-            changelog.id,
-            changelog.published_at,
-          );
+      state["release-notes"].markSeen(changelog.id, changelog.published_at);
 
-          openModal({
-            type: "changelog",
-            changelog,
-          });
-        });
-      },
-    ),
-  );
+      openModal({
+        type: "changelog",
+        changelog,
+      });
+    });
+  });
 
-  createEffect(
-    on(
-      () => controller.lifecycle.policyAttentionRequired(),
-      (attentionRequired) => {
-        if (typeof attentionRequired !== "undefined") {
-          const [changes, acknowledge] = attentionRequired;
+  createEffect(() => {
+    const policy = controller.lifecycle.policyAttentionRequired();
+    if (policy) {
+      const [changes, acknowledge] = policy;
 
-          openModal({
-            type: "policy_change",
-            changes,
-            acknowledge,
-          });
-        }
-      },
-    ),
-  );
+      openModal({
+        type: "policy_change",
+        changes,
+        acknowledge,
+      });
+    }
+  });
 
   return (
     <clientContext.Provider value={controller}>
@@ -90,26 +77,16 @@ export function ClientContext(props: { state: State; children: JSXElement }) {
  * @returns Lifecycle information
  */
 export function useClientLifecycle() {
-  const { login, logout, selectUsername, lifecycle, isLoggedIn, isError } =
-    useContext(clientContext);
-
-  return {
-    login,
-    logout,
-    selectUsername,
-    lifecycle,
-    isLoggedIn,
-    isError,
-  };
+  return useContext(clientContext);
 }
 
 /**
- * Get the currently active client if one is available
+ * Get the currently active client
  * @returns Client
  */
 export function useClient(): Accessor<Client> {
-  const controller = useContext(clientContext);
-  return () => controller.getCurrentClient()!;
+  const instance = useInstance();
+  return () => instance.client;
 }
 
 /**
@@ -117,8 +94,8 @@ export function useClient(): Accessor<Client> {
  * @returns User
  */
 export function useUser(): Accessor<User | undefined> {
-  const controller = useContext(clientContext);
-  return () => controller.getCurrentClient()!.user;
+  const instance = useInstance();
+  return () => instance.client.user;
 }
 
 /**

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -69,14 +69,14 @@ export class Device {
 
     this.pMedia = matchMedia(Breakpoint.phone);
     this.tMedia = matchMedia(Breakpoint.tablet);
-    (this.pMedia.onchange = this.tMedia.onchange = this.onLayout.bind(this))();
+    (this.pMedia.onchange = this.tMedia.onchange = this.onLayout)();
 
     if (this.isPWA && navigator.virtualKeyboard) {
       navigator.virtualKeyboard.overlaysContent = true;
     }
   }
 
-  onLayout() {
+  onLayout = () => {
     this.setLayout(
       this.pMedia.matches
         ? "phone"
@@ -84,11 +84,11 @@ export class Device {
           ? "tablet"
           : "desktop",
     );
-  }
+  };
 
-  destroy() {
+  destroy = () => {
     this.pMedia.onchange = this.tMedia.onchange = null;
-  }
+  };
 }
 
 const deviceCtx = createContext<Device>(null! as Device);

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -1,90 +1,39 @@
-const DEFAULT_API_URL =
-  (import.meta.env.DEV ? import.meta.env.VITE_DEV_API_URL : undefined) ??
-  (import.meta.env.VITE_API_URL as string) ??
-  "https://stoat.chat/api";
+export const STOAT_HOST = "stoat.chat";
+export const STOAT_API = "https://api.stoat.chat";
+
+/** App `stoat.json` endpoint format */
+export interface AppConfig {
+  api: string;
+}
 
 export default {
   /**
    * Whether to emit additional debug information
    */
   DEBUG: import.meta.env.DEV || true,
-  /**
-   * What API server to connect to by default.
-   */
-  DEFAULT_API_URL,
-  /**
-   * Whether this is Stoat
-   */
-  IS_STOAT: [
-    // historically...
-    "https://api.revolt.chat",
-    "https://beta.revolt.chat/api",
-    "https://revolt.chat/api",
-    // ... and now:
-    "https://stoat.chat/api",
-  ].includes(DEFAULT_API_URL),
-  /**
-   * What WS server to connect to by default.
-   */
-  DEFAULT_WS_URL:
-    (import.meta.env.DEV ? import.meta.env.VITE_DEV_WS_URL : undefined) ??
-    (import.meta.env.VITE_WS_URL as string) ??
-    "wss://stoat.chat/events",
-  /**
-   * What media server to connect to by default.
-   */
-  DEFAULT_MEDIA_URL:
-    (import.meta.env.DEV ? import.meta.env.VITE_DEV_MEDIA_URL : undefined) ??
-    (import.meta.env.VITE_MEDIA_URL as string) ??
-    "https://cdn.stoatusercontent.com",
-  /**
-   * What proxy server to connect to by default.
-   */
-  DEFAULT_PROXY_URL:
-    (import.meta.env.DEV ? import.meta.env.VITE_DEV_PROXY_URL : undefined) ??
-    (import.meta.env.VITE_PROXY_URL as string) ??
-    "https://proxy.stoatusercontent.com",
-  /**
-   * What gifbox server to connect to by default.
-   */
-  DEFAULT_GIFBOX_URL:
-    (import.meta.env.DEV ? import.meta.env.VITE_DEV_GIFBOX_URL : undefined) ??
-    (import.meta.env.VITE_GIFBOX_URL as string) ??
-    "https://api.gifbox.me",
-  /**
-   * hCaptcha site key to use if enabled
-   */
-  HCAPTCHA_SITEKEY: import.meta.env.VITE_HCAPTCHA_SITEKEY as string,
-  /**
-   * Maximum number of replies a message can have
-   */
-  MAX_REPLIES: (import.meta.env.VITE_CFG_MAX_REPLIES as number) ?? 5,
-  /**
-   * Maximum number of attachments a message can have
-   */
-  MAX_ATTACHMENTS: (import.meta.env.VITE_CFG_MAX_ATTACHMENTS as number) ?? 5,
-  /**
-   * Maximum number of emoji a server can have
-   */
-  MAX_EMOJI: (import.meta.env.VITE_CFG_MAX_EMOJI as number) ?? 100,
-  /**
-   * Max file size allowed for uploads (in bytes)
-   * 20 MB = 20 * 1024 * 1024 = 20,971,520 bytes
-   * I kinda wonder if this should be a setting, or something fetched from the backend dynamically.
-   */
-  MAX_FILE_SIZE:
-    (import.meta.env.VITE_CFG_MAX_FILE_SIZE as number) ?? 20_000_000,
+  /** Default instance (without the protocol) */
+  DEFAULT_HOST:
+    (import.meta.env.DEV ? import.meta.env.VITE_DEV_HOST : undefined) ??
+    (import.meta.env.VITE_HOST as string) ??
+    STOAT_HOST,
+  /** API URL of default instance */
+  DEFAULT_API_URL:
+    (import.meta.env.DEV ? import.meta.env.VITE_DEV_API_URL : undefined) ??
+    (import.meta.env.VITE_API_URL as string) ??
+    STOAT_API,
+  /** WS server override for development */
+  DEV_WS_URL: import.meta.env.VITE_DEV_WS_URL as string | undefined,
+  /** Media server override for development */
+  DEV_MEDIA_URL: import.meta.env.VITE_DEV_MEDIA_URL as string | undefined,
+  /** Proxy server override for development */
+  DEV_PROXY_URL: import.meta.env.VITE_DEV_PROXY_URL as string | undefined,
+  /** Gifbox server override for development */
+  DEV_GIFBOX_URL: import.meta.env.VITE_DEV_GIFBOX_URL as string | undefined,
   /**
    * RNNoise worklet CDN host location. Defaults to blank, which uses the url provided by the livekit-rnnoise-processor package.
    */
   RNNOISE_WORKLET_CDN_URL:
     (import.meta.env.VITE_RNNOISE_WORKLET_CDN_URL as string) ?? "",
-  /**
-   * Enable video allows the web client to enable video and screensharing
-   */
-  ENABLE_VIDEO:
-    ((import.meta.env.VITE_CFG_ENABLE_VIDEO as string) ?? "").toLowerCase() ==
-    "true",
   /**
    * Session ID to set during development.
    */

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -6,21 +6,28 @@ export interface AppConfig {
   api: string;
 }
 
+const DEFAULT_HOST =
+  (import.meta.env.DEV ? import.meta.env.VITE_DEV_HOST : undefined) ??
+  (import.meta.env.VITE_HOST as string) ??
+  STOAT_HOST;
+
+const DEFAULT_API_URL =
+  (import.meta.env.DEV ? import.meta.env.VITE_DEV_API_URL : undefined) ??
+  (import.meta.env.VITE_API_URL as string) ??
+  STOAT_API;
+
+if (DEFAULT_API_URL !== STOAT_API && DEFAULT_HOST === STOAT_HOST)
+  throw "VITE_HOST required when VITE_API_URL is set!";
+
 export default {
   /**
    * Whether to emit additional debug information
    */
   DEBUG: import.meta.env.DEV || true,
   /** Default instance (without the protocol) */
-  DEFAULT_HOST:
-    (import.meta.env.DEV ? import.meta.env.VITE_DEV_HOST : undefined) ??
-    (import.meta.env.VITE_HOST as string) ??
-    STOAT_HOST,
+  DEFAULT_HOST,
   /** API URL of default instance */
-  DEFAULT_API_URL:
-    (import.meta.env.DEV ? import.meta.env.VITE_DEV_API_URL : undefined) ??
-    (import.meta.env.VITE_API_URL as string) ??
-    STOAT_API,
+  DEFAULT_API_URL,
   /** WS server override for development */
   DEV_WS_URL: import.meta.env.VITE_DEV_WS_URL as string | undefined,
   /** Media server override for development */

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -1,0 +1,62 @@
+export default class Instance {
+  readonly isStoat: boolean;
+  readonly apiUrl: string;
+  readonly wsUrl: string;
+  readonly mediaUrl: string;
+  readonly proxyUrl: string;
+  readonly gifboxUrl: string;
+  readonly hcaptcha_sitekey: string;
+  readonly maxEmoji: number;
+  readonly enableVideo: boolean;
+  readonly hostname: string | undefined;
+
+  // Not implemented, but should be fine for now
+  // readonly maxReplies: number;
+  // readonly maxAttachments: number;
+  // readonly maxFileSize: number;
+  // DEVELOPMENT_SESSION_ID
+  // DEVELOPMENT_TOKEN
+  // DEVELOPMENT_USER_ID
+
+  constructor(
+    apiUrl: string,
+    wsUrl: string,
+    mediaUrl: string,
+    proxyUrl: string,
+    gifboxUrl: string,
+    hcaptcha_sitekey: string,
+    maxEmoji: number,
+    enableVideo: boolean,
+    hostname?: string,
+  ) {
+    this.isStoat = [
+      // historically...
+      "https://api.revolt.chat",
+      "https://beta.revolt.chat/api",
+      "https://revolt.chat/api",
+      // ... and now:
+      "https://stoat.chat/api",
+    ].includes(apiUrl);
+    this.apiUrl = apiUrl;
+    this.wsUrl = wsUrl;
+    this.mediaUrl = mediaUrl;
+    this.proxyUrl = proxyUrl;
+    this.gifboxUrl = gifboxUrl;
+    this.hcaptcha_sitekey = hcaptcha_sitekey;
+    this.maxEmoji = maxEmoji;
+    this.enableVideo = enableVideo;
+    this.hostname = hostname;
+  }
+
+  /**
+   * Prepends the given url with this instances' base path.
+   * @param url - The url to link to.
+   */
+  href(url: string) {
+    if (!this.hostname) {
+      return url;
+    }
+
+    return `/instance/${this.hostname}${url}`;
+  }
+}

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -1,62 +1,110 @@
+import { Navigator } from "@solidjs/router";
+import { Accessor, createMemo } from "solid-js";
+
+import { CONFIGURATION } from "@revolt/common";
+import { AppConfig, STOAT_HOST } from "@revolt/common/lib/env";
+import { Client, UserLimits } from "stoat.js";
+
+import { DefaultHost, StoatOrigin } from ".";
+
+const R_RelPath = /^\/i\/[^/]+/;
+
 export default class Instance {
+  readonly host?: string;
+  readonly origin: string;
   readonly isStoat: boolean;
+  readonly #base;
+  readonly #nav;
+
   readonly apiUrl: string;
   readonly wsUrl: string;
   readonly mediaUrl: string;
   readonly proxyUrl: string;
   readonly gifboxUrl: string;
-  readonly hcaptcha_sitekey: string;
-  readonly maxEmoji: number;
-  readonly enableVideo: boolean;
-  readonly hostname: string | undefined;
 
-  // Not implemented, but should be fine for now
-  // readonly maxReplies: number;
-  // readonly maxAttachments: number;
-  // readonly maxFileSize: number;
-  // DEVELOPMENT_SESSION_ID
-  // DEVELOPMENT_TOKEN
-  // DEVELOPMENT_USER_ID
+  #firstInit = true;
+  /** Note: This is slightly risky- If you import with const braces, eg. `const { client } = useInstance()`,
+   * it won't be reactive. `useClient()` is preferred to avoid ambiguity. */
+  readonly client!: Client;
+  readonly config;
 
-  constructor(
-    apiUrl: string,
-    wsUrl: string,
-    mediaUrl: string,
-    proxyUrl: string,
-    gifboxUrl: string,
-    hcaptcha_sitekey: string,
-    maxEmoji: number,
-    enableVideo: boolean,
-    hostname?: string,
-  ) {
-    this.isStoat = [
-      // historically...
-      "https://api.revolt.chat",
-      "https://beta.revolt.chat/api",
-      "https://revolt.chat/api",
-      // ... and now:
-      "https://stoat.chat/api",
-    ].includes(apiUrl);
-    this.apiUrl = apiUrl;
-    this.wsUrl = wsUrl;
-    this.mediaUrl = mediaUrl;
-    this.proxyUrl = proxyUrl;
-    this.gifboxUrl = gifboxUrl;
-    this.hcaptcha_sitekey = hcaptcha_sitekey;
-    this.maxEmoji = maxEmoji;
-    this.enableVideo = enableVideo;
-    this.hostname = hostname;
+  //Instead of these, use the reactive limits accessor below when possible
+  readonly globalLimits;
+  readonly baseLimits;
+
+  /** Current enforced limits based on user type */
+  readonly limits: Accessor<UserLimits>;
+
+  constructor(appCfg: AppConfig, cli: Client, host: string, nav: Navigator) {
+    const apiCfg = (this.client = cli).configuration!,
+      isDef = !host || host === DefaultHost;
+
+    //Endpoints
+    this.apiUrl = appCfg.api;
+    this.wsUrl = (isDef && CONFIGURATION.DEV_WS_URL) || apiCfg.ws;
+    this.mediaUrl =
+      (isDef && CONFIGURATION.DEV_MEDIA_URL) || apiCfg.features.autumn.url;
+    this.proxyUrl =
+      (isDef && CONFIGURATION.DEV_PROXY_URL) || apiCfg.features.january.url;
+    //TODO Gifbox URL from backend
+    this.gifboxUrl =
+      (isDef && CONFIGURATION.DEV_GIFBOX_URL) || "https://api.gifbox.me";
+
+    //Features
+    this.config = apiCfg;
+    this.globalLimits = apiCfg.features.limits.global;
+    this.baseLimits = apiCfg.features.limits.new_user;
+    this.limits = createMemo(() => this.client.limits ?? this.baseLimits);
+
+    this.host = host || undefined;
+    if (!host) host = DefaultHost;
+
+    const hostUrl = new URL(`https://${host}`);
+    this.origin = hostUrl.origin;
+    this.isStoat = host === STOAT_HOST;
+    this.#base = this.isStoat ? "" : `/i/${host}`;
+    this.#nav = nav;
   }
 
-  /**
-   * Prepends the given url with this instances' base path.
-   * @param url - The url to link to.
+  /** Prepend a relative path with instance base URL
+   * @param pathOnly Get only the path component and not URL
+   * @param base Defaults to the base path of this instance
    */
-  href(url: string) {
-    if (!this.hostname) {
-      return url;
+  href = (path: string, pathOnly?: boolean, base?: string) =>
+    (pathOnly ? "" : StoatOrigin) + (base ? `/i/${base}` : this.#base) + path;
+
+  /** Convert path to relative form, stripping instance prefix (if any)
+   * @param path Defaults to `location.pathname` (non-reactive,
+   * try `useLocation().pathname` if you need reactivity)
+   */
+  static relPath = (path = location.pathname) => path.replace(R_RelPath, "");
+
+  /** Switch to a new instance and redirect the client */
+  switchTo = (host: string) =>
+    this.#nav(this.href(Instance.relPath(), true, host));
+
+  /** Create a new Stoat.js client, disposing the old one */
+  newClient() {
+    //Reuse initial client for first login only
+    if (this.#firstInit) {
+      this.#firstInit = false;
+      return this.client;
     }
 
-    return `/instance/${this.hostname}${url}`;
+    this.client.events.removeAllListeners();
+    this.client.removeAllListeners();
+    this.client.events.disconnect();
+
+    //@ts-expect-error replace client
+    return (this.client = _newClient(this.apiUrl));
   }
+}
+
+export function _newClient(apiUrl: string) {
+  return new Client({
+    baseURL: apiUrl,
+    autoReconnect: false,
+    syncUnreads: true,
+    debug: import.meta.env.DEV,
+  });
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -17,7 +17,6 @@ export default class Instance {
   readonly #nav;
 
   readonly apiUrl: string;
-  readonly wsUrl: string;
   readonly mediaUrl: string;
   readonly proxyUrl: string;
   readonly gifboxUrl: string;
@@ -41,11 +40,8 @@ export default class Instance {
 
     //Endpoints
     this.apiUrl = appCfg.api;
-    this.wsUrl = (isDef && CONFIGURATION.DEV_WS_URL) || apiCfg.ws;
-    this.mediaUrl =
-      (isDef && CONFIGURATION.DEV_MEDIA_URL) || apiCfg.features.autumn.url;
-    this.proxyUrl =
-      (isDef && CONFIGURATION.DEV_PROXY_URL) || apiCfg.features.january.url;
+    this.mediaUrl = apiCfg.features.autumn.url;
+    this.proxyUrl = apiCfg.features.january.url;
     //TODO Gifbox URL from backend
     this.gifboxUrl =
       (isDef && CONFIGURATION.DEV_GIFBOX_URL) || "https://api.gifbox.me";
@@ -101,10 +97,24 @@ export default class Instance {
 }
 
 export function _newClient(apiUrl: string) {
-  return new Client({
+  const cli = new Client({
     baseURL: apiUrl,
     autoReconnect: false,
     syncUnreads: true,
     debug: import.meta.env.DEV,
   });
+
+  //Init client with env overrides
+  cli.initConfig(() => {
+    if (cli.options.baseURL === CONFIGURATION.DEFAULT_API_URL) {
+      if (CONFIGURATION.DEV_WS_URL)
+        cli.configuration!.ws = CONFIGURATION.DEV_WS_URL;
+      if (CONFIGURATION.DEV_MEDIA_URL)
+        cli.configuration!.features.autumn.url = CONFIGURATION.DEV_MEDIA_URL;
+      if (CONFIGURATION.DEV_PROXY_URL)
+        cli.configuration!.features.january.url = CONFIGURATION.DEV_PROXY_URL;
+    }
+  });
+
+  return cli;
 }

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -35,16 +35,14 @@ export default class Instance {
   readonly limits: Accessor<UserLimits>;
 
   constructor(appCfg: AppConfig, cli: Client, host: string, nav: Navigator) {
-    const apiCfg = (this.client = cli).configuration!,
-      isDef = !host || host === DefaultHost;
+    const apiCfg = (this.client = cli).configuration!;
 
     //Endpoints
     this.apiUrl = appCfg.api;
     this.mediaUrl = apiCfg.features.autumn.url;
     this.proxyUrl = apiCfg.features.january.url;
     //TODO Gifbox URL from backend
-    this.gifboxUrl =
-      (isDef && CONFIGURATION.DEV_GIFBOX_URL) || "https://api.gifbox.me";
+    this.gifboxUrl = CONFIGURATION.DEV_GIFBOX_URL || "https://api.gifbox.me";
 
     //Features
     this.config = apiCfg;
@@ -105,14 +103,13 @@ export function _newClient(apiUrl: string) {
   });
 
   //Init client with env overrides
-  cli.initConfig(() => {
+  cli.initConfig((config) => {
     if (cli.options.baseURL === CONFIGURATION.DEFAULT_API_URL) {
-      if (CONFIGURATION.DEV_WS_URL)
-        cli.configuration!.ws = CONFIGURATION.DEV_WS_URL;
+      if (CONFIGURATION.DEV_WS_URL) config.ws = CONFIGURATION.DEV_WS_URL;
       if (CONFIGURATION.DEV_MEDIA_URL)
-        cli.configuration!.features.autumn.url = CONFIGURATION.DEV_MEDIA_URL;
+        config.features.autumn.url = CONFIGURATION.DEV_MEDIA_URL;
       if (CONFIGURATION.DEV_PROXY_URL)
-        cli.configuration!.features.january.url = CONFIGURATION.DEV_PROXY_URL;
+        config.features.january.url = CONFIGURATION.DEV_PROXY_URL;
     }
   });
 

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -1,5 +1,5 @@
 import { Navigator } from "@solidjs/router";
-import { Accessor, createMemo } from "solid-js";
+import { Accessor, createMemo, createSignal } from "solid-js";
 
 import { CONFIGURATION } from "@revolt/common";
 import { AppConfig, STOAT_HOST } from "@revolt/common/lib/env";
@@ -21,10 +21,9 @@ export default class Instance {
   readonly proxyUrl: string;
   readonly gifboxUrl: string;
 
+  #cli;
+  #setCli;
   #firstInit = true;
-  /** Note: This is slightly risky- If you import with const braces, eg. `const { client } = useInstance()`,
-   * it won't be reactive. `useClient()` is preferred to avoid ambiguity. */
-  readonly client!: Client;
   readonly config;
 
   //Instead of these, use the reactive limits accessor below when possible
@@ -32,10 +31,13 @@ export default class Instance {
   readonly baseLimits;
 
   /** Current enforced limits based on user type */
-  readonly limits: Accessor<UserLimits>;
+  readonly limits!: Accessor<UserLimits>;
 
   constructor(appCfg: AppConfig, cli: Client, host: string, nav: Navigator) {
-    const apiCfg = (this.client = cli).configuration!;
+    const apiCfg = cli.configuration!;
+    const [getCli, setCli] = createSignal(cli);
+    this.#cli = getCli;
+    this.#setCli = setCli;
 
     //Endpoints
     this.apiUrl = appCfg.api;
@@ -48,7 +50,6 @@ export default class Instance {
     this.config = apiCfg;
     this.globalLimits = apiCfg.features.limits.global;
     this.baseLimits = apiCfg.features.limits.new_user;
-    this.limits = createMemo(() => this.client.limits ?? this.baseLimits);
 
     this.host = host || undefined;
     if (!host) host = DefaultHost;
@@ -58,6 +59,18 @@ export default class Instance {
     this.isStoat = host === STOAT_HOST;
     this.#base = this.isStoat ? "" : `/i/${host}`;
     this.#nav = nav;
+  }
+
+  /** Note: This is slightly risky- If you import with const braces, eg. `const { client } = useInstance()`,
+   * it won't be reactive. `useClient()` is preferred to avoid ambiguity. */
+  get client(): Client {
+    return this.#cli();
+  }
+
+  /** Initialize reactive vars; must be called in reactive scope */
+  _init() {
+    //@ts-expect-error set readonly
+    this.limits = createMemo(() => this.client.limits ?? this.baseLimits);
   }
 
   /** Prepend a relative path with instance base URL
@@ -89,8 +102,8 @@ export default class Instance {
     this.client.removeAllListeners();
     this.client.events.disconnect();
 
-    //@ts-expect-error replace client
-    return (this.client = _newClient(this.apiUrl));
+    this.#setCli(_newClient(this.apiUrl));
+    return this.client;
   }
 }
 

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -1,0 +1,61 @@
+import { CONFIGURATION } from "@revolt/common";
+import { useParams } from "@solidjs/router";
+import { createContext, JSXElement, useContext } from "solid-js";
+import { API } from "stoat.js";
+import Instance from "./Instance";
+
+const instanceContext = createContext<Instance>();
+
+export function InstanceContext(props: { children?: JSXElement }) {
+  const params = useParams();
+
+  let apiUrl = CONFIGURATION.DEFAULT_API_URL as string;
+  let wsUrl = CONFIGURATION.DEFAULT_WS_URL as string;
+  let mediaUrl = CONFIGURATION.DEFAULT_MEDIA_URL as string;
+  let proxyUrl = CONFIGURATION.DEFAULT_PROXY_URL as string;
+
+  if (params.hostname) {
+    // TODO: Find a way to get this other than guessing
+    apiUrl = `https://${params.hostname}/api`;
+
+    const api = new API.API({
+      baseURL: apiUrl,
+    });
+
+    api.get("/").then((config) => {
+      wsUrl = config.ws;
+      mediaUrl = config.features.autumn.url;
+      proxyUrl = config.features.january.url;
+    });
+  }
+
+  return (
+    <instanceContext.Provider
+      value={
+        new Instance(
+          apiUrl,
+          wsUrl,
+          mediaUrl,
+          proxyUrl,
+          CONFIGURATION.DEFAULT_GIFBOX_URL,
+          CONFIGURATION.HCAPTCHA_SITEKEY,
+          CONFIGURATION.MAX_EMOJI,
+          CONFIGURATION.ENABLE_VIDEO,
+          params.hostname,
+        )
+      }
+    >
+      {props.children}
+    </instanceContext.Provider>
+  );
+}
+
+export function useInstance() {
+  const instance = useContext(instanceContext);
+
+  if (!instance) {
+    throw new Error("useInstance must be called inside InstanceProvider");
+  }
+
+  return instance;
+}

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -2,7 +2,6 @@ import { useLingui } from "@lingui-solid/solid/macro";
 import { useBeforeLeave, useNavigate, useParams } from "@solidjs/router";
 import {
   createContext,
-  createEffect,
   createSignal,
   JSXElement,
   Show,
@@ -63,7 +62,9 @@ export function InstanceContext(props: { children?: JSXElement }) {
     setInst(undefined);
 
     //Redirect default instance
-    if (host === DefaultHost) return nav(Instance.relPath(), { replace: true });
+    //TODO This redirects ALL instance paths to default until multi-instance is ready
+    // Replace with `if (host === DefaultHost)` when ready
+    if (host) return nav(Instance.relPath(), { replace: true });
 
     try {
       const appCfg: AppConfig = host
@@ -71,14 +72,8 @@ export function InstanceContext(props: { children?: JSXElement }) {
         : { api: CONFIGURATION.DEFAULT_API_URL };
 
       const cli = _newClient(appCfg.api);
-      let instSet = false;
-
-      createEffect(() => {
-        if (cli.configured() && !instSet) {
-          instSet = true;
-          setInst(new Instance(appCfg, cli, host, nav));
-        }
-      });
+      await cli.initConfig();
+      setInst(new Instance(appCfg, cli, host, nav));
     } catch (e) {
       onError(e);
     }
@@ -87,7 +82,9 @@ export function InstanceContext(props: { children?: JSXElement }) {
   return (
     <Show
       when={inst()}
-      fallback={<LoadingScreen isStoat={host === STOAT_HOST} />}
+      fallback={
+        <LoadingScreen isStoat={(host || DefaultHost) === STOAT_HOST} />
+      }
     >
       <Dynamic component={instanceContext.Provider} value={inst()}>
         <Redirect />

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -2,6 +2,7 @@ import { useLingui } from "@lingui-solid/solid/macro";
 import { useBeforeLeave, useNavigate, useParams } from "@solidjs/router";
 import {
   createContext,
+  createMemo,
   createSignal,
   JSXElement,
   Show,
@@ -59,8 +60,6 @@ export function InstanceContext(props: { children?: JSXElement }) {
   }
 
   (async () => {
-    setInst(undefined);
-
     //Redirect default instance
     //TODO This redirects ALL instance paths to default until multi-instance is ready
     // Replace with `if (host === DefaultHost)` when ready
@@ -79,14 +78,21 @@ export function InstanceContext(props: { children?: JSXElement }) {
     }
   })();
 
+  //Finish init in reactive scope
+  const instInit = createMemo(() => {
+    const i = inst();
+    if (i) i._init();
+    return i;
+  });
+
   return (
     <Show
-      when={inst()}
+      when={instInit()}
       fallback={
         <LoadingScreen isStoat={(host || DefaultHost) === STOAT_HOST} />
       }
     >
-      <Dynamic component={instanceContext.Provider} value={inst()}>
+      <Dynamic component={instanceContext.Provider} value={instInit()}>
         <Redirect />
         {props.children}
       </Dynamic>

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -1,61 +1,127 @@
+import { useLingui } from "@lingui-solid/solid/macro";
+import { useBeforeLeave, useNavigate, useParams } from "@solidjs/router";
+import {
+  createContext,
+  createEffect,
+  createSignal,
+  JSXElement,
+  Show,
+  useContext,
+} from "solid-js";
+import { Dynamic } from "solid-js/web";
+
 import { CONFIGURATION } from "@revolt/common";
-import { useParams } from "@solidjs/router";
-import { createContext, JSXElement, useContext } from "solid-js";
-import { API } from "stoat.js";
-import Instance from "./Instance";
+import { AppConfig, STOAT_HOST } from "@revolt/common/lib/env";
+import { LoadingScreen, useSnackbar } from "@revolt/ui";
+
+import Instance, { _newClient } from "./Instance";
+
+export const StoatOrigin = new URL(`https://${STOAT_HOST}`).origin;
+export const DefaultURL = new URL(`https://${CONFIGURATION.DEFAULT_HOST}`);
+export const DefaultHost = DefaultURL.host;
+const DefRoute = `/i/${DefaultHost}/`;
 
 const instanceContext = createContext<Instance>();
 
 export function InstanceContext(props: { children?: JSXElement }) {
   const params = useParams();
+  const snackbar = useSnackbar();
+  const nav = useNavigate();
+  const { t } = useLingui();
 
-  let apiUrl = CONFIGURATION.DEFAULT_API_URL as string;
-  let wsUrl = CONFIGURATION.DEFAULT_WS_URL as string;
-  let mediaUrl = CONFIGURATION.DEFAULT_MEDIA_URL as string;
-  let proxyUrl = CONFIGURATION.DEFAULT_PROXY_URL as string;
+  const [inst, setInst] = createSignal<Instance>();
 
-  if (params.hostname) {
-    // TODO: Find a way to get this other than guessing
-    apiUrl = `https://${params.hostname}/api`;
+  //Check Stoat instance
+  const host = [
+    // historically...
+    "api.revolt.chat",
+    "beta.revolt.chat",
+    "revolt.chat",
+    // ... and now:
+    "api.stoat.chat",
+    "beta.stoat.chat",
+  ].includes(params.host)
+    ? STOAT_HOST
+    : params.host;
 
-    const api = new API.API({
-      baseURL: apiUrl,
+  function onError(e: unknown) {
+    console.error(e);
+    if ((e as Error).message === "Failed to fetch") {
+      const hStr = `'${host}'`;
+      e = t`Couldn't fetch Stoat configuration from ${hStr}.`;
+    }
+    snackbar.show({
+      message: t`Oops, something went wrong! ${e}`,
+      placement: "bottom",
+      closeable: true,
+      autoCloseDelay: 30000,
     });
-
-    api.get("/").then((config) => {
-      wsUrl = config.ws;
-      mediaUrl = config.features.autumn.url;
-      proxyUrl = config.features.january.url;
-    });
+    history.back();
   }
 
+  (async () => {
+    setInst(undefined);
+
+    //Redirect default instance
+    if (host === DefaultHost) return nav(Instance.relPath(), { replace: true });
+
+    try {
+      const appCfg: AppConfig = host
+        ? await (await fetch(`https://${host}/.well-known/stoat`)).json()
+        : { api: CONFIGURATION.DEFAULT_API_URL };
+
+      const cli = _newClient(appCfg.api);
+      let instSet = false;
+
+      createEffect(() => {
+        if (cli.configured() && !instSet) {
+          instSet = true;
+          setInst(new Instance(appCfg, cli, host, nav));
+        }
+      });
+    } catch (e) {
+      onError(e);
+    }
+  })();
+
   return (
-    <instanceContext.Provider
-      value={
-        new Instance(
-          apiUrl,
-          wsUrl,
-          mediaUrl,
-          proxyUrl,
-          CONFIGURATION.DEFAULT_GIFBOX_URL,
-          CONFIGURATION.HCAPTCHA_SITEKEY,
-          CONFIGURATION.MAX_EMOJI,
-          CONFIGURATION.ENABLE_VIDEO,
-          params.hostname,
-        )
-      }
+    <Show
+      when={inst()}
+      fallback={<LoadingScreen isStoat={host === STOAT_HOST} />}
     >
-      {props.children}
-    </instanceContext.Provider>
+      <Dynamic component={instanceContext.Provider} value={inst()}>
+        <Redirect />
+        {props.children}
+      </Dynamic>
+    </Show>
   );
 }
 
-export function useInstance() {
-  const instance = useContext(instanceContext);
+const DEF_MARK = "_defInst";
 
-  if (!instance) {
-    throw new Error("useInstance must be called inside InstanceProvider");
-  }
+function Redirect() {
+  const inst = useInstance(),
+    nav = useNavigate();
 
-  return instance;
+  useBeforeLeave((e) => {
+    if (typeof e.to !== "string") return;
+
+    if ((e.to + "/").startsWith(DefRoute)) {
+      //Redirect default instance
+      e.preventDefault();
+      nav(Instance.relPath(e.to), { state: DEF_MARK });
+    } else if (
+      inst.host &&
+      !e.to.startsWith("/i/") &&
+      e.options?.state !== DEF_MARK
+    ) {
+      //Redirect relative path to instance path
+      e.preventDefault();
+      nav(inst.href(e.to, true));
+    }
+  });
+
+  return <></>;
 }
+
+export const useInstance = () => useContext(instanceContext)!;

--- a/packages/client/components/markdown/emoji/CustomEmoji.tsx
+++ b/packages/client/components/markdown/emoji/CustomEmoji.tsx
@@ -1,7 +1,6 @@
 import { ComponentProps, splitProps } from "solid-js";
 
-import { useClient } from "@revolt/client";
-
+import { useInstance } from "@revolt/instance";
 import { EmojiBase } from ".";
 
 /**
@@ -14,13 +13,7 @@ export function CustomEmoji(
   >,
 ) {
   const [local, remote] = splitProps(props, ["id"]);
-  const client = useClient();
-
-  /**
-   * Resolve emoji URL
-   */
-  const url = () =>
-    `${client()?.configuration?.features.autumn.url}/emojis/${local.id}`;
+  const { mediaUrl } = useInstance();
 
   return (
     <EmojiBase
@@ -28,7 +21,7 @@ export function CustomEmoji(
       loading="lazy"
       class="emoji"
       draggable={false}
-      src={url()}
+      src={`${mediaUrl}/emojis/${local.id}`}
       alt={`:${local.id}:`}
     />
   );

--- a/packages/client/components/markdown/plugins/anchors.tsx
+++ b/packages/client/components/markdown/plugins/anchors.tsx
@@ -1,10 +1,12 @@
-import { JSX, Match, Show, Switch, splitProps } from "solid-js";
+import { JSX, Show, splitProps } from "solid-js";
 
 import { Trans } from "@lingui-solid/solid/macro";
 import { cva } from "styled-system/css";
 
 import { MessageContextMenu, useMessage } from "@revolt/app";
 import { useClient } from "@revolt/client";
+import { STOAT_HOST } from "@revolt/common/lib/env";
+import { DefaultHost, useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { paramsFromPathname } from "@revolt/routing";
 import { useState } from "@revolt/state";
@@ -15,8 +17,6 @@ import { Symbol } from "@revolt/ui/components/utils/Symbol";
 import MdChat from "@material-design-icons/svg/outlined/chat.svg?component-solid";
 import MdChevronRight from "@material-design-icons/svg/outlined/chevron_right.svg?component-solid";
 import MdPeople from "@material-design-icons/svg/outlined/people.svg?component-solid";
-// import { determineLink } from "../../../lib/links";
-// import { modalController } from "../../../controllers/modals/ModalController";
 
 const link = cva({
   base: {
@@ -45,16 +45,17 @@ const internalLink = cva({
   },
 });
 
-function inAppScope(link: URL): boolean {
+function inAppScope(link: URL, root: string): boolean {
   return (
     [
-      location.origin,
+      root,
+      "https://stoat.chat",
+      "https://beta.stoat.chat",
       "https://old.stoat.chat",
       "https://revolt.chat",
       "https://app.revolt.chat",
-      "https://stoat.chat",
     ].includes(link.origin) &&
-    /\/(app|home|pwa|dev|invite|bot|friends|server|channel)\/?/.test(
+    /\/(i|app|home|pwa|dev|invite|bot|friends|server|channel)\/?/.test(
       link.pathname,
     )
   );
@@ -72,9 +73,12 @@ export function RenderAnchor(
     "disabled",
   ]);
 
-  // Handle case where there is no link
+  const instance = useInstance();
+
+  // Handle empty link
   if (!localProps.href) return <span>{remoteProps.children}</span>;
 
+  // Test internal link
   try {
     let url = new URL(localProps.href);
 
@@ -91,33 +95,36 @@ export function RenderAnchor(
     // Remap discover links to native links
     if (url.origin === "https://rvlt.gg" || url.origin === "https://stt.gg") {
       if (/^\/[\w\d]+$/.test(url.pathname)) {
-        url = new URL(`/invite${url.pathname}`, location.origin);
+        url = new URL(`/invite${url.pathname}`, instance.origin);
       } else if (url.pathname.startsWith("/discover")) {
-        url = new URL(url.pathname, location.origin);
+        url = new URL(url.pathname, instance.origin);
       }
     }
 
     // Determine whether it's in our scope
-    if (inAppScope(url)) {
-      const client = useClient();
-      const params = paramsFromPathname(url.pathname);
+    if (inAppScope(url, instance.origin)) {
+      const client = useClient(),
+        params = paramsFromPathname(url.pathname);
+
+      params.host ||= STOAT_HOST;
+      const remote = params.host !== (instance.host || DefaultHost);
 
       if (params.exactChannel) {
         const channel = () => client().channels.get(params.channelId!);
-
         const internalUrl = () =>
           new URL(
-            (channel()!.serverId
-              ? `/server/${channel()!.serverId}/channel/${channel()!.id}`
-              : `/channel/${channel()!.id}`) +
+            `/i/${params.host}` +
+              (channel()?.serverId ? `/server/${channel()!.serverId}` : "") +
+              `/channel/${params.channelId}` +
               (params.exactMessage && params.messageId
                 ? `/${params.messageId}`
                 : ""),
             location.origin,
-          ).toString();
+          ).href;
 
         return (
-          <Switch
+          <Show
+            when={remote || channel()}
             fallback={
               <span class={internalLink()}>
                 <Symbol>tag</Symbol>
@@ -125,31 +132,33 @@ export function RenderAnchor(
               </span>
             }
           >
-            <Match when={channel()}>
-              <LinkComponent
-                class={internalLink()}
-                disabled={localProps.disabled}
-                href={internalUrl()}
-              >
-                <Symbol>tag</Symbol>
-                {channel()!.name}
-                {params.exactMessage && (
-                  <>
-                    <MdChevronRight {...iconSize("1em")} />
-                    <MdChat {...iconSize("1em")} />
-                  </>
-                )}
-              </LinkComponent>
-            </Match>
-          </Switch>
+            <LinkComponent
+              class={internalLink()}
+              disabled={props.disabled}
+              href={internalUrl()}
+            >
+              <Symbol>tag</Symbol>
+              {remote ? <Trans>Remote Channel</Trans> : channel()!.name}
+              {params.exactMessage && (
+                <>
+                  <MdChevronRight {...iconSize("1em")} />
+                  <MdChat {...iconSize("1em")} />
+                </>
+              )}
+            </LinkComponent>
+          </Show>
         );
       } else if (params.exactServer) {
         const server = () => client().servers.get(params.serverId!);
         const internalUrl = () =>
-          new URL(`/server/${server()!.id}`, location.origin).toString();
+          new URL(
+            `/i/${params.host}/server/${params.serverId}`,
+            location.origin,
+          ).href;
 
         return (
-          <Switch
+          <Show
+            when={remote || server()}
             fallback={
               <span class={internalLink()}>
                 <MdPeople {...iconSize("1em")} />
@@ -157,16 +166,24 @@ export function RenderAnchor(
               </span>
             }
           >
-            <Match when={server()}>
-              <LinkComponent
-                class={internalLink()}
-                disabled={localProps.disabled}
-                href={internalUrl()}
-              >
-                <Avatar size={16} src={server()?.iconURL} /> {server()?.name}
-              </LinkComponent>
-            </Match>
-          </Switch>
+            <LinkComponent
+              class={internalLink()}
+              disabled={props.disabled}
+              href={internalUrl()}
+            >
+              {remote ? (
+                <>
+                  <MdPeople {...iconSize("1em")} />
+                  <Trans>Remote Server</Trans>
+                </>
+              ) : (
+                <>
+                  <Avatar size={16} src={server()!.iconURL} />
+                  {server()!.name}
+                </>
+              )}
+            </LinkComponent>
+          </Show>
         );
       } else if (
         params.inviteId &&
@@ -191,7 +208,7 @@ export function RenderAnchor(
       }
     }
 
-    // ... all other links:
+    // All other links
     const state = useState();
     const { openModal } = useModals();
 

--- a/packages/client/components/markdown/plugins/channels.tsx
+++ b/packages/client/components/markdown/plugins/channels.tsx
@@ -1,9 +1,12 @@
+import { useInstance } from "@revolt/instance";
 import { Plugin } from "unified";
 import { visit } from "unist-util-visit";
 
 const RE_CHANNEL = /<#([A-z0-9]{26})>/g;
 
 export const remarkChannels: Plugin = () => (tree) => {
+  const instance = useInstance();
+
   visit(
     tree,
     "text",
@@ -19,7 +22,7 @@ export const remarkChannels: Plugin = () => (tree) => {
         if (index % 2) {
           return {
             type: "link",
-            url: `${location.origin}/channel/${value}`,
+            url: instance.href(`/channel/${value}`),
           };
         }
 

--- a/packages/client/components/modal/modals/CreateInvite.tsx
+++ b/packages/client/components/modal/modals/CreateInvite.tsx
@@ -4,11 +4,11 @@ import { Trans } from "@lingui-solid/solid/macro";
 import { useMutation } from "@tanstack/solid-query";
 import { styled } from "styled-system/jsx";
 
+import { useInstance } from "@revolt/instance";
 import { Dialog, DialogProps } from "@revolt/ui";
 
 import { useModals } from "..";
 import { Modals } from "../types";
-import { useInstance } from "@revolt/instance";
 
 /**
  * Code block which displays invite
@@ -46,7 +46,7 @@ export function CreateInviteModal(
           setLink(
             instance.isStoat
               ? `https://stt.gg/${_id}`
-              : `${window.location.protocol}//${window.location.host}/invite/${_id}`,
+              : instance.href(`/invite/${_id}`),
           ),
         ),
     onError: showError,

--- a/packages/client/components/modal/modals/CreateInvite.tsx
+++ b/packages/client/components/modal/modals/CreateInvite.tsx
@@ -4,11 +4,11 @@ import { Trans } from "@lingui-solid/solid/macro";
 import { useMutation } from "@tanstack/solid-query";
 import { styled } from "styled-system/jsx";
 
-import { CONFIGURATION } from "@revolt/common";
 import { Dialog, DialogProps } from "@revolt/ui";
 
 import { useModals } from "..";
 import { Modals } from "../types";
+import { useInstance } from "@revolt/instance";
 
 /**
  * Code block which displays invite
@@ -36,6 +36,7 @@ export function CreateInviteModal(
 ) {
   const { showError } = useModals();
   const [link, setLink] = createSignal("...");
+  const instance = useInstance();
 
   const fetchInvite = useMutation(() => ({
     mutationFn: () =>
@@ -43,7 +44,7 @@ export function CreateInviteModal(
         .createInvite()
         .then(({ _id }) =>
           setLink(
-            CONFIGURATION.IS_STOAT
+            instance.isStoat
               ? `https://stt.gg/${_id}`
               : `${window.location.protocol}//${window.location.host}/invite/${_id}`,
           ),

--- a/packages/client/components/modal/modals/ServerIdentity.tsx
+++ b/packages/client/components/modal/modals/ServerIdentity.tsx
@@ -1,13 +1,13 @@
 import { createFormControl, createFormGroup } from "solid-forms";
+import { Show } from "solid-js";
 
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { API } from "stoat.js";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
 
-import { Show } from "solid-js";
 import { useModals } from "..";
 import { Modals } from "../types";
 
@@ -20,6 +20,7 @@ export function ServerIdentityModal(
   const { t } = useLingui();
   const client = useClient();
   const { showError } = useModals();
+  const instance = useInstance();
 
   /* eslint-disable solid/reactivity */
   const group = createFormGroup({
@@ -53,7 +54,7 @@ export function ServerIdentityModal(
           changes.avatar = await client().uploadFile(
             "avatars",
             group.controls.avatar.value[0],
-            CONFIGURATION.DEFAULT_MEDIA_URL,
+            instance.mediaUrl,
           );
         }
       }

--- a/packages/client/components/routing/index.tsx
+++ b/packages/client/components/routing/index.tsx
@@ -23,15 +23,16 @@ const RE_SERVER = /\/server\/([A-Z0-9]{26})/;
 const RE_CHANNEL = /\/channel\/([A-Z0-9]{26})/;
 const RE_MESSAGE_ID = /\/channel\/[A-Z0-9]{26}\/([A-Z0-9]{26})/;
 const RE_BOT_ID = /\/bot\/([A-Z0-9]{26})/;
+const RE_HOST = /^\/i\/([\w:.]+)\//;
 
-const RE_INVITE_EXACT = /^\/invite\/([\w\d]+)$/;
-const RE_BOT_ID_EXACT = /^\/bot\/[A-Z0-9]{26}$/;
+const RE_INVITE_EXACT = /^(?:\/i\/[\w:.]+)?\/invite\/([\w\d]+)$/;
+const RE_BOT_ID_EXACT = /^(?:\/i\/[\w:.]+)?\/bot\/[A-Z0-9]{26}$/;
 
-const RE_SERVER_EXACT = /^\/server\/([A-Z0-9]{26})$/;
+const RE_SERVER_EXACT = /^(?:\/i\/[\w:.]+)?\/server\/([A-Z0-9]{26})$/;
 const RE_CHANNEL_EXACT =
-  /^(?:\/server\/[A-Z0-9]{26})?\/channel\/([A-Z0-9]{26})(?:\/[A-Z0-9]{26})?$/;
+  /^(?:\/i\/[\w:.]+)?(?:\/server\/[A-Z0-9]{26})?\/channel\/([A-Z0-9]{26})(?:\/[A-Z0-9]{26})?$/;
 const RE_MESSAGE_ID_EXACT =
-  /^(?:\/server\/[A-Z0-9]{26})?\/channel\/[A-Z0-9]{26}\/([A-Z0-9]{26})$/;
+  /^(?:\/i\/[\w:.]+)?(?:\/server\/[A-Z0-9]{26})?\/channel\/[A-Z0-9]{26}\/([A-Z0-9]{26})$/;
 
 /**
  * Route parameters available globally
@@ -81,6 +82,9 @@ type GlobalParams = {
    * Exact match for bot?
    */
   exactBot: boolean;
+
+  /** Instance hostname */
+  host?: string;
 };
 
 /**
@@ -98,33 +102,27 @@ export function paramsFromPathname(pathname: string): GlobalParams {
 
   // Check for invite ID
   const invite = pathname.match(RE_INVITE_EXACT);
-  if (invite) {
-    params.inviteId = invite[1];
-  }
+  if (invite) params.inviteId = invite[1];
 
   // Check for server ID
   const server = pathname.match(RE_SERVER);
-  if (server) {
-    params.serverId = server[1];
-  }
+  if (server) params.serverId = server[1];
 
   // Check for channel ID
   const channel = pathname.match(RE_CHANNEL);
-  if (channel) {
-    params.channelId = channel[1];
-  }
+  if (channel) params.channelId = channel[1];
 
   // Check for message ID
   const message = pathname.match(RE_MESSAGE_ID);
-  if (message) {
-    params.messageId = message[1];
-  }
+  if (message) params.messageId = message[1];
 
   // Check for bot ID
   const bot = pathname.match(RE_BOT_ID);
-  if (bot) {
-    params.botId = bot[1];
-  }
+  if (bot) params.botId = bot[1];
+
+  // Check for instance host
+  const host = pathname.match(RE_HOST);
+  if (host) params.host = host[1];
 
   return params;
 }

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -22,8 +22,9 @@ import {
 import { DenoiseTrackProcessor } from "livekit-rnnoise-processor";
 import { Channel } from "stoat.js";
 
-import { SoundController, useClient, useSound } from "@revolt/client";
+import { SoundController, useSound } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { ModalController, useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
 import {
@@ -84,7 +85,8 @@ class Voice {
   private sound: SoundController;
 
   private openModal;
-  private getClient;
+  private config;
+  private limits;
   private screenShareTracks: Set<string>;
 
   constructor(
@@ -132,9 +134,10 @@ class Voice {
     this.showBar = showBar;
     this.#setShowBar = setShowBar;
 
+    const inst = useInstance();
+    this.config = inst.config;
+    this.limits = inst.limits;
     this.openModal = modals.openModal;
-
-    this.getClient = useClient();
 
     this.screenShareTracks = new Set();
   }
@@ -233,13 +236,11 @@ class Voice {
 
     // Gather latency
     const selected = await Promise.any(
-      this.getClient().configuration!.features.livekit.nodes.map(
-        async (node) => {
-          return fetch(node.public_url.replace("wss", "https")).then(() => {
-            return node.name;
-          });
-        },
-      ),
+      this.config.features.livekit.nodes.map(async (node) => {
+        return fetch(node.public_url.replace("wss", "https")).then(() => {
+          return node.name;
+        });
+      }),
     );
 
     if (!auth) {
@@ -360,54 +361,40 @@ class Voice {
       },
     };
 
-    if (this.getClient().configured()) {
-      // TODO: Use new user limits if the user is new - I don't think there's a way to do that now?
-      const limit =
-        this.getClient().configuration?.features.limits.default
-          .video_resolution;
+    const limit = this.limits().video_resolution;
 
-      // TODO: Add more resolutions to stream from if they're enabled. May tie into premium users in the future?
-      if (limit) {
-        if (
-          (limit[0] === 0 || limit[0] >= 1920) &&
-          (limit[1] === 0 || limit[1] >= 1080)
-        ) {
-          qualities.high = {
-            name: "high",
-            resolution: ScreenSharePresets.h1080fps30.resolution,
-            fullName: `1080p 30FPS`,
-            contentHint: "motion",
-          };
-          const originalResolution = ScreenSharePresets.original.resolution;
-          originalResolution.frameRate = 5;
-          originalResolution.aspectRatio = 0;
-          if (this.getClient().configured()) {
-            // TODO: Use new user limits if the user is new - I don't think there's a way to do that now?
-            const limit =
-              this.getClient().configuration?.features.limits.default
-                .video_resolution;
-            if (limit) {
-              originalResolution.width = limit[0];
-              originalResolution.height = limit[1];
-              // If both resolutions are limited, set aspect ratio
-              if (
-                originalResolution.height !== 0 &&
-                originalResolution.width !== 0
-              ) {
-                originalResolution.aspectRatio =
-                  originalResolution.width / originalResolution.height;
-              }
-            }
-          }
-          qualities.text = {
-            name: "text",
-            resolution: originalResolution,
-            fullName: `Source 5FPS`,
-            contentHint: "text",
-          };
-        }
+    // TODO: Add more resolutions to stream from if they're enabled. May tie into premium users in the future?
+    if (
+      (limit[0] === 0 || limit[0] >= 1920) &&
+      (limit[1] === 0 || limit[1] >= 1080)
+    ) {
+      qualities.high = {
+        name: "high",
+        resolution: ScreenSharePresets.h1080fps30.resolution,
+        fullName: `1080p 30FPS`,
+        contentHint: "motion",
+      };
+      const originalResolution = ScreenSharePresets.original.resolution;
+      originalResolution.frameRate = 5;
+      originalResolution.aspectRatio = 0;
+
+      const limit = this.limits().video_resolution;
+      originalResolution.width = limit[0];
+      originalResolution.height = limit[1];
+      // If both resolutions are limited, set aspect ratio
+      if (originalResolution.height !== 0 && originalResolution.width !== 0) {
+        originalResolution.aspectRatio =
+          originalResolution.width / originalResolution.height;
       }
+
+      qualities.text = {
+        name: "text",
+        resolution: originalResolution,
+        fullName: `Source 5FPS`,
+        contentHint: "text",
+      };
     }
+
     return qualities;
   }
 

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -12,6 +12,7 @@ import equal from "fast-deep-equal";
 import localforage from "localforage";
 
 import { SlideDrawer } from "@revolt/ui/components/navigation/SlideDrawer";
+
 import { AbstractStore, Store } from "./stores";
 import { Auth } from "./stores/Auth";
 import { Draft } from "./stores/Draft";
@@ -29,9 +30,8 @@ import { Sync } from "./stores/Sync";
 import { Theme } from "./stores/Theme";
 import { Voice } from "./stores/Voice";
 
-export { SyncWorker } from "./SyncWorker";
-
 export type { Sounds, TypeSounds } from "./stores/Sounds";
+export { SyncWorker } from "./SyncWorker";
 
 export { ALLOWED_IMAGE_TYPES } from "./stores/Draft";
 

--- a/packages/client/components/state/stores/Draft.ts
+++ b/packages/client/components/state/stores/Draft.ts
@@ -3,11 +3,11 @@ import { Accessor, Setter, batch, createSignal } from "solid-js";
 import { API, Channel, Client, Message } from "stoat.js";
 import { ulid } from "ulid";
 
-import { CONFIGURATION, insecureUniqueId } from "@revolt/common";
-
-import { State } from "..";
+import { insecureUniqueId } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 
 import { AbstractStore } from ".";
+import { State } from "..";
 import { LAYOUT_SECTIONS } from "./Layout";
 
 export interface DraftData {
@@ -114,6 +114,8 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
 
   _setNodeReplacement?: Setter<readonly [string | "_focus"] | undefined>;
 
+  private instance;
+
   /**
    * Construct store
    * @param state State
@@ -124,6 +126,7 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
 
     this.getFile = this.getFile.bind(this);
     this.setEditingMessageContent = this.setEditingMessageContent.bind(this);
+    this.instance = useInstance();
   }
 
   /**
@@ -252,14 +255,8 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
     channelId: string,
     data?: DraftData | ((data: DraftData) => DraftData),
   ) {
-    if (typeof data === "function") {
-      data = data(this.getDraft(channelId));
-    }
-
-    if (typeof data === "undefined") {
-      return this.clearDraft(channelId);
-    }
-
+    if (typeof data === "function") data = data(this.getDraft(channelId));
+    if (!data) return this.clearDraft(channelId);
     this.set("drafts", channelId, data);
   }
 
@@ -350,11 +347,7 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
             resolve([xhr.readyState === 4 && xhr.status === 200, xhr.response]);
           });
 
-          xhr.open(
-            "POST",
-            `${client.configuration!.features.autumn.url}/attachments`,
-            true,
-          );
+          xhr.open("POST", `${this.instance.mediaUrl}/attachments`, true);
 
           const [authHeader, authHeaderValue] = client.authenticationHeader;
           xhr.setRequestHeader(authHeader, authHeaderValue);
@@ -415,17 +408,18 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
    */
   popDraft(channelId: string) {
     const { content, replies, files } = this.getDraft(channelId);
+    const maxAttachments = this.instance.limits().message_attachments;
 
     this.setDraft(channelId, {
       content: "",
       replies: [],
-      files: files?.splice(CONFIGURATION.MAX_ATTACHMENTS),
+      files: files?.splice(maxAttachments),
     });
 
     return {
       content,
       replies,
-      files: files?.slice(0, CONFIGURATION.MAX_ATTACHMENTS),
+      files: files?.slice(0, maxAttachments),
     };
   }
 
@@ -535,7 +529,7 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
 
     if (
       (this.getDraft(message.channelId).replies?.length ?? 0) >=
-      CONFIGURATION.MAX_REPLIES
+      this.instance.globalLimits.message_replies
     ) {
       return;
     }

--- a/packages/client/components/ui/components/design/LoadingScreen.tsx
+++ b/packages/client/components/ui/components/design/LoadingScreen.tsx
@@ -2,6 +2,8 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { JSX, Show, createSignal, onCleanup, onMount } from "solid-js";
 import { styled } from "styled-system/jsx";
 
+import { useInstance } from "@revolt/instance";
+import Instance from "@revolt/instance/Instance";
 import { Button, CircularProgress, Symbol, Text } from "@revolt/ui";
 
 /**
@@ -45,18 +47,6 @@ type StatusResponse = {
 };
 
 /**
- * Whether the current origin is eligible to probe the status API
- */
-const isEligibleOrigin = () => {
-  const { hostname } = window.location;
-  return (
-    hostname === "localhost" || // (for testing)
-    hostname.endsWith(".stoat.chat") ||
-    hostname === "stoat.chat"
-  );
-};
-
-/**
  * Loading screen shown while the client connects for the first time.
  *
  * If the connection does not succeed within {@link STATUS_PROBE_DELAY}, and we
@@ -67,7 +57,8 @@ const isEligibleOrigin = () => {
  * a troubleshooting notice is shown to help the user diagnose their connection issues.
  * We also link to the support page there.
  */
-export function LoadingScreen() {
+export function LoadingScreen(props: { isStoat?: boolean }) {
+  const instance = useInstance() as Instance | undefined;
   const { t } = useLingui();
 
   const [notice, setNotice] = createSignal<
@@ -96,12 +87,12 @@ export function LoadingScreen() {
   };
 
   onMount(() => {
-    if (!isEligibleOrigin()) return;
-
     const controller = new AbortController();
 
     // Check the status API for an ongoing incident.
     const statusTimer = setTimeout(async () => {
+      //TODO Fetch status from current instance backend instead of only stoat.chat
+      if (!props.isStoat && !instance?.isStoat) return;
       try {
         const res = await fetch(STATUS_API_URL, { signal: controller.signal });
         const data = (await res.json()) as StatusResponse;

--- a/packages/client/components/ui/components/design/LoadingScreen.tsx
+++ b/packages/client/components/ui/components/design/LoadingScreen.tsx
@@ -209,6 +209,7 @@ const Base = styled("div", {
     minHeight: 0,
     alignItems: "center",
     justifyContent: "center",
+    height: "100%",
   },
 });
 

--- a/packages/client/components/ui/components/design/index.ts
+++ b/packages/client/components/ui/components/design/index.ts
@@ -38,6 +38,7 @@ export { FloatingSelect } from "./FloatingSelect";
 export { IconButton } from "./IconButton";
 export { List } from "./List";
 export { CircularProgress } from "./LoadingProgress";
+export { LoadingScreen } from "./LoadingScreen";
 export { MenuItem } from "./Menu";
 export { MenuButton } from "./MenuButton";
 export { Radio2 } from "./Radio";

--- a/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
@@ -3,7 +3,7 @@ import { For, Match, Show, Switch } from "solid-js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { ALLOWED_IMAGE_TYPES } from "@revolt/state";
 import { Ripple, typography } from "@revolt/ui/components/design";
 import { OverflowingText, iconSize } from "@revolt/ui/components/utils";
@@ -58,6 +58,8 @@ export function determineFileSize(size: number) {
  * File carousel
  */
 export function FileCarousel(props: Props) {
+  const { limits } = useInstance();
+
   return (
     <Show when={props.files.length}>
       <Container>
@@ -76,11 +78,11 @@ export function FileCarousel(props: Props) {
 
               return (
                 <>
-                  <Show when={index() === CONFIGURATION.MAX_ATTACHMENTS}>
+                  <Show when={index() === limits().message_attachments}>
                     <Divider />
                   </Show>
 
-                  <Entry ignored={index() >= CONFIGURATION.MAX_ATTACHMENTS}>
+                  <Entry ignored={index() >= limits().message_attachments}>
                     <PreviewBox
                       onClick={onClick}
                       image={ALLOWED_IMAGE_TYPES.includes(file().file.type)}

--- a/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
@@ -15,7 +15,7 @@ import { useQuery } from "@tanstack/solid-query";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
-import env from "@revolt/common/lib/env";
+import { useInstance } from "@revolt/instance";
 import { useState } from "@revolt/state";
 import {
   Button,
@@ -323,6 +323,7 @@ type CategoryItem =
 
 function Categories() {
   const client = useClient();
+  const instance = useInstance();
 
   const setFilter = useContext(FilterContext);
 
@@ -331,7 +332,7 @@ function Categories() {
     queryFn: () => {
       const [authHeader, authHeaderValue] = client()!.authenticationHeader;
 
-      return fetch(`${env.DEFAULT_GIFBOX_URL}/categories?locale=en_US`, {
+      return fetch(`${instance.gifboxUrl}/categories?locale=en_US`, {
         headers: {
           [authHeader]: authHeaderValue,
         },
@@ -441,6 +442,7 @@ const Label = styled("span", {
 
 function GifSearch(props: { query: string }) {
   const client = useClient();
+  const instance = useInstance();
 
   const { onMessage } = useContext(CompositionMediaPickerContext);
 
@@ -450,7 +452,7 @@ function GifSearch(props: { query: string }) {
       const [authHeader, authHeaderValue] = client()!.authenticationHeader;
 
       return fetch(
-        `${env.DEFAULT_GIFBOX_URL}/` +
+        `${instance.gifboxUrl}/` +
           (props.query === "trending"
             ? `trending?locale=en_US`
             : `search?locale=en_US&query=${encodeURIComponent(props.query)}`),

--- a/packages/client/components/ui/components/features/messaging/elements/SystemMessage.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/SystemMessage.tsx
@@ -16,6 +16,7 @@ import {
 import { styled } from "styled-system/jsx";
 
 import { useTime } from "@revolt/i18n";
+import { useInstance } from "@revolt/instance";
 import { time } from "@revolt/markdown/elements";
 import { RenderAnchor } from "@revolt/markdown/plugins/anchors";
 import { UserMention } from "@revolt/markdown/plugins/mentions";
@@ -43,6 +44,7 @@ interface Props {
  * System Message
  */
 export function SystemMessage(props: Props) {
+  const instance = useInstance();
   const params = useSmartParams();
   const dayjs = useTime();
 
@@ -172,11 +174,10 @@ export function SystemMessage(props: Props) {
             />{" "}
             pinned{" "}
             <RenderAnchor
-              href={
-                location.origin +
+              href={instance.href(
                 (params().serverId ? `/server/${params().serverId}` : "") +
-                `/channel/${params().channelId}/${(props.systemMessage as MessagePinnedSystemMessage).messageId}`
-              }
+                  `/channel/${params().channelId}/${(props.systemMessage as MessagePinnedSystemMessage).messageId}`,
+              )}
             />
           </Trans>
         </Match>
@@ -187,11 +188,10 @@ export function SystemMessage(props: Props) {
             />{" "}
             unpinned{" "}
             <RenderAnchor
-              href={
-                location.origin +
+              href={instance.href(
                 (params().serverId ? `/server/${params().serverId}` : "") +
-                `/channel/${params().channelId}/${(props.systemMessage as MessagePinnedSystemMessage).messageId}`
-              }
+                  `/channel/${params().channelId}/${(props.systemMessage as MessagePinnedSystemMessage).messageId}`,
+              )}
             />
           </Trans>
         </Match>

--- a/packages/client/components/ui/components/features/profiles/ProfileActions.tsx
+++ b/packages/client/components/ui/components/features/profiles/ProfileActions.tsx
@@ -31,7 +31,7 @@ export function ProfileActions(props: {
    * Open direct message channel
    */
   function openDm() {
-    props.user.openDM().then((channel) => navigate(`/channel/${channel.id}`));
+    props.user.openDM().then((channel) => navigate(channel.path));
     props.onClose();
   }
 

--- a/packages/client/components/ui/components/features/texteditor/codeMirrorWidgets.ts
+++ b/packages/client/components/ui/components/features/texteditor/codeMirrorWidgets.ts
@@ -9,7 +9,6 @@ import {
 } from "@codemirror/view";
 import { Channel, ServerMember, ServerRole, User } from "stoat.js";
 
-import { useClient } from "@revolt/client";
 import {
   RE_UNICODE_EMOJI,
   unicodeEmojiUrl,
@@ -17,11 +16,12 @@ import {
 import { userInformation } from "@revolt/markdown/users";
 import { useSmartParams } from "@revolt/routing";
 
+import { useInstance } from "@revolt/instance";
 import { parseUnicodeEmoji } from "@revolt/markdown/plugins/unicodeEmoji";
 import { isInCodeBlock } from "./codeMirrorCommon";
 
 export function codeMirrorWidgets() {
-  const getClient = useClient();
+  const instance = useInstance();
   const params = useSmartParams();
 
   const widgetMatcher = new MatchDecorator({
@@ -41,7 +41,6 @@ export function codeMirrorWidgets() {
         return null;
       }
 
-      const client = getClient();
       const { serverId } = params();
 
       let widget: WidgetType = null!;
@@ -51,28 +50,26 @@ export function codeMirrorWidgets() {
 
         widget = new EmojiWidget(unicodeEmojiUrl(pack, str));
       } else if (emojiId) {
-        widget = new EmojiWidget(
-          `${client?.configuration?.features.autumn.url}/emojis/${emojiId}`,
-        );
+        widget = new EmojiWidget(`${instance.mediaUrl}/emojis/${emojiId}`);
       } else if (userId) {
         const member = serverId
-          ? getClient().serverMembers.getByKey({
+          ? instance.client.serverMembers.getByKey({
               server: serverId,
               user: userId,
             })
           : undefined;
 
-        const user = getClient().users.get(userId);
+        const user = instance.client.users.get(userId);
 
         widget = new UserMentionWidget(user, member);
       } else if (channelId) {
-        const channel = getClient().channels.get(channelId);
+        const channel = instance.client.channels.get(channelId);
 
         if (channel) {
           widget = new ChannelMentionWidget(channel);
         }
       } else if (roleId) {
-        const role = getClient().servers.get(serverId!)?.roles.get(roleId);
+        const role = instance.client.servers.get(serverId!)?.roles.get(roleId);
 
         if (role) {
           widget = new RoleMentionWidget(role);

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -15,7 +15,7 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
   const state = useState();
   const navigate = useNavigate();
   const { t } = useLingui();
-  const { enableVideo } = useInstance();
+  const { limits } = useInstance();
 
   return (
     <Actions>
@@ -82,44 +82,44 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
       </IconButton>
       <IconButton
         size={props.size}
-        variant={enableVideo && voice.video() ? "filled" : "tonal"}
+        variant={limits().video && voice.video() ? "filled" : "tonal"}
         onPress={() => {
-          if (enableVideo) voice.toggleCamera();
+          if (limits().video) voice.toggleCamera();
         }}
         use:floating={{
           tooltip: {
             placement: "top",
-            content: enableVideo
+            content: limits().video
               ? voice.video()
                 ? t`Stop camera`
                 : t`Start camera`
               : t`Coming soon! 👀`,
           },
         }}
-        isDisabled={!enableVideo}
+        isDisabled={!limits().video}
       >
         <Symbol>camera_video</Symbol>
       </IconButton>
       <IconButton
         size={props.size}
-        variant={enableVideo && voice.screenshare() ? "filled" : "tonal"}
+        variant={limits().video && voice.screenshare() ? "filled" : "tonal"}
         onPress={() => {
-          if (enableVideo) voice.toggleScreenshare();
+          if (limits().video) voice.toggleScreenshare();
         }}
         use:floating={{
           tooltip: {
             placement: "top",
-            content: enableVideo
+            content: limits().video
               ? voice.screenshare()
                 ? t`Stop sharing`
                 : t`Share screen`
               : t`Coming soon! 👀`,
           },
         }}
-        isDisabled={!enableVideo}
+        isDisabled={!limits().video}
       >
         <Show
-          when={!enableVideo || voice.screenshare()}
+          when={!limits().video || voice.screenshare()}
           fallback={<Symbol>stop_screen_share</Symbol>}
         >
           <Symbol>screen_share</Symbol>

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -4,7 +4,7 @@ import { Show } from "solid-js";
 import { useLingui } from "@lingui-solid/solid/macro";
 import { styled } from "styled-system/jsx";
 
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useVoice } from "@revolt/rtc";
 import { useState } from "@revolt/state";
 import { Button, IconButton } from "@revolt/ui/components/design";
@@ -15,8 +15,7 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
   const state = useState();
   const navigate = useNavigate();
   const { t } = useLingui();
-
-  const enableVideo = CONFIGURATION.ENABLE_VIDEO;
+  const { enableVideo } = useInstance();
 
   return (
     <Actions>

--- a/packages/client/src/Interface.tsx
+++ b/packages/client/src/Interface.tsx
@@ -20,9 +20,9 @@ import { useModals } from "@revolt/modal";
 import { Navigate, useBeforeLeave, useLocation } from "@revolt/routing";
 import { useState } from "@revolt/state";
 import { LAYOUT_SECTIONS } from "@revolt/state/stores/Layout";
+import { LoadingScreen } from "@revolt/ui";
 
 import { SlideDrawer } from "../components/ui/components/navigation/SlideDrawer";
-import { LoadingScreen } from "./LoadingScreen";
 import { Sidebar } from "./interface/Sidebar";
 
 /**

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -39,6 +39,7 @@ import {
 /* @refresh reload */
 import "@revolt/ui/styles";
 
+import { InstanceContext } from "@revolt/instance";
 import { AndroidNag } from "./AndroidNag";
 import AuthPage from "./Auth";
 import Interface from "./Interface";
@@ -129,67 +130,83 @@ function MountContext(props: { children?: JSX.Element }) {
   const snackbarController = new SnackbarController();
 
   return (
-    <KeybindContext>
-      <ModalContext>
-        <ClientContext state={state}>
-          <I18nProvider>
-            <SoundContext>
-              <VoiceContext>
-                <QueryClientProvider client={client}>
-                  <SnackbarProvider controller={snackbarController}>
-                    {props.children}
-                    <ModalRenderer />
-                    <FloatingManager />
-                    <AndroidNag />
-                  </SnackbarProvider>
-                </QueryClientProvider>
-              </VoiceContext>
-            </SoundContext>
-          </I18nProvider>
-          <SyncWorker />
-        </ClientContext>
-      </ModalContext>
-    </KeybindContext>
+    <>
+      <KeybindContext>
+        <ModalContext>
+          <ClientContext state={state}>
+            <I18nProvider>
+              <SoundContext>
+                <VoiceContext>
+                  <QueryClientProvider client={client}>
+                    <SnackbarProvider controller={snackbarController}>
+                      {props.children}
+                      <ModalRenderer />
+                      <FloatingManager />
+                      <AndroidNag />
+                    </SnackbarProvider>
+                  </QueryClientProvider>
+                </VoiceContext>
+              </SoundContext>
+            </I18nProvider>
+            <SyncWorker />
+          </ClientContext>
+        </ModalContext>
+      </KeybindContext>
+      <LoadTheme />
+    </>
   );
 }
 
+const routes = (
+  <>
+    <Route component={StateContext}>
+      <Route component={MountContext}>
+        <Route path="/login" component={AuthPage as never}>
+          <Route path="/delete/:token" component={FlowDeleteAccount} />
+          <Route path="/check" component={FlowCheck} />
+          <Route path="/create" component={FlowCreate} />
+          <Route path="/create/:code" component={FlowCreate} />
+          <Route path="/auth" component={FlowLogin} />
+          <Route path="/resend" component={FlowResend} />
+          <Route path="/reset" component={FlowReset} />
+          <Route path="/verify/:token" component={FlowVerify} />
+          <Route path="/reset/:token" component={FlowConfirmReset} />
+          <Route path="/*" component={FlowHome} />
+        </Route>
+        <Route path="/" component={Interface as never}>
+          <Route path="/pwa" component={PWARedirect} />
+          <Route path="/dev" component={DevelopmentPage} />
+          <Route path="/discover/*" component={Discover} />
+          <Route path="/settings" component={SettingsRedirect} />
+          <Route path="/invite/:code" component={InviteRedirect} />
+          <Route path="/bot/:code" component={BotRedirect} />
+          <Route path="/friends" component={Friends} />
+          <Route path="/server/:server/*">
+            <Route path="/channel/:channel/*" component={ChannelPage} />
+            <Route path="/*" component={ServerHome} />
+          </Route>
+          <Route path="/channel/:channel/*" component={ChannelPage} />
+          <Route path="/*" component={HomePage} />
+        </Route>
+      </Route>
+    </Route>
+  </>
+);
+
+// TODO: update urls to instance-specific ones as needed
 render(
   () => (
     <DeviceContext>
-      <StateContext>
-        <Router root={MountContext}>
-          <Route path="/login" component={AuthPage as never}>
-            <Route path="/delete/:token" component={FlowDeleteAccount} />
-            <Route path="/check" component={FlowCheck} />
-            <Route path="/create" component={FlowCreate} />
-            <Route path="/create/:code" component={FlowCreate} />
-            <Route path="/auth" component={FlowLogin} />
-            <Route path="/resend" component={FlowResend} />
-            <Route path="/reset" component={FlowReset} />
-            <Route path="/verify/:token" component={FlowVerify} />
-            <Route path="/reset/:token" component={FlowConfirmReset} />
-            <Route path="/*" component={FlowHome} />
-          </Route>
-          <Route path="/" component={Interface as never}>
-            <Route path="/pwa" component={PWARedirect} />
-            <Route path="/dev" component={DevelopmentPage} />
-            <Route path="/discover/*" component={Discover} />
-            <Route path="/settings" component={SettingsRedirect} />
-            <Route path="/invite/:code" component={InviteRedirect} />
-            <Route path="/bot/:code" component={BotRedirect} />
-            <Route path="/friends" component={Friends} />
-            <Route path="/server/:server/*">
-              <Route path="/channel/:channel/*" component={ChannelPage} />
-              <Route path="/*" component={ServerHome} />
-            </Route>
-            <Route path="/channel/:channel/*" component={ChannelPage} />
-            <Route path="/*" component={HomePage} />
-          </Route>
-        </Router>
+      <Router>
+        <Route path="/" component={InstanceContext}>
+          {routes}
+        </Route>
+        <Route path="/instance/:hostname" component={InstanceContext}>
+          {routes}
+        </Route>
+      </Router>
 
-        <LoadTheme />
-        {/* <ReportBug /> */}
-      </StateContext>
+      {/* <ReportBug /> */}
     </DeviceContext>
   ),
   document.getElementById("root") as HTMLElement,

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -183,9 +183,9 @@ render(
       <I18nProvider>
         <SnackbarProvider controller={snackbarCtrl}>
           <Router>
-            {/* <Route path="/i/:host" component={InstanceContext}>
-            {routes()}
-          </Route> */}
+            <Route path="/i/:host" component={InstanceContext}>
+              {routes()}
+            </Route>
             <Route path="/" component={InstanceContext}>
               {routes()}
             </Route>

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -25,6 +25,7 @@ import FlowVerify from "@revolt/auth/src/flows/FlowVerify";
 import { ClientContext, SoundContext, useClient } from "@revolt/client";
 import { DeviceContext } from "@revolt/common";
 import { I18nProvider } from "@revolt/i18n";
+import { InstanceContext } from "@revolt/instance";
 import { KeybindContext } from "@revolt/keybinds";
 import { ModalContext, ModalRenderer, useModals } from "@revolt/modal";
 import { VoiceContext } from "@revolt/rtc";
@@ -39,7 +40,6 @@ import {
 /* @refresh reload */
 import "@revolt/ui/styles";
 
-import { InstanceContext } from "@revolt/instance";
 import { AndroidNag } from "./AndroidNag";
 import AuthPage from "./Auth";
 import Interface from "./Interface";
@@ -117,96 +117,82 @@ function BotRedirect() {
 }
 
 function MountContext(props: { children?: JSX.Element }) {
-  const state = useState();
-
-  /**
-   * Tanstack Query client
-   */
   const client = new QueryClient();
 
-  /**
-   * Snackbar controller
-   */
-  const snackbarController = new SnackbarController();
-
   return (
-    <>
+    <StateContext>
       <KeybindContext>
         <ModalContext>
-          <ClientContext state={state}>
-            <I18nProvider>
-              <SoundContext>
-                <VoiceContext>
-                  <QueryClientProvider client={client}>
-                    <SnackbarProvider controller={snackbarController}>
-                      {props.children}
-                      <ModalRenderer />
-                      <FloatingManager />
-                      <AndroidNag />
-                    </SnackbarProvider>
-                  </QueryClientProvider>
-                </VoiceContext>
-              </SoundContext>
-            </I18nProvider>
+          <ClientContext>
+            <SoundContext>
+              <VoiceContext>
+                <QueryClientProvider client={client}>
+                  {props.children}
+                  <ModalRenderer />
+                  <FloatingManager />
+                  <AndroidNag />
+                </QueryClientProvider>
+              </VoiceContext>
+            </SoundContext>
             <SyncWorker />
           </ClientContext>
         </ModalContext>
       </KeybindContext>
       <LoadTheme />
-    </>
+    </StateContext>
   );
 }
 
-const routes = (
-  <>
-    <Route component={StateContext}>
-      <Route component={MountContext}>
-        <Route path="/login" component={AuthPage as never}>
-          <Route path="/delete/:token" component={FlowDeleteAccount} />
-          <Route path="/check" component={FlowCheck} />
-          <Route path="/create" component={FlowCreate} />
-          <Route path="/create/:code" component={FlowCreate} />
-          <Route path="/auth" component={FlowLogin} />
-          <Route path="/resend" component={FlowResend} />
-          <Route path="/reset" component={FlowReset} />
-          <Route path="/verify/:token" component={FlowVerify} />
-          <Route path="/reset/:token" component={FlowConfirmReset} />
-          <Route path="/*" component={FlowHome} />
-        </Route>
-        <Route path="/" component={Interface as never}>
-          <Route path="/pwa" component={PWARedirect} />
-          <Route path="/dev" component={DevelopmentPage} />
-          <Route path="/discover/*" component={Discover} />
-          <Route path="/settings" component={SettingsRedirect} />
-          <Route path="/invite/:code" component={InviteRedirect} />
-          <Route path="/bot/:code" component={BotRedirect} />
-          <Route path="/friends" component={Friends} />
-          <Route path="/server/:server/*">
-            <Route path="/channel/:channel/*" component={ChannelPage} />
-            <Route path="/*" component={ServerHome} />
-          </Route>
-          <Route path="/channel/:channel/*" component={ChannelPage} />
-          <Route path="/*" component={HomePage} />
-        </Route>
-      </Route>
+const routes = () => (
+  <Route component={MountContext}>
+    <Route path="/login" component={AuthPage as never}>
+      <Route path="/delete/:token" component={FlowDeleteAccount} />
+      <Route path="/check" component={FlowCheck} />
+      <Route path="/create" component={FlowCreate} />
+      <Route path="/create/:code" component={FlowCreate} />
+      <Route path="/auth" component={FlowLogin} />
+      <Route path="/resend" component={FlowResend} />
+      <Route path="/reset" component={FlowReset} />
+      <Route path="/verify/:token" component={FlowVerify} />
+      <Route path="/reset/:token" component={FlowConfirmReset} />
+      <Route path="/*" component={FlowHome} />
     </Route>
-  </>
+    <Route path="/" component={Interface as never}>
+      <Route path="/pwa" component={PWARedirect} />
+      <Route path="/dev" component={DevelopmentPage} />
+      <Route path="/discover/*" component={Discover} />
+      <Route path="/settings" component={SettingsRedirect} />
+      <Route path="/invite/:code" component={InviteRedirect} />
+      <Route path="/bot/:code" component={BotRedirect} />
+      <Route path="/friends" component={Friends} />
+      <Route path="/server/:server/*">
+        <Route path="/channel/:channel/*" component={ChannelPage} />
+        <Route path="/*" component={ServerHome} />
+      </Route>
+      <Route path="/channel/:channel/*" component={ChannelPage} />
+      <Route path="/*" component={HomePage} />
+    </Route>
+  </Route>
 );
 
-// TODO: update urls to instance-specific ones as needed
+const snackbarCtrl = new SnackbarController();
+
 render(
   () => (
     <DeviceContext>
-      <Router>
-        <Route path="/" component={InstanceContext}>
-          {routes}
-        </Route>
-        <Route path="/instance/:hostname" component={InstanceContext}>
-          {routes}
-        </Route>
-      </Router>
-
-      {/* <ReportBug /> */}
+      <I18nProvider>
+        <SnackbarProvider controller={snackbarCtrl}>
+          <Router>
+            {/* <Route path="/i/:host" component={InstanceContext}>
+            {routes()}
+          </Route> */}
+            <Route path="/" component={InstanceContext}>
+              {routes()}
+            </Route>
+          </Router>
+          {/* <ReportBug /> */}
+        </SnackbarProvider>
+      </I18nProvider>
     </DeviceContext>
   ),
   document.getElementById("root") as HTMLElement,

--- a/packages/client/src/interface/Home.tsx
+++ b/packages/client/src/interface/Home.tsx
@@ -6,7 +6,7 @@ import { css, cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { IS_DEV, useClient } from "@revolt/client";
-import { CONFIGURATION } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { useNavigate } from "@revolt/routing";
 import {
@@ -96,9 +96,10 @@ export function HomePage() {
   const { openModal } = useModals();
   const navigate = useNavigate();
   const client = useClient();
+  const instance = useInstance();
 
   // check if we're stoat.chat; if so, check if the user is in the Lounge
-  const showLoungeButton = CONFIGURATION.IS_STOAT;
+  const showLoungeButton = instance.isStoat;
   const isInLounge =
     client()!.servers.get("01F7ZSBSFHQ8TA81725KQCSDDP") !== undefined;
 
@@ -187,7 +188,7 @@ export function HomePage() {
             </CategoryButton>
           </SeparatedColumn>
           <SeparatedColumn>
-            <Show when={CONFIGURATION.IS_STOAT}>
+            <Show when={instance.isStoat}>
               <CategoryButton
                 onClick={() => navigate("/discover")}
                 description={

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -17,7 +17,8 @@ import { Channel } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION, debounce } from "@revolt/common";
+import { debounce } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { Keybind, KeybindAction, createKeybind } from "@revolt/keybinds";
 import { useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
@@ -55,6 +56,7 @@ export function MessageComposition(props: Props) {
   const state = useState();
   const { t } = useLingui();
   const client = useClient();
+  const { limits } = useInstance();
   const { openModal } = useModals();
 
   const currentSlowmode = (): UserSlowmodes | undefined => {
@@ -139,16 +141,8 @@ export function MessageComposition(props: Props) {
   }
 
   const messageLength = () => draft().content?.length ?? 0;
-
-  const maxMessageLength = () => {
-    const cl = client();
-    return cl.configured()
-      ? (cl.configuration?.features.limits.default.message_length ?? 2000)
-      : 2000;
-  };
-
+  const maxMessageLength = () => limits().message_length;
   const isAlmostTooLong = () => messageLength() > maxMessageLength() - 200;
-
   const wayTooLong = () => messageLength() > maxMessageLength() + 9999;
 
   // Whether the send button should be active/clickable
@@ -293,11 +287,7 @@ export function MessageComposition(props: Props) {
   function onFiles(files: File[]) {
     const rejectedFiles: File[] = [];
     const validFiles: File[] = [];
-
-    const maxSize = client().configured()
-      ? (client().configuration?.features.limits.default.file_upload_size_limits
-          .attachments ?? CONFIGURATION.MAX_FILE_SIZE)
-      : CONFIGURATION.MAX_FILE_SIZE;
+    const maxSize = limits().file_upload_size_limits.attachments;
 
     for (const file of files) {
       if (file.size > maxSize) {

--- a/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
@@ -8,6 +8,8 @@ import { styled } from "styled-system/jsx";
 
 import { ChannelContextMenu, UserContextMenu } from "@revolt/app";
 import { useClient } from "@revolt/client";
+import { useDevice } from "@revolt/common";
+import Instance from "@revolt/instance/Instance";
 import { TextWithEmoji } from "@revolt/markdown";
 import { useModals } from "@revolt/modal";
 import { useLocation, useNavigate } from "@revolt/routing";
@@ -25,7 +27,6 @@ import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
 import MdClose from "@material-design-icons/svg/outlined/close.svg?component-solid";
 
-import { useDevice } from "@revolt/common";
 import { SidebarBase } from "./common";
 
 interface Props {
@@ -79,7 +80,11 @@ export const HomeSidebar = (props: Props) => {
             href="/app"
             size="normal"
             icon={<Symbol>home</Symbol>}
-            attention={location.pathname === "/app" ? "selected" : "normal"}
+            attention={
+              Instance.relPath(location.pathname) === "/app"
+                ? "selected"
+                : "normal"
+            }
           >
             <ButtonTitle>
               <Trans>Home</Trans>
@@ -92,7 +97,11 @@ export const HomeSidebar = (props: Props) => {
             href="/friends"
             size="normal"
             icon={<Symbol>group</Symbol>}
-            attention={location.pathname === "/friends" ? "selected" : "normal"}
+            attention={
+              Instance.relPath(location.pathname) === "/friends"
+                ? "selected"
+                : "normal"
+            }
           >
             <ButtonTitle>
               <Trans>Friends</Trans>

--- a/packages/client/src/interface/navigation/servers/ServerList.tsx
+++ b/packages/client/src/interface/navigation/servers/ServerList.tsx
@@ -6,7 +6,7 @@ import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
-import { CONFIGURATION, useDevice } from "@revolt/common";
+import { useDevice } from "@revolt/common";
 import { KeybindAction, createKeybind } from "@revolt/keybinds";
 import { useModals } from "@revolt/modal";
 import { useNavigate } from "@revolt/routing";
@@ -17,6 +17,7 @@ import MdAdd from "@material-design-icons/svg/filled/add.svg?component-solid";
 import MdExplore from "@material-design-icons/svg/filled/explore.svg?component-solid";
 import MdHome from "@material-design-icons/svg/filled/home.svg?component-solid";
 import MdSettings from "@material-design-icons/svg/filled/settings.svg?component-solid";
+import { useInstance } from "@revolt/instance";
 
 import { Tooltip } from "../../../../components/ui/components/floating";
 import { Draggable } from "../../../../components/ui/components/utils/Draggable";
@@ -71,6 +72,7 @@ export const ServerList = (props: Props) => {
   const navigate = useNavigate();
   const { isMobile } = useDevice();
   const { openModal } = useModals();
+  const instance = useInstance();
 
   const navigateServer = (byOffset: number) => {
     const serverId = props.selectedServer();
@@ -311,7 +313,7 @@ export const ServerList = (props: Props) => {
             <Avatar size={42} fallback={<MdAdd />} />
           </a>
         </Tooltip>
-        <Show when={CONFIGURATION.IS_STOAT}>
+        <Show when={instance.isStoat}>
           <Tooltip placement="right" content={"Find new servers to join"}>
             <a
               href={state.layout.getLastActiveDiscoverPath()}

--- a/packages/client/src/interface/navigation/servers/ServerList.tsx
+++ b/packages/client/src/interface/navigation/servers/ServerList.tsx
@@ -7,22 +7,21 @@ import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
 import { useDevice } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import { KeybindAction, createKeybind } from "@revolt/keybinds";
 import { useModals } from "@revolt/modal";
 import { useNavigate } from "@revolt/routing";
 import { useState } from "@revolt/state";
 import { Avatar, Column, Text, Time, Unreads, UserStatus } from "@revolt/ui";
+import { VoiceStatus } from "@revolt/ui/components/design/VoiceStatus";
 
 import MdAdd from "@material-design-icons/svg/filled/add.svg?component-solid";
 import MdExplore from "@material-design-icons/svg/filled/explore.svg?component-solid";
 import MdHome from "@material-design-icons/svg/filled/home.svg?component-solid";
 import MdSettings from "@material-design-icons/svg/filled/settings.svg?component-solid";
-import { useInstance } from "@revolt/instance";
 
 import { Tooltip } from "../../../../components/ui/components/floating";
 import { Draggable } from "../../../../components/ui/components/utils/Draggable";
-
-import { VoiceStatus } from "@revolt/ui/components/design/VoiceStatus";
 import { UserMenu } from "./UserMenu";
 
 interface Props {

--- a/packages/client/src/serviceWorker.ts
+++ b/packages/client/src/serviceWorker.ts
@@ -46,7 +46,10 @@ self.addEventListener("push", (event) => {
     }
   }
 
-  notification.url ||= self.registration.scope;
+  //Redirect instance URL
+  const scope = self.registration.scope,
+    url = notification.url && new URL(notification.url);
+  notification.url = url ? `${scope}i/${url.host}${url.pathname}` : scope;
 
   event.waitUntil(
     self.registration.showNotification(notification.title || "Stoat", {

--- a/packages/client/src/serviceWorker.ts
+++ b/packages/client/src/serviceWorker.ts
@@ -46,10 +46,7 @@ self.addEventListener("push", (event) => {
     }
   }
 
-  //Redirect instance URL
-  const scope = self.registration.scope,
-    url = notification.url && new URL(notification.url);
-  notification.url = url ? `${scope}i/${url.host}${url.pathname}` : scope;
+  notification.url ||= self.registration.scope;
 
   event.waitUntil(
     self.registration.showNotification(notification.title || "Stoat", {

--- a/packages/client/src/serviceWorkerInterface.ts
+++ b/packages/client/src/serviceWorkerInterface.ts
@@ -6,20 +6,16 @@ const [pendingUpdate, setPendingUpdate] = createSignal<() => void>();
 
 export { pendingUpdate };
 
-if (import.meta.env.PROD) {
-  const updateSW = registerSW({
-    onNeedRefresh() {
-      setPendingUpdate(() => void updateSW(true));
-    },
-    onOfflineReady() {
-      console.info("Ready to work offline =)");
-      // toast to users
-    },
-    onRegistered(r) {
-      // registration = r;
-
-      // Check for updates every hour
-      setInterval(() => r!.update(), 36e5);
-    },
-  });
-}
+const updateSW = registerSW({
+  onNeedRefresh() {
+    setPendingUpdate(() => void updateSW(true));
+  },
+  onOfflineReady() {
+    console.info("Ready to work offline =)");
+    // toast to users
+  },
+  onRegistered(r) {
+    // Check for updates every hour
+    setInterval(() => r!.update(), 36e5);
+  },
+});

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -28,6 +28,8 @@
       "@revolt/client/*": ["components/client/*"],
       "@revolt/common": ["components/common"],
       "@revolt/common/*": ["components/common/*"],
+      "@revolt/instance": ["components/instance"],
+      "@revolt/instance/*": ["components/instance/*"],
       "@revolt/i18n": ["components/i18n"],
       "@revolt/i18n/*": ["components/i18n/*"],
       "@revolt/keybinds": ["components/keybinds"],

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       },
       devOptions: {
         enabled: true,
+        type: "module",
       },
       manifest: {
         name: "Stoat",


### PR DESCRIPTION
Requires:

- <https://github.com/stoatchat/javascript-client-sdk/pull/172>

Perquisite for:

- \#999
- \#1217

Supersedes:

- \#1309
- \#1312

Adds the Instance context for accessing instance-specific configurations and detecting the API endpoint from the current instance. Also adds an easy-to-use memo to the ClientController that simplifies limit checks and safely returns defaults if client is unconfigured, and drops some now-unused CONFIGURATION env vars.

*Note: This PR **does not** actually enable instance switching, nor does it add/change any UI. But it is the groundwork for doing so, adding the necessary reactivity, and enabling the route handling for alternate instances.*

Edit: Messed around with the commit history a bit to make sure Gtoasted gets credited for their initial contributions to this.

- `main` <!-- branch-stack -->
  - \#1315 :point\_left:
