### PR TITLE
fix: PWA mobile rotation-lock fix & system bar theme color

### DIFF
--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -4,6 +4,8 @@ import {
   createContext,
   createEffect,
   onCleanup,
+  onMount,
+  Setter,
   useContext,
 } from "solid-js";
 
@@ -26,12 +28,16 @@ const clientContext = createContext(null! as ClientController);
 /**
  * Mount the modal controller
  */
-export function ClientContext(props: { children: JSXElement }) {
+export function ClientContext(props: {
+  children: JSXElement;
+  setCtx: Setter<ClientController | undefined>;
+}) {
   const { openModal } = useModals();
   const state = useState();
   const instance = useInstance();
 
   const controller = new ClientController(state, instance);
+  onMount(() => props.setCtx?.(controller));
   onCleanup(() => controller.dispose());
 
   let fetchedChangelog = false;

--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -4,8 +4,6 @@ import {
   createContext,
   createEffect,
   onCleanup,
-  onMount,
-  Setter,
   useContext,
 } from "solid-js";
 
@@ -28,16 +26,12 @@ const clientContext = createContext(null! as ClientController);
 /**
  * Mount the modal controller
  */
-export function ClientContext(props: {
-  children: JSXElement;
-  setCtx: Setter<ClientController | undefined>;
-}) {
+export function ClientContext(props: { children: JSXElement }) {
   const { openModal } = useModals();
   const state = useState();
   const instance = useInstance();
 
   const controller = new ClientController(state, instance);
-  onMount(() => props.setCtx?.(controller));
   onCleanup(() => controller.dispose());
 
   let fetchedChangelog = false;

--- a/packages/client/components/ui/components/navigation/SlideDrawer.ts
+++ b/packages/client/components/ui/components/navigation/SlideDrawer.ts
@@ -28,7 +28,7 @@ type TrackTouch = {
   vOfs?: number;
 };
 
-export enum SlideState {
+export const enum SlideState {
   HIDDEN = 1,
   SHOWN,
   HIDING,

--- a/packages/client/components/ui/themes/LoadTheme.tsx
+++ b/packages/client/components/ui/themes/LoadTheme.tsx
@@ -1,5 +1,6 @@
-import { createEffect } from "solid-js";
+import { createEffect, createMemo } from "solid-js";
 
+import ClientController, { State } from "@revolt/client/Controller";
 import { useState } from "@revolt/state";
 
 import {
@@ -7,6 +8,7 @@ import {
   createMduiColourTriplets,
   createStoatWebVariables,
 } from ".";
+import { SlideState } from "../components/navigation/SlideDrawer";
 import { Masks } from "./Masks";
 import { FONTS, MONOSPACE_FONTS } from "./fonts";
 import { legacyThemeUnsetShim } from "./legacyThemeGeneratorCode";
@@ -14,17 +16,17 @@ import { legacyThemeUnsetShim } from "./legacyThemeGeneratorCode";
 /**
  * Component for loading theme variables into root
  */
-export function LoadTheme() {
+export function LoadTheme(props: { cliCtx?: ClientController }) {
   const state = useState();
 
-  createEffect(() => {
+  const getCssProps = createMemo(() => {
     const activeTheme = state.theme.activeTheme;
 
     // load fonts
     FONTS[state.theme.interfaceFont].load();
     MONOSPACE_FONTS[state.theme.monospaceFont].load();
 
-    for (const [key, value] of Object.entries({
+    const cssProps = {
       // create unset variables to indicate where colours need replacing
       ...Object.keys(legacyThemeUnsetShim().colours).reduce(
         (d, k) => ({
@@ -41,9 +43,39 @@ export function LoadTheme() {
       ...createMaterialColourVariables(activeTheme, "--md-sys-color-"),
       // mount --mdui-color triplet variables
       ...createMduiColourTriplets(activeTheme, "--mdui-color-"),
-    })) {
+    };
+
+    for (const [key, value] of Object.entries(cssProps))
       document.body.style.setProperty(key, value);
-    }
+
+    return cssProps;
+  });
+
+  //Set PWA theme color
+  createEffect(() => {
+    const cssProps = getCssProps(),
+      dShown =
+        state.appDrawer()?.state === SlideState.SHOWN ||
+        state.diagDrawer()?.state === SlideState.SHOWN;
+
+    const banner =
+      props.cliCtx &&
+      [
+        State.Connecting,
+        State.Disconnected,
+        State.Reconnecting,
+        State.Offline,
+      ].includes(props.cliCtx.lifecycle.state());
+
+    for (const meta of document.head.querySelectorAll("meta[name=theme-color]"))
+      (meta as HTMLMetaElement).content =
+        cssProps[
+          banner
+            ? "--md-sys-color-primary-container"
+            : dShown
+              ? "--md-sys-color-surface-container-low"
+              : "--md-sys-color-surface-container-high"
+        ];
   });
 
   return <Masks />;

--- a/packages/client/components/ui/themes/LoadTheme.tsx
+++ b/packages/client/components/ui/themes/LoadTheme.tsx
@@ -55,10 +55,9 @@ export function LoadTheme() {
 
   //Set PWA theme color
   createEffect(() => {
-    const cssProps = getCssProps(),
-      dShown =
-        state.appDrawer()?.state === SlideState.SHOWN ||
-        state.diagDrawer()?.state === SlideState.SHOWN;
+    const dShown =
+      state.appDrawer()?.state === SlideState.SHOWN ||
+      state.diagDrawer()?.state === SlideState.SHOWN;
 
     const banner = [
       State.Connecting,
@@ -67,15 +66,17 @@ export function LoadTheme() {
       State.Offline,
     ].includes(lifecycle.state());
 
+    const color =
+      getCssProps()[
+        banner
+          ? "--md-sys-color-primary-container"
+          : dShown
+            ? "--md-sys-color-surface-container-low"
+            : "--md-sys-color-surface-container-high"
+      ];
+
     for (const meta of document.head.querySelectorAll("meta[name=theme-color]"))
-      (meta as HTMLMetaElement).content =
-        cssProps[
-          banner
-            ? "--md-sys-color-primary-container"
-            : dShown
-              ? "--md-sys-color-surface-container-low"
-              : "--md-sys-color-surface-container-high"
-        ];
+      (meta as HTMLMetaElement).content = color;
   });
 
   return <Masks />;

--- a/packages/client/components/ui/themes/LoadTheme.tsx
+++ b/packages/client/components/ui/themes/LoadTheme.tsx
@@ -1,6 +1,7 @@
 import { createEffect, createMemo } from "solid-js";
 
-import ClientController, { State } from "@revolt/client/Controller";
+import { useClientLifecycle } from "@revolt/client";
+import { State } from "@revolt/client/Controller";
 import { useState } from "@revolt/state";
 
 import {
@@ -16,8 +17,9 @@ import { legacyThemeUnsetShim } from "./legacyThemeGeneratorCode";
 /**
  * Component for loading theme variables into root
  */
-export function LoadTheme(props: { cliCtx?: ClientController }) {
+export function LoadTheme() {
   const state = useState();
+  const { lifecycle } = useClientLifecycle();
 
   const getCssProps = createMemo(() => {
     const activeTheme = state.theme.activeTheme;
@@ -58,14 +60,12 @@ export function LoadTheme(props: { cliCtx?: ClientController }) {
         state.appDrawer()?.state === SlideState.SHOWN ||
         state.diagDrawer()?.state === SlideState.SHOWN;
 
-    const banner =
-      props.cliCtx &&
-      [
-        State.Connecting,
-        State.Disconnected,
-        State.Reconnecting,
-        State.Offline,
-      ].includes(props.cliCtx.lifecycle.state());
+    const banner = [
+      State.Connecting,
+      State.Disconnected,
+      State.Reconnecting,
+      State.Offline,
+    ].includes(lifecycle.state());
 
     for (const meta of document.head.querySelectorAll("meta[name=theme-color]"))
       (meta as HTMLMetaElement).content =

--- a/packages/client/components/ui/themes/LoadTheme.tsx
+++ b/packages/client/components/ui/themes/LoadTheme.tsx
@@ -21,6 +21,15 @@ export function LoadTheme() {
   const state = useState();
   const { lifecycle } = useClientLifecycle();
 
+  const bannerShown = createMemo(() =>
+    [
+      State.Connecting,
+      State.Disconnected,
+      State.Reconnecting,
+      State.Offline,
+    ].includes(lifecycle.state()),
+  );
+
   const getCssProps = createMemo(() => {
     const activeTheme = state.theme.activeTheme;
 
@@ -28,7 +37,7 @@ export function LoadTheme() {
     FONTS[state.theme.interfaceFont].load();
     MONOSPACE_FONTS[state.theme.monospaceFont].load();
 
-    const cssProps = {
+    return {
       // create unset variables to indicate where colours need replacing
       ...Object.keys(legacyThemeUnsetShim().colours).reduce(
         (d, k) => ({
@@ -46,31 +55,26 @@ export function LoadTheme() {
       // mount --mdui-color triplet variables
       ...createMduiColourTriplets(activeTheme, "--mdui-color-"),
     };
+  });
 
+  //Update CSS props on body
+  createEffect(() => {
+    const cssProps = getCssProps();
     for (const [key, value] of Object.entries(cssProps))
       document.body.style.setProperty(key, value);
-
-    return cssProps;
   });
 
   //Set PWA theme color
   createEffect(() => {
-    const dShown =
+    const drawerShown =
       state.appDrawer()?.state === SlideState.SHOWN ||
       state.diagDrawer()?.state === SlideState.SHOWN;
 
-    const banner = [
-      State.Connecting,
-      State.Disconnected,
-      State.Reconnecting,
-      State.Offline,
-    ].includes(lifecycle.state());
-
     const color =
       getCssProps()[
-        banner
+        bannerShown()
           ? "--md-sys-color-primary-container"
-          : dShown
+          : drawerShown
             ? "--md-sys-color-surface-container-low"
             : "--md-sys-color-surface-container-high"
       ];

--- a/packages/client/components/ui/themes/LoadTheme.tsx
+++ b/packages/client/components/ui/themes/LoadTheme.tsx
@@ -33,10 +33,6 @@ export function LoadTheme() {
   const getCssProps = createMemo(() => {
     const activeTheme = state.theme.activeTheme;
 
-    // load fonts
-    FONTS[state.theme.interfaceFont].load();
-    MONOSPACE_FONTS[state.theme.monospaceFont].load();
-
     return {
       // create unset variables to indicate where colours need replacing
       ...Object.keys(legacyThemeUnsetShim().colours).reduce(
@@ -57,8 +53,11 @@ export function LoadTheme() {
     };
   });
 
-  //Update CSS props on body
+  //Load fonts & update CSS props on body
   createEffect(() => {
+    FONTS[state.theme.interfaceFont].load();
+    MONOSPACE_FONTS[state.theme.monospaceFont].load();
+
     const cssProps = getCssProps();
     for (const [key, value] of Object.entries(cssProps))
       document.body.style.setProperty(key, value);

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -7,6 +7,7 @@
     content="width=device-width, initial-scale=1, user-scalable=no, interactive-widget=resizes-content">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="theme-color" content="#000">
+  <meta name="theme-color" content="#000" media="(prefers-color-scheme: dark)">
   <meta http-equiv="cache-control" content="no-cache">
   <link rel="shortcut icon" type="image/png" href="./public/assets/web/icon.ico">
   <title>Stoat</title>

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -3,7 +3,7 @@
  */
 import "./sentry";
 
-import { JSX, onMount } from "solid-js";
+import { createSignal, JSX, onMount } from "solid-js";
 import { render } from "solid-js/web";
 
 import { attachDevtoolsOverlay } from "@solid-devtools/overlay";
@@ -22,7 +22,12 @@ import FlowLogin from "@revolt/auth/src/flows/FlowLogin";
 import FlowResend from "@revolt/auth/src/flows/FlowResend";
 import FlowReset from "@revolt/auth/src/flows/FlowReset";
 import FlowVerify from "@revolt/auth/src/flows/FlowVerify";
-import { ClientContext, SoundContext, useClient } from "@revolt/client";
+import {
+  ClientContext,
+  ClientController,
+  SoundContext,
+  useClient,
+} from "@revolt/client";
 import { DeviceContext } from "@revolt/common";
 import { I18nProvider } from "@revolt/i18n";
 import { InstanceContext } from "@revolt/instance";
@@ -117,13 +122,14 @@ function BotRedirect() {
 }
 
 function MountContext(props: { children?: JSX.Element }) {
+  const [cliCtx, setCliCtx] = createSignal<ClientController>();
   const client = new QueryClient();
 
   return (
     <StateContext>
       <KeybindContext>
         <ModalContext>
-          <ClientContext>
+          <ClientContext setCtx={setCliCtx}>
             <SoundContext>
               <VoiceContext>
                 <QueryClientProvider client={client}>
@@ -138,7 +144,7 @@ function MountContext(props: { children?: JSX.Element }) {
           </ClientContext>
         </ModalContext>
       </KeybindContext>
-      <LoadTheme />
+      <LoadTheme cliCtx={cliCtx()} />
     </StateContext>
   );
 }

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -3,7 +3,7 @@
  */
 import "./sentry";
 
-import { createSignal, JSX, onMount } from "solid-js";
+import { JSX, onMount } from "solid-js";
 import { render } from "solid-js/web";
 
 import { attachDevtoolsOverlay } from "@solid-devtools/overlay";
@@ -22,12 +22,7 @@ import FlowLogin from "@revolt/auth/src/flows/FlowLogin";
 import FlowResend from "@revolt/auth/src/flows/FlowResend";
 import FlowReset from "@revolt/auth/src/flows/FlowReset";
 import FlowVerify from "@revolt/auth/src/flows/FlowVerify";
-import {
-  ClientContext,
-  ClientController,
-  SoundContext,
-  useClient,
-} from "@revolt/client";
+import { ClientContext, SoundContext, useClient } from "@revolt/client";
 import { DeviceContext } from "@revolt/common";
 import { I18nProvider } from "@revolt/i18n";
 import { InstanceContext } from "@revolt/instance";
@@ -122,14 +117,14 @@ function BotRedirect() {
 }
 
 function MountContext(props: { children?: JSX.Element }) {
-  const [cliCtx, setCliCtx] = createSignal<ClientController>();
   const client = new QueryClient();
 
   return (
     <StateContext>
       <KeybindContext>
         <ModalContext>
-          <ClientContext setCtx={setCliCtx}>
+          <ClientContext>
+            <LoadTheme />
             <SoundContext>
               <VoiceContext>
                 <QueryClientProvider client={client}>
@@ -144,7 +139,6 @@ function MountContext(props: { children?: JSX.Element }) {
           </ClientContext>
         </ModalContext>
       </KeybindContext>
-      <LoadTheme cliCtx={cliCtx()} />
     </StateContext>
   );
 }

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -48,7 +48,6 @@ export default defineConfig({
         categories: ["communication", "chat", "messaging"],
         start_url: base,
         scope: pwaScope,
-        orientation: "any",
         display_override: ["window-controls-overlay"],
         display: "standalone",
         background_color: "#101823",


### PR DESCRIPTION
Fixes a recently reported issue where the app continues to rotate even if the OS-level Rotation Lock is enabled. This is because setting orientation to `any` in Vite overrode the system setting.

Also fixes the system bar color being locked to the color of the default theme even if you change theme colors, by reactively matching the meta theme color to the current UI state.

## How was this PR tested?

PWA build in dev and production mode and tested on Android in Brave and Firefox.

## Screenshots

Open/closed slide drawer:

<img width=300 src="https://github.com/user-attachments/assets/45d9ab5d-ebd4-4860-914c-7914004cc3ee" /> <img width=300 src="https://github.com/user-attachments/assets/90c7db31-7cc9-4c66-a4bd-c944b38c932b" />

Landscape:

<img width=600 src="https://github.com/user-attachments/assets/f68ea55a-7131-4bff-acbc-1384c6884b71" />

URL bar / PWA notification shade during load:

<img width=300 src="https://github.com/user-attachments/assets/e084ce78-25c7-4545-b2fd-dca72ec6622b" /> <img width=300 src="https://github.com/user-attachments/assets/93c03952-5676-426f-914e-aed0356ce42d" />

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Electric mice Pokemon are not defined as valid end users in ChatGPT's ToS.

- `main` <!-- branch-stack -->
  - \#1364 :point\_left:
