### PR TITLE
fix: Make gifbox videos embed correctly

### DIFF
--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -12,18 +12,16 @@ import {
 } from "solid-js";
 
 import { useLingui } from "@lingui-solid/solid/macro";
-import {
-  ImageEmbed,
-  Message as MessageInterface,
-  WebsiteEmbed,
-} from "stoat.js";
+import { Message as MessageInterface } from "stoat.js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 import { decodeTime } from "ulid";
 
 import { useClient } from "@revolt/client";
+import { isGif } from "@revolt/common/lib/gifs";
 import { useTime } from "@revolt/i18n";
 import { Markdown } from "@revolt/markdown";
+import { startsWithPackPUA } from "@revolt/markdown/emoji/UnicodeEmoji";
 import { useState } from "@revolt/state";
 import {
   Attachment,
@@ -38,6 +36,7 @@ import {
   Tooltip,
   Username,
 } from "@revolt/ui";
+import { MediaPickerProps } from "@revolt/ui/components/features/messaging/composition/picker/CompositionMediaPicker";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
 import { MessageContextMenu } from "../../../menus/MessageContextMenu";
@@ -46,8 +45,6 @@ import {
   floatingUserMenusFromMessage,
 } from "../../../menus/UserContextMenu";
 
-import { startsWithPackPUA } from "@revolt/markdown/emoji/UnicodeEmoji";
-import { MediaPickerProps } from "@revolt/ui/components/features/messaging/composition/picker/CompositionMediaPicker";
 import { EditMessage } from "./EditMessage";
 
 /**
@@ -55,11 +52,6 @@ import { EditMessage } from "./EditMessage";
  */
 const RE_URL =
   /[(http(s)?)://(www.)?a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
-
-/**
- * Regex for matching gif providers
- */
-const GIF_PROVIDERS_REGEX = /^https:\/\/(tenor\.com|gifbox\.me|giphy\.com)/;
 
 interface Props {
   /**
@@ -132,17 +124,7 @@ export function Message(props: Props) {
   const isOnlyGIF = () =>
     props.message.embeds &&
     props.message.embeds.length === 1 &&
-    ((props.message.embeds[0].type === "Website" &&
-      ((props.message.embeds[0] as WebsiteEmbed).specialContent?.type ===
-        "GIF" ||
-        !!(
-          (props.message.embeds[0] as WebsiteEmbed).originalUrl ||
-          (props.message.embeds[0] as WebsiteEmbed).url
-        )?.match(GIF_PROVIDERS_REGEX))) ||
-      (props.message.embeds[0].type === "Image" &&
-        !!(props.message.embeds[0] as ImageEmbed).url?.match(
-          GIF_PROVIDERS_REGEX,
-        ))) &&
+    isGif(props.message.embeds[0]) &&
     props.message.content &&
     !props.message.content.replace(RE_URL, "").length;
 

--- a/packages/client/components/common/lib/gifs.ts
+++ b/packages/client/components/common/lib/gifs.ts
@@ -1,0 +1,40 @@
+import { ImageEmbed, MessageEmbed, VideoEmbed, WebsiteEmbed } from "stoat.js";
+
+/**
+ * Regex for matching gif providers
+ */
+const GIF_PROVIDERS_REGEX = /^https:\/\/(tenor\.com|gifbox\.me|giphy\.com)/;
+
+/**
+ * Check the giffyness of an embed
+ *
+ * @param embed MessageEmbed to check for giffyness
+ * @returns Whether embed is a gif
+ */
+export function isGif(embed: MessageEmbed) {
+  return (
+    (embed.type === "Website" &&
+      ((embed as WebsiteEmbed).specialContent?.type === "GIF" ||
+        !!(
+          (embed as WebsiteEmbed).originalUrl || (embed as WebsiteEmbed).url
+        )?.match(GIF_PROVIDERS_REGEX))) ||
+    (embed.type === "Image" &&
+      !!(embed as ImageEmbed).url?.match(GIF_PROVIDERS_REGEX)) ||
+    (embed.type === "Video" &&
+      !!(embed as VideoEmbed).url?.match(GIF_PROVIDERS_REGEX))
+  );
+}
+
+export function isGifBox(embed: MessageEmbed) {
+  return (
+    (embed.type === "Website" &&
+      ((embed as WebsiteEmbed).specialContent?.type === "GIF" ||
+        !!(
+          (embed as WebsiteEmbed).originalUrl || (embed as WebsiteEmbed).url
+        )?.startsWith("https://gifbox.me"))) ||
+    (embed.type === "Image" &&
+      !!(embed as ImageEmbed).url?.startsWith("https://gifbox.me")) ||
+    (embed.type === "Video" &&
+      !!(embed as VideoEmbed).url?.startsWith("https://gifbox.me"))
+  );
+}

--- a/packages/client/components/modal/modals/ImageViewer.tsx
+++ b/packages/client/components/modal/modals/ImageViewer.tsx
@@ -17,6 +17,7 @@ import { styled } from "styled-system/jsx";
 import { Column, Dialog, DialogProps, IconButton, Text } from "@revolt/ui";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
+import { isGifBox } from "@revolt/common/lib/gifs";
 import { Modals } from "../types";
 
 export function ImageViewerModal(
@@ -173,7 +174,11 @@ export function ImageViewerModal(
                     style={{
                       "aspect-ratio": `${props.gif!.width}/${props.gif!.height}`,
                     }}
-                    src={props.gif!.url}
+                    src={
+                      isGifBox(props.gif!)
+                        ? props.gif!.proxiedURL
+                        : props.gif!.url
+                    }
                     onClick={(e) => e.stopPropagation()}
                   />
                 </Match>

--- a/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Embed.tsx
@@ -9,6 +9,7 @@ import {
 } from "stoat.js";
 import { css } from "styled-system/css";
 
+import { isGifBox, isGif as isGifLib } from "@revolt/common/lib/gifs";
 import { useModals } from "@revolt/modal";
 import { SizedContent } from "@revolt/ui/components/utils";
 
@@ -23,12 +24,7 @@ export function Embed(props: { embed: MessageEmbed }) {
   /**
    * Whether the embed is a GIF
    */
-  const isGIF = () =>
-    props.embed.type === "Website" &&
-    ((props.embed as WebsiteEmbed).specialContent?.type === "GIF" ||
-      (props.embed as WebsiteEmbed).originalUrl?.startsWith(
-        "https://tenor.com",
-      ));
+  const isGIF = () => isGifLib(props.embed);
 
   /**
    * Whether there is a video
@@ -52,7 +48,12 @@ export function Embed(props: { embed: MessageEmbed }) {
         <SizedContent width={image()!.width} height={image()!.height}>
           <img
             // bypass proxy for known GIF providers
-            src={isGIF() ? image()!.url : image()!.proxiedURL}
+            // TODO: Remove the Gifbox check here once gifbox embeds are fixed
+            src={
+              isGIF() && !isGifBox(props.embed)
+                ? image()!.url
+                : image()!.proxiedURL
+            }
             loading="lazy"
             class={css({ cursor: "pointer" })}
             onClick={() =>
@@ -74,7 +75,12 @@ export function Embed(props: { embed: MessageEmbed }) {
             controls={!isGIF()}
             preload="metadata"
             // bypass proxy for known GIF providers
-            src={isGIF() ? video()!.url : video()!.proxiedURL}
+            // TODO: Remove the Gifbox check here once gifbox embeds are fixed
+            src={
+              isGIF() && !isGifBox(props.embed)
+                ? video()!.url
+                : video()!.proxiedURL
+            }
             class={css({ cursor: isGIF() ? "pointer" : "unset" })}
             onClick={() =>
               isGIF() &&


### PR DESCRIPTION
Fixes gifbox video embedding.

Centralizes giffyness check

Stoat backend is currently returning the wrong url for gifbox, this PR takes that into account.

## How was this PR tested?

embedded some gifs from the box into stoat

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<img width="523" height="320" alt="image" src="https://github.com/user-attachments/assets/721e9833-224e-49f9-addd-34e642a49acc" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1329 :point\_left:
