### PR TITLE
fix: user could report priviledged accounts

### DIFF
--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -527,9 +527,11 @@ export function UserContextMenu(props: {
             <Trans>Unblock user</Trans>
           </ContextMenuButton>
         </Show>
-        <ContextMenuButton icon={MdReport} onClick={reportUser} destructive>
-          <Trans>Report user</Trans>
-        </ContextMenuButton>
+        <Show when={!props.user.privileged}>
+          <ContextMenuButton icon={MdReport} onClick={reportUser} destructive>
+            <Trans>Report user</Trans>
+          </ContextMenuButton>
+        </Show>
       </Show>
 
       {/* Developer tools */}


### PR DESCRIPTION
<!-- Describe your changes -->

Users could (or at least, attempt to) report privileged users via the user context menu, now they can't.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Open context menu by right-clicking a privileged user (eg. Platform Moderation) 
- [x] Open context menu by right-clicking a non-privileged user

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<img width="224" height="331" alt="image" src="https://github.com/user-attachments/assets/8b18c712-a99d-4655-8e08-26a05d839c80" />


</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No AI was used at the time of making this PR.
