### PR TITLE
feat: helpful loading screen

### DIFF
--- a/packages/client/src/Interface.tsx
+++ b/packages/client/src/Interface.tsx
@@ -20,9 +20,9 @@ import { useModals } from "@revolt/modal";
 import { Navigate, useBeforeLeave, useLocation } from "@revolt/routing";
 import { useState } from "@revolt/state";
 import { LAYOUT_SECTIONS } from "@revolt/state/stores/Layout";
-import { CircularProgress } from "@revolt/ui";
 
 import { SlideDrawer } from "../components/ui/components/navigation/SlideDrawer";
+import { LoadingScreen } from "./LoadingScreen";
 import { Sidebar } from "./interface/Sidebar";
 
 /**
@@ -91,7 +91,7 @@ const Interface = (props: { children: JSX.Element }) => {
     <MessageCache client={client()}>
       <AppRoot ref={rootRef} class="app_root">
         <Titlebar />
-        <Switch fallback={<CircularProgress />}>
+        <Switch fallback={<LoadingScreen />}>
           <Match when={!isLoggedIn()}>
             <Navigate href="/login" />
           </Match>

--- a/packages/client/src/LoadingScreen.tsx
+++ b/packages/client/src/LoadingScreen.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
-import { Show, createSignal, onCleanup, onMount } from "solid-js";
+import { JSX, Show, createSignal, onCleanup, onMount } from "solid-js";
 import { styled } from "styled-system/jsx";
 
 import { Button, CircularProgress, Symbol, Text } from "@revolt/ui";
@@ -10,6 +10,12 @@ import { Button, CircularProgress, Symbol, Text } from "@revolt/ui";
 const STATUS_PAGE_URL = "https://status.stoat.chat";
 
 /**
+ * Connection troubleshooting knowledge base article
+ */
+const TROUBLESHOOTING_URL =
+  "https://support.stoat.chat/kb/troubleshooting/connection-issues";
+
+/**
  * Status API queried when the client is slow to connect
  */
 const STATUS_API_URL = "https://stoat.chat/-/status";
@@ -17,7 +23,12 @@ const STATUS_API_URL = "https://stoat.chat/-/status";
 /**
  * How long to wait for a proper connection before asking the status API
  */
