### PR TITLE
fix: remove marginInlineStart(70px) when opened in a macOS browser

### DIFF
--- a/packages/client/components/app/interface/desktop/Titlebar.tsx
+++ b/packages/client/components/app/interface/desktop/Titlebar.tsx
@@ -18,7 +18,7 @@ import Wordmark from "../../../../public/assets/web/wordmark.svg?component-solid
 import { pendingUpdate } from "../../../../src/serviceWorkerInterface";
 
 const isMacOS = navigator.platform.startsWith("Mac");
-const isNative = Boolean(window.native);
+const isNative = !!window.native;
 
 export function Titlebar() {
   const [isMaximised, setIsMaximised] = createSignal(

--- a/packages/client/components/app/interface/desktop/Titlebar.tsx
+++ b/packages/client/components/app/interface/desktop/Titlebar.tsx
@@ -18,10 +18,11 @@ import Wordmark from "../../../../public/assets/web/wordmark.svg?component-solid
 import { pendingUpdate } from "../../../../src/serviceWorkerInterface";
 
 const isMacOS = navigator.platform.startsWith("Mac");
+const isNative = Boolean(window.native);
 
 export function Titlebar() {
   const [isMaximised, setIsMaximised] = createSignal(
-    window.native ? window.desktopConfig.get().windowState.isMaximised : false,
+    isNative ? window.desktopConfig.get().windowState.isMaximised : false,
   );
   const { lifecycle } = useClientLifecycle();
 
@@ -43,7 +44,7 @@ export function Titlebar() {
     <Presence>
       <Show
         when={
-          (window.native && window.desktopConfig?.get().customFrame) ||
+          (isNative && window.desktopConfig?.get().customFrame) ||
           isDisconnected()
         }
       >
@@ -71,7 +72,7 @@ export function Titlebar() {
               </Show>
             </Title>
             <DragHandle
-              macos={isMacOS}
+              macos={isMacOS && isNative}
               style={{
                 "-webkit-user-select": "none",
                 "-webkit-app-region": "drag",
@@ -126,7 +127,7 @@ export function Titlebar() {
                 </div>
               </Show>
             </DragHandle>
-            <Show when={window.native && !isMacOS}>
+            <Show when={isNative && !isMacOS}>
               <Action onClick={window.native.minimise}>
                 <Ripple />
                 <MdMinimize {...symbolSize(20)} />


### PR DESCRIPTION
I recently created a pull request #1274 to make the macOS app use native traffic lights UI. But it ended up giving unnecessary space for browsers too. This pull request fixes it.

## How was this PR tested?
Yes. I'm attaching two screenshots for comparison.

#### Before
<img width="950" height="772" alt="Screenshot 2026-07-23 at 3 26 53 AM" src="https://github.com/user-attachments/assets/7370b7c7-c561-4d0d-b864-e3a7290a8541" />

#### After
<img width="950" height="772" alt="Screenshot 2026-07-23 at 3 23 34 AM" src="https://github.com/user-attachments/assets/ef655e4c-baeb-42de-a3b8-4ea69b59302b" />