### PR TITLE
feat: show the message that is being deleted

### DIFF
--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -85,7 +85,7 @@ interface Props {
   /**
    * Whether this message is a link
    */
-  isLink?: boolean;
+  isLink?: boolean | "hide";
 }
 
 interface MessageContextShape {

--- a/packages/client/components/modal/modals/DeleteMessage.tsx
+++ b/packages/client/components/modal/modals/DeleteMessage.tsx
@@ -3,6 +3,8 @@ import { useMutation } from "@tanstack/solid-query";
 
 import { Dialog, DialogProps } from "@revolt/ui";
 
+import { Message } from "@revolt/app";
+import { styled } from "styled-system/jsx";
 import { useModals } from "..";
 import { Modals } from "../types";
 
@@ -34,6 +36,19 @@ export function DeleteMessageModal(
       isDisabled={deleteMessage.isPending}
     >
       <Trans>Are you sure you want to delete this?</Trans>
+      <MessagePreview>
+        <Message isLink="hide" message={props.message} />
+      </MessagePreview>
     </Dialog>
   );
 }
+
+const MessagePreview = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    paddingBlock: "var(--gap-md)",
+    gap: "var(--message-group-spacing)",
+    pointerEvents: "none",
+  },
+});


### PR DESCRIPTION
<!-- Describe your changes -->

The delete message modal did not show which message was being deleted, which could have lead confusion to users trying to delete messages and accidentally pressing the wrong one. Now, the modal shows which message is being deleted, causing less confusion.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Tried deleting my own message
  - [x] Check if embedded content (attachments and link previews) appears correctly
  - [x] Check if replies are also shown alongside the message
- [x] Tried deleting other person's message
  - [x] Check if embedded content (attachments and link previews) appears correctly
  - [x] Check if replies are also shown alongside the message

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<img width="700" height="803" alt="image" src="https://github.com/user-attachments/assets/972429f3-b394-41d3-a547-96a299d39414" />
<img width="700" height="803" alt="image" src="https://github.com/user-attachments/assets/295c9abf-1875-4dd4-bce4-53d1d1d92535" />
<img width="698" height="324" alt="image" src="https://github.com/user-attachments/assets/3a1b2d4c-1b71-4395-beff-fc381a3e2741" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No AI was used at the time of writing the pull request.