-const STATUS_PROBE_DELAY = 5000;
+const STATUS_PROBE_DELAY = 5_000;
+
+/**
+ * How long to wait before showing troubleshooting advice if an incident has not been reported by the status API yet
+ */
+const TROUBLESHOOTING_DELAY = 10_000;
 
 /**
  * Partial API response we care about
@@ -51,14 +62,18 @@ const isEligibleOrigin = () => {
  * If the connection does not succeed within {@link STATUS_PROBE_DELAY}, and we
  * are on an eligible origin, the status API is queried and any ongoing incident
  * is shown so the user knows the outage isn't on their end.
+ *
+ * Additionally if the connection does not succeed within {@link TROUBLESHOOTING_DELAY},
+ * a troubleshooting notice is shown to help the user diagnose their connection issues.
+ * We also link to the support page there.
  */
 export function LoadingScreen() {
   const { t } = useLingui();
 
-  const [incident, setIncident] = createSignal<{
-    impact: string;
-    title: string;
-  }>();
+  const [notice, setNotice] = createSignal<
+    | { type: "incident"; impact: string; title: string }
+    | { type: "troubleshooting" }
+  >();
 
   /**
    * Label for a status impact level
@@ -85,31 +100,37 @@ export function LoadingScreen() {
 
     const controller = new AbortController();
 
-    const timer = setTimeout(async () => {
+    // Check the status API for an ongoing incident.
+    const statusTimer = setTimeout(async () => {
       try {
         const res = await fetch(STATUS_API_URL, { signal: controller.signal });
         const data = (await res.json()) as StatusResponse;
 
         const impact = data?.status?.current_incident_impact;
-        if (!impact || impact === "operational") return;
-
         const active = (data.status?.active_incidents ?? []).filter(
           (i) => i.status !== "recovered",
         );
-        if (!active.length) return;
 
-        const newest = active.reduce((a, b) =>
-          Date.parse(b.incident_at) > Date.parse(a.incident_at) ? b : a,
-        );
+        if (impact && impact !== "operational" && active.length) {
+          const newest = active.reduce((a, b) =>
+            Date.parse(b.incident_at) > Date.parse(a.incident_at) ? b : a,
+          );
 
-        setIncident({ impact, title: newest.title });
+          setNotice({ type: "incident", impact, title: newest.title });
+        }
       } catch {
-        // Don't care
+        // the troubleshooting timer handles this case
       }
     }, STATUS_PROBE_DELAY);
 
+    // Still no incident so try troubleshooting
+    const troubleshootingTimer = setTimeout(() => {
+      setNotice((prev) => prev ?? { type: "troubleshooting" });
+    }, TROUBLESHOOTING_DELAY);
+
     onCleanup(() => {
-      clearTimeout(timer);
+      clearTimeout(statusTimer);
+      clearTimeout(troubleshootingTimer);
       controller.abort();
     });
   });
@@ -120,36 +141,69 @@ export function LoadingScreen() {
         <CircularProgress />
       </Spinner>
 
-      <Show when={incident()}>
-        {(active) => (
-          <Notice>
-            <Header>
-              <Impact>
-                <Symbol fill={active().impact === "maintenance"} size={28}>
-                  {active().impact === "maintenance"
-                    ? "build"
-                    : "running_with_errors"}
-                </Symbol>
-                <Text class="label" size="large">
-                  {impactLabel(active().impact)}
-                </Text>
-              </Impact>
-              <Text class="title" size="medium">
-                {active().title}
-              </Text>
-            </Header>
-            <Button
-              variant="text"
-              onPress={() =>
-                window.open(STATUS_PAGE_URL, "_blank", "noopener,noreferrer")
+      <Show when={notice()} keyed>
+        {(current) =>
+          current.type === "incident" ? (
+            <NoticeContent
+              symbol={
+                current.impact === "maintenance"
+                  ? "build"
+                  : "running_with_errors"
               }
-            >
-              <Trans>View status page</Trans>
-            </Button>
-          </Notice>
-        )}
+              fill={current.impact === "maintenance"}
+              label={impactLabel(current.impact)}
+              title={current.title}
+              url={STATUS_PAGE_URL}
+              action={<Trans>View status page</Trans>}
+            />
+          ) : (
+            <NoticeContent
+              symbol="wifi_off"
+              label={t`This is taking longer than usual.`}
+              title={t`You may be experiencing connection issues.`}
+              url={TROUBLESHOOTING_URL}
+              action={<Trans>Troubleshooting</Trans>}
+            />
+          )
+        }
       </Show>
     </Base>
+  );
+}
+
+/**
+ * A notice that can be shown below the loading spinner
+ */
+function NoticeContent(props: {
+  symbol: string;
+  fill?: boolean;
+  label: JSX.Element;
+  title: JSX.Element;
+  url: string;
+  action: JSX.Element;
+}) {
+  return (
+    <Notice>
+      <Header>
+        <Impact>
+          <Symbol fill={props.fill} size={28}>
+            {props.symbol}
+          </Symbol>
+          <Text class="label" size="large">
+            {props.label}
+          </Text>
+        </Impact>
+        <Text class="title" size="medium">
+          {props.title}
+        </Text>
+      </Header>
+      <Button
+        variant="text"
+        onPress={() => window.open(props.url, "_blank", "noopener,noreferrer")}
+      >
+        {props.action}
+      </Button>
+    </Notice>
   );
 }
 

--- a/packages/client/src/LoadingScreen.tsx
+++ b/packages/client/src/LoadingScreen.tsx
@@ -1,0 +1,226 @@
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
+import { Show, createSignal, onCleanup, onMount } from "solid-js";
+import { styled } from "styled-system/jsx";
+
+import { Button, CircularProgress, Symbol, Text } from "@revolt/ui";
+
+/**
+ * Stoat status page URL
+ */
+const STATUS_PAGE_URL = "https://status.stoat.chat";
+
+/**
+ * Status API queried when the client is slow to connect
+ */
+const STATUS_API_URL = "https://stoat.chat/-/status";
+
+/**
+ * How long to wait for a proper connection before asking the status API
+ */
+const STATUS_PROBE_DELAY = 5000;
+
+/**
+ * Partial API response we care about
+ */
+type StatusResponse = {
+  status?: {
+    current_incident_impact?: string;
+    active_incidents?: {
+      title: string;
+      status: string;
+      incident_at: string;
+    }[];
+  };
+};
+
+/**
+ * Whether the current origin is eligible to probe the status API
+ */
+const isEligibleOrigin = () => {
+  const { hostname } = window.location;
+  return (
+    hostname === "localhost" || // (for testing)
+    hostname.endsWith(".stoat.chat") ||
+    hostname === "stoat.chat"
+  );
+};
+
+/**
+ * Loading screen shown while the client connects for the first time.
+ *
+ * If the connection does not succeed within {@link STATUS_PROBE_DELAY}, and we
+ * are on an eligible origin, the status API is queried and any ongoing incident
+ * is shown so the user knows the outage isn't on their end.
+ */
+export function LoadingScreen() {
+  const { t } = useLingui();
+
+  const [incident, setIncident] = createSignal<{
+    impact: string;
+    title: string;
+  }>();
+
+  /**
+   * Label for a status impact level
+   */
+  const impactLabel = (impact: string) => {
+    switch (impact) {
+      case "operational":
+        return t`All Systems Operational`;
+      case "degraded_performance":
+        return t`Degraded Performance`;
+      case "partial_outage":
+        return t`Partial Outage`;
+      case "major_outage":
+        return t`Major Outage`;
+      case "maintenance":
+        return t`Ongoing Maintenance`;
+      default:
+        return t`Unknown`;
+    }
+  };
+
+  onMount(() => {
+    if (!isEligibleOrigin()) return;
+
+    const controller = new AbortController();
+
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(STATUS_API_URL, { signal: controller.signal });
+        const data = (await res.json()) as StatusResponse;
+
+        const impact = data?.status?.current_incident_impact;
+        if (!impact || impact === "operational") return;
+
+        const active = (data.status?.active_incidents ?? []).filter(
+          (i) => i.status !== "recovered",
+        );
+        if (!active.length) return;
+
+        const newest = active.reduce((a, b) =>
+          Date.parse(b.incident_at) > Date.parse(a.incident_at) ? b : a,
+        );
+
+        setIncident({ impact, title: newest.title });
+      } catch {
+        // Don't care
+      }
+    }, STATUS_PROBE_DELAY);
+
+    onCleanup(() => {
+      clearTimeout(timer);
+      controller.abort();
+    });
+  });
+
+  return (
+    <Base>
+      <Spinner>
+        <CircularProgress />
+      </Spinner>
+
+      <Show when={incident()}>
+        {(active) => (
+          <Notice>
+            <Header>
+              <Impact>
+                <Symbol fill={active().impact === "maintenance"} size={28}>
+                  {active().impact === "maintenance"
+                    ? "build"
+                    : "running_with_errors"}
+                </Symbol>
+                <Text class="label" size="large">
+                  {impactLabel(active().impact)}
+                </Text>
+              </Impact>
+              <Text class="title" size="medium">
+                {active().title}
+              </Text>
+            </Header>
+            <Button
+              variant="text"
+              onPress={() =>
+                window.open(STATUS_PAGE_URL, "_blank", "noopener,noreferrer")
+              }
+            >
+              <Trans>View status page</Trans>
+            </Button>
+          </Notice>
+        )}
+      </Show>
+    </Base>
+  );
+}
+
+/**
+ * Full-height container that keeps the spinner centred
+ */
+const Base = styled("div", {
+  base: {
+    position: "relative",
+    display: "flex",
+    flexGrow: 1,
+    minHeight: 0,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+
+/**
+ * Fixed size wrapper so the spinner does not stretch inside the flex column
+ */
+const Spinner = styled("div", {
+  base: {
+    flexShrink: 0,
+    width: "48px",
+    height: "48px",
+  },
+});
+
+/**
+ * Incident notice
+ */
+const Notice = styled("div", {
+  base: {
+    position: "absolute",
+    top: "calc(50% + 48px)",
+    insetInline: 0,
+
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "var(--gap-lg)",
+    textAlign: "center",
+    maxWidth: "42ch",
+    marginInline: "auto",
+    paddingInline: "var(--gap-lg)",
+    color: "var(--md-sys-color-on-surface-variant)",
+  },
+});
+
+/**
+ * Impact level and title
+ */
+const Header = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "var(--gap-md)",
+  },
+});
+
+/**
+ * Current incident impact level with symbol
+ */
+const Impact = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "var(--gap-md)",
+    letterSpacing: "0.05em",
+    color: "var(--md-sys-color-on-surface-variant)",
+  },
+});


### PR DESCRIPTION
- **feat: loading screen with status querying**
- **feat: also show troubleshooting advice after 10s**

## How was this PR tested?

Proprietary E.Y.E.S. technology

<h2>Screenshots & Screencasts (if appropriate)</h2>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<img width="410" height="372" alt="image" src="https://github.com/user-attachments/assets/7e4423e4-eb2d-4bc2-a113-549317a05e04" />
<img width="410" height="372" alt="image" src="https://github.com/user-attachments/assets/d7328feb-dacf-4f83-bd90-3203bf44c2ad" />
<img width="410" height="372" alt="image" src="https://github.com/user-attachments/assets/a0aad8be-e71d-4747-b851-97fa2267aeef" />


</details>

- `main` <!-- branch-stack -->
  - \#1327 :point\_left:
