### PR TITLE
feat: Show an icon when users are in voice, video, or screenshare

### DIFF
--- a/packages/client/components/ui/components/design/VoiceStatus.tsx
+++ b/packages/client/components/ui/components/design/VoiceStatus.tsx
@@ -1,0 +1,80 @@
+import { Match, Switch } from "solid-js";
+import { styled } from "styled-system/jsx";
+
+import { VoiceStatus as APIVoiceStatus } from "stoat.js";
+
+import MdScreenShare from "@material-design-icons/svg/outlined/screen_share.svg?component-solid";
+import MdVideoChat from "@material-design-icons/svg/outlined/video_call.svg?component-solid";
+import MdVoiceChat from "@material-design-icons/svg/outlined/volume_up.svg?component-solid";
+
+import { iconSize } from "../utils";
+
+export type Props = {
+  status: APIVoiceStatus;
+};
+
+/**
+ * Styles for the counter
+ */
+const VoiceStatusSymbol = styled("div", {
+  base: {
+    width: "10px",
+    height: "10px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+
+    fontSize: "8px",
+    fontWeight: 600,
+
+    color: "var(--md-sys-color-on-surface)",
+    fill: "var(--md-sys-color-on-surface)",
+  },
+});
+
+/**
+ * Unreads count SVG graphic
+ */
+function VoiceGraphic(props: Props) {
+  return (
+    <Switch>
+      <Match when={props.status === "voice"}>
+        <circle cx="27" cy="27" r="5" fill="var(--md-sys-color-surface)" />
+        <foreignObject x="22" y="22" width="10" height="10">
+          <VoiceStatusSymbol>
+            <MdVoiceChat {...iconSize(10)} />
+          </VoiceStatusSymbol>
+        </foreignObject>
+      </Match>
+      <Match when={props.status === "video"}>
+        <circle cx="27" cy="27" r="5" fill="var(--md-sys-color-surface)" />
+        <foreignObject x="22" y="22" width="10" height="10">
+          <VoiceStatusSymbol>
+            <MdVideoChat {...iconSize(10)} />
+          </VoiceStatusSymbol>
+        </foreignObject>
+      </Match>
+      <Match when={props.status === "screenshare"}>
+        <circle cx="27" cy="27" r="5" fill="var(--md-sys-color-surface)" />
+        <foreignObject x="22" y="22" width="10" height="10">
+          <VoiceStatusSymbol>
+            <MdScreenShare {...iconSize(10)} />
+          </VoiceStatusSymbol>
+        </foreignObject>
+      </Match>
+    </Switch>
+  );
+}
+
+/**
+ * Standalone unreads count element
+ */
+export function VoiceStatus(props: Props & { size: string }) {
+  return (
+    <svg viewBox="22 0 10 10" height={props.size}>
+      <VoiceGraphic {...props} />
+    </svg>
+  );
+}
+
+VoiceStatus.Graphic = VoiceGraphic;

--- a/packages/client/components/ui/components/design/VoiceStatus.tsx
+++ b/packages/client/components/ui/components/design/VoiceStatus.tsx
@@ -33,7 +33,7 @@ const VoiceStatusSymbol = styled("div", {
 });
 
 /**
- * Unreads count SVG graphic
+ * Voice status SVG graphic
  */
 function VoiceGraphic(props: Props) {
   return (
@@ -67,7 +67,7 @@ function VoiceGraphic(props: Props) {
 }
 
 /**
- * Standalone unreads count element
+ * Standalone voice status element
  */
 export function VoiceStatus(props: Props & { size: string }) {
   return (

--- a/packages/client/src/interface/navigation/servers/ServerList.tsx
+++ b/packages/client/src/interface/navigation/servers/ServerList.tsx
@@ -21,6 +21,7 @@ import MdSettings from "@material-design-icons/svg/filled/settings.svg?component
 import { Tooltip } from "../../../../components/ui/components/floating";
 import { Draggable } from "../../../../components/ui/components/utils/Draggable";
 
+import { VoiceStatus } from "@revolt/ui/components/design/VoiceStatus";
 import { UserMenu } from "./UserMenu";
 
 interface Props {
@@ -266,7 +267,13 @@ export const ServerList = (props: Props) => {
                     size={42}
                     src={entry.item.iconURL}
                     holepunch={
-                      entry.item.mentions.length ? "top-right" : "none"
+                      entry.item.mentions.length
+                        ? entry.item.voiceStatus !== "none"
+                          ? "right"
+                          : "top-right"
+                        : entry.item.voiceStatus !== "none"
+                          ? "bottom-right"
+                          : "none"
                     }
                     overlay={
                       <>
@@ -279,6 +286,11 @@ export const ServerList = (props: Props) => {
                           <Unreads.Graphic
                             count={entry.item.mentions.length}
                             unread
+                          />
+                        </Show>
+                        <Show when={entry.item.voiceStatus !== "none"}>
+                          <VoiceStatus.Graphic
+                            status={entry.item.voiceStatus}
                           />
                         </Show>
                       </>


### PR DESCRIPTION
Add a punchout for if users in a server are in voice, streaming video, or screen sharing.

## How was this PR tested?

Joined some servers and watched the icon go brrrrrrrr

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

When users are in voice:

<img width="64" height="50" alt="image" src="https://github.com/user-attachments/assets/4aaef48d-c453-401f-9d1c-eedc80dc577d" />

When a user is streaming video:

<img width="64" height="55" alt="image" src="https://github.com/user-attachments/assets/a0cd385d-c264-4a78-807c-f6417312b088" />

When a user is screen sharing. Note that this is unreliable due to how screen sharing is handled (fast events), and may result in false negatives.

<img width="64" height="55" alt="image" src="https://github.com/user-attachments/assets/e04516bc-e959-4dc2-8a41-6798fbd18063" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1324 :point\_left:
