### PR TITLE
chore(docs): Add brand presence colour roles to reference.md

### DIFF
--- a/doc/src/components/ui/themes/reference.md
+++ b/doc/src/components/ui/themes/reference.md
@@ -8,7 +8,17 @@ The following Material colour roles are accessible through the CSS variables `va
 
 ![M3 Colour Roles](./material-colour-roles.png)
 
-TODO: extension with online,idle,focus,busy,invisible
+## Brand presence colour roles
+
+The following brand presence colour roles are accessible through the CSS variables `var(--brand-presence-*)`:
+
+| Status | CSS-Variable | Hex-Code |
+| :--- | :--- | :--- |
+| **Online** | `var(--brand-presence-online)` | <span style="color:#3ABF7E;font-weight:bold;">#3ABF7E</span> |
+| **Idle** | `var(--brand-presence-idle)` | <span style="color:#F39F00;font-weight:bold;">#F39F00</span> |
+| **Busy** | `var(--brand-presence-busy)` | <span style="color:#F84848;font-weight:bold;">#F84848</span> |
+| **Focus** | `var(--brand-presence-focus)` | <span style="color:#4799F0;font-weight:bold;">#4799F0</span> |
+| **Invisible** | `var(--brand-presence-invisible)` | <span style="color:#A5A5A5;font-weight:bold;">#A5A5A5</span> |
 
 ## Roundness
 


### PR DESCRIPTION
Added brand presence colour roles with CSS variables and hex codes.

<!-- Describe your changes -->

Fixes # (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

Test A : I have checked if its correct and it is. Here is the source packages/client/components/ui/themes/stoatWebTheme.ts
Test B:  Checked out the preview
- [ -] Test A: 
- [- ] Test B :

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [ -] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [- ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ -] I have no unrelated changes in the PR
- [ -] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [ -] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
Copilot for commit message
...
