### PR TITLE
fix: clicking message on profiles and context menu should work now

### DIFF
--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -61,7 +61,7 @@ export function UserContextMenu(props: {
    * Open direct message channel
    */
   function openDm() {
-    props.user.openDM().then((channel) => navigate(channel.url));
+    props.user.openDM().then((channel) => navigate(`/channel/${channel.id}`));
     props.onClose?.();
   }
 

--- a/packages/client/components/ui/components/features/profiles/ProfileActions.tsx
+++ b/packages/client/components/ui/components/features/profiles/ProfileActions.tsx
@@ -31,7 +31,7 @@ export function ProfileActions(props: {
    * Open direct message channel
    */
   function openDm() {
-    props.user.openDM().then((channel) => navigate(channel.url));
+    props.user.openDM().then((channel) => navigate(`/channel/${channel.id}`));
     props.onClose();
   }
 


### PR DESCRIPTION
Clicking the message button should take you to the dm page now.

Previously it was trying to navigate to the channel's URL, but that didn't work because navigate expects local links.

Fixes #1330

## How was this PR tested?

<!-- What did you do to test your changes? -->

Clicked some buttons idk

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1334 :point\_left:
