### PR TITLE
feat: Add TranslatedError and use it in register error

### DIFF
--- a/doc/src/components/i18n/translating-errors.md
+++ b/doc/src/components/i18n/translating-errors.md
@@ -1,11 +1,19 @@
 # Translating Errors
 
-To handle an API error, use the hook:
+To handle an API error, use the hook or use the TranslatedError component. If you can call the TranslatedError component, you should prefer that:
+
+```typescript
+import { TranslatedError } from "@revolt/i18n";
+
+<TranslatedError error={someErrorObject} />
+```
+
+To use the hook:
 
 ```typescript
 import { useError } from "@revolt/i18n";
 
 const err = useError();
 
-<span>{err(someErrorObject)}</span>;
+<span>{err(someErrorObject)}</span>
 ```

--- a/packages/client/components/auth/src/flows/Form.tsx
+++ b/packages/client/components/auth/src/flows/Form.tsx
@@ -3,11 +3,11 @@ import { createSignal, For, JSX, Show } from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
 
-import { useError } from "@revolt/i18n";
 import { Checkbox, Column, iconSize, Text, TextField } from "@revolt/ui";
 import { styled } from "styled-system/jsx";
 
 import MdError from "@material-design-icons/svg/filled/error.svg?component-solid";
+import { TranslatedError } from "@revolt/i18n/errors";
 
 const ErrorContainer = styled("span", {
   base: {
@@ -15,6 +15,10 @@ const ErrorContainer = styled("span", {
     display: "flex",
     alignItems: "center",
     gap: "0.25em",
+
+    "& a": {
+      color: "var(--md-sys-color-primary)",
+    },
   },
 });
 
@@ -154,7 +158,6 @@ interface Props {
  */
 export function Form(props: Props) {
   const [error, setError] = createSignal();
-  const err = useError();
   let hcaptcha: HCaptchaFunctions | undefined;
 
   /**
@@ -192,7 +195,7 @@ export function Form(props: Props) {
               style={{ "flex-shrink": 0 }}
             />
             <Text class="label" size="small">
-              {err(error())}
+              <TranslatedError error={error()} />
             </Text>
           </ErrorContainer>
         </Show>

--- a/packages/client/components/i18n/errors.tsx
+++ b/packages/client/components/i18n/errors.tsx
@@ -1,7 +1,26 @@
-import { useLingui } from "@lingui-solid/solid/macro";
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
+import { createMemo, Match, Switch } from "solid-js";
 import { API } from "stoat.js";
 
 const RE_BREAK = /\s*\n\s*/g;
+
+function cleanError(
+  error: unknown,
+): { type?: never } | { message?: never } | string | undefined {
+  // Attempt to parse the incoming error as JSON if it is a string,
+  // as some errors (e.g on login) are sent to this function as a string,
+  // which then causes the error message to be unlocalised and unhelpful.
+  if (typeof error === "string") {
+    try {
+      return JSON.parse(error);
+    } catch {
+      // Ignore JSON parse errors
+      return error;
+    }
+  }
+
+  return error as { type?: never } | { message?: never } | undefined;
+}
 
 /**
  * Translate any error
@@ -10,18 +29,9 @@ export function useError() {
   const { t } = useLingui();
 
   return (error: unknown) => {
-    // TODO: HTTP errors
+    error = cleanError(error);
 
-    // Attempt to parse the incoming error as JSON if it is a string,
-    // as some errors (e.g on login) are sent to this function as a string,
-    // which then causes the error message to be unlocalised and unhelpful.
-    if (typeof error === "string") {
-      try {
-        error = JSON.parse(error);
-      } catch {
-        // Ignore JSON parse errors
-      }
-    }
+    // TODO: HTTP errors
 
     // handle Revolt API errors
     if (
@@ -185,4 +195,60 @@ export function useError() {
     // revert to `Try again later.` later
     // need to capture envelopes properly
   };
+}
+
+type TranslatedErrorProps = {
+  error: unknown;
+};
+
+export function TranslatedError(props: TranslatedErrorProps) {
+  const err = useError();
+
+  const errorString = createMemo(() => {
+    const clean = cleanError(props.error);
+
+    if (
+      (clean as { type?: never } | undefined)?.type &&
+      typeof (clean as { type: never }).type === "string"
+    ) {
+      const err = clean as
+        | API.Error
+        | Exclude<
+            API.Authifier_Error,
+            | { type: "UnknownUser" }
+            | { type: "DatabaseError" }
+            | { type: "InternalError" }
+          >;
+
+      return err;
+    }
+
+    return err(props.error);
+  });
+
+  return (
+    <Switch fallback={errorString() as string}>
+      <Match when={typeof errorString() !== "string"}>
+        <Switch fallback={err(props.error)}>
+          <Match
+            when={
+              (errorString() as API.Error | API.Authifier_Error).type ===
+              "BlockedByShield"
+            }
+          >
+            <Trans>
+              This sign up is marked as spam. Please see{" "}
+              <a
+                href="https://support.stoat.chat/kb/safety/blocked-for-spam"
+                target="_blank"
+                rel="noreferrer"
+              >
+                this support article.
+              </a>
+            </Trans>
+          </Match>
+        </Switch>
+      </Match>
+    </Switch>
+  );
 }

--- a/packages/client/components/modal/modals/Error2.tsx
+++ b/packages/client/components/modal/modals/Error2.tsx
@@ -1,11 +1,11 @@
 import { Trans } from "@lingui-solid/solid/macro";
 import { styled } from "styled-system/jsx";
 
-import { useError } from "@revolt/i18n";
 import { Dialog, DialogProps, iconSize } from "@revolt/ui";
 
 import MdError from "@material-design-icons/svg/outlined/error.svg?component-solid";
 
+import { TranslatedError } from "@revolt/i18n/errors";
 import { Modals } from "../types";
 
 const Error = styled("div", {
@@ -15,8 +15,6 @@ const Error = styled("div", {
 });
 
 export function Error2Modal(props: DialogProps & Modals & { type: "error2" }) {
-  const err = useError();
-
   return (
     <Dialog
       icon={<MdError {...iconSize(24)} />}
@@ -25,7 +23,9 @@ export function Error2Modal(props: DialogProps & Modals & { type: "error2" }) {
       title={<Trans>An error occurred.</Trans>}
       actions={[{ text: <Trans>OK</Trans> }]}
     >
-      <Error>{err(props.error)}</Error>
+      <Error>
+        <TranslatedError error={props.error} />
+      </Error>
     </Dialog>
   );
 }


### PR DESCRIPTION
Adds TranslatedError component, adds a error string for the BlockedByShield error.

## How was this PR tested?

I did some registrations and looked at the new error

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<img width="308" height="83" alt="image (1)" src="https://github.com/user-attachments/assets/d4a809a7-9dba-4f06-8c5f-f3e7649fd797" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1317 :point\_left:
