### PR TITLE
fix: Add a latency checker for all available livekit nodes and choose

### DIFF
--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -231,8 +231,19 @@ class Voice {
       }
     });
 
+    // Gather latency
+    const selected = await Promise.race(
+      this.getClient().configuration!.features.livekit.nodes.map(
+        async (node) => {
+          return fetch(node.public_url.replace("wss", "https")).then(() => {
+            return node.name;
+          });
+        },
+      ),
+    );
+
     if (!auth) {
-      auth = await channel.joinCall("worldwide");
+      auth = await channel.joinCall(selected);
     }
 
     await room.connect(auth.url, auth.token, {


### PR DESCRIPTION
Add a latency checker for all available livekit nodes sent by the api configuration. It will then choose the lowest latency node to connect to.

## How was this PR tested?

Tested that correct node was selected when using multiple nodes in self-host

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1345 :point\_left:
