### PR TITLE
fix: Correct message preview color in Appearance menu & Add pronouns

### DIFF
--- a/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
+++ b/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
@@ -306,6 +306,7 @@ export function AppearanceMenu() {
               }
               timestamp={new Date()}
               username={user()?.displayName}
+              pronouns={user()?.pronouns}
               isLink="hide"
             >
               Sphinx of black quartz, judge my vow
@@ -440,7 +441,7 @@ const Preview = styled("div", {
     height: "126px",
     overflow: "hidden",
     borderRadius: "var(--borderRadius-lg)",
-    background: "var(--md-sys-color-surface-container-highest)",
+    background: "var(--md-sys-color-surface-container-lowest)",
   },
 });
 


### PR DESCRIPTION
Corrects the message preview box background color in the Appearance menu, and added pronouns to the preview while I was at it.

This doesn't have an open issue, but it was pointed out [by someone in the Support channel](https://stoat.chat/server/01F7ZSBSFHQ8TA81725KQCSDDP/channel/01FY1ENB2K17625XAB985HVWSQ/01KK3CW1ECGDT9XGC9GG1C5CPD) a while ago, had it on my TODO backlog and I was bored today lol.

## How was this PR tested?

See below pics lol

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
Before:<br>
<img width=600 src="https://github.com/user-attachments/assets/ed475414-7201-4254-b38b-4db2b7d95faa" /><br>After:<br>
<img width=600 src="https://github.com/user-attachments/assets/18b5022d-745f-4e12-b976-ae9423fa8877" />
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Llama? I love llamas!

- `main` <!-- branch-stack -->
  - \#1368 :point\_left:
