### PR TITLE
fix: Fix keyboard flicker via VirtualKeyboard API

### DIFF
--- a/packages/client/components/auth/src/AuthPage.tsx
+++ b/packages/client/components/auth/src/AuthPage.tsx
@@ -26,13 +26,6 @@ const Base = styled("div", {
     userSelect: "none",
     overflowY: "scroll",
 
-    color: "var(--md-sys-color-on-surface)",
-    background: "var(--md-sys-color-surface)",
-    // background: `var(--url)`,
-    // backgroundPosition: "center",
-    // backgroundRepeat: "no-repeat",
-    // backgroundSize: "cover",
-
     display: "flex",
     flexDirection: "column",
     justifyContent: "space-between",
@@ -40,6 +33,22 @@ const Base = styled("div", {
     mdDown: {
       padding: "30px 20px",
     },
+  },
+});
+
+const Root = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    paddingBottom: "env(keyboard-inset-height)",
+
+    color: "var(--md-sys-color-on-surface)",
+    background: "var(--md-sys-color-surface)",
+    // background: `var(--url)`,
+    // backgroundPosition: "center",
+    // backgroundRepeat: "no-repeat",
+    // backgroundSize: "cover",
   },
 });
 
@@ -118,13 +127,7 @@ export function AuthPage(props: { children: JSX.Element }) {
   const state = useState();
 
   return (
-    <div
-      style={{
-        display: "flex",
-        "flex-direction": "column",
-        height: "100%",
-      }}
-    >
+    <Root>
       <Titlebar />
       <Base
         style={{ "--url": `url('${background}')` }}
@@ -175,6 +178,6 @@ export function AuthPage(props: { children: JSX.Element }) {
           </NavItems>
         </Nav>
       </Base>
-    </div>
+    </Root>
   );
 }

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -12,6 +12,14 @@ import Breakpoint from "./Breakpoint";
 
 export type Layout = "desktop" | "tablet" | "phone";
 
+declare global {
+  interface Navigator {
+    virtualKeyboard?: {
+      overlaysContent: boolean;
+    };
+  }
+}
+
 /** Device type and compatibility info */
 export class Device {
   /** Layout type based on viewport size
@@ -40,6 +48,10 @@ export class Device {
     this.pMedia = matchMedia(Breakpoint.phone);
     this.tMedia = matchMedia(Breakpoint.tablet);
     (this.pMedia.onchange = this.tMedia.onchange = this.onLayout.bind(this))();
+
+    if (navigator.virtualKeyboard) {
+      navigator.virtualKeyboard.overlaysContent = true;
+    }
   }
 
   onLayout() {

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -34,6 +34,13 @@ export class Device {
    * Granular feature-detection is preferred when possible. */
   readonly isMobile: boolean;
 
+  /** If Stoat is running as a web app */
+  readonly isPWA =
+    //Safari
+    (window.navigator as never as { standalone: boolean }).standalone ||
+    //Other
+    window.matchMedia("(display-mode: standalone)").matches;
+
   private pMedia;
   private tMedia;
   private setLayout;
@@ -49,7 +56,7 @@ export class Device {
     this.tMedia = matchMedia(Breakpoint.tablet);
     (this.pMedia.onchange = this.tMedia.onchange = this.onLayout.bind(this))();
 
-    if (navigator.virtualKeyboard) {
+    if (this.isPWA && navigator.virtualKeyboard) {
       navigator.virtualKeyboard.overlaysContent = true;
     }
   }

--- a/packages/client/components/ui/components/design/Dialog.tsx
+++ b/packages/client/components/ui/components/design/Dialog.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js";
-import { For, Show } from "solid-js";
+import { For, Show, splitProps } from "solid-js";
 import { Portal } from "solid-js/web";
 import { Motion, Presence } from "solid-motionone";
 
@@ -43,7 +43,6 @@ export function Dialog(props: Props) {
       <Dialog.Scrim
         show={props.show}
         onClick={props.onClose}
-        class="dialog_scrim"
         style={{
           "--background": props.scrimBackground
             ? `url('${props.scrimBackground}'), rgba(0, 0, 0, 0.6)`
@@ -53,10 +52,7 @@ export function Dialog(props: Props) {
         <Presence>
           <Show when={props.show}>
             <Motion.div
-              initial={{
-                opacity: 0,
-                y: 20,
-              }}
+              initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}
               transition={{ duration: 0.3, easing: [0.05, 0.7, 0.1, 1.0] }}
@@ -120,7 +116,26 @@ export function Dialog(props: Props) {
  *
  * @specification https://m3.material.io/components/dialogs
  */
-Dialog.Scrim = styled("div", {
+Dialog.Scrim = (
+  props: Omit<
+    Parameters<typeof Scrim>[0] & Parameters<typeof ScrimPad>[0],
+    "class"
+  >,
+) => {
+  const [local, remote] = splitProps(props, [
+    "children",
+    "padding",
+    "overflow",
+  ]);
+
+  return (
+    <Scrim {...remote} class="dialog_scrim">
+      <ScrimPad {...local} />
+    </Scrim>
+  );
+};
+
+const Scrim = styled("div", {
   base: {
     top: 0,
     left: 0,
@@ -128,14 +143,8 @@ Dialog.Scrim = styled("div", {
     bottom: 0,
     position: "fixed",
     zIndex: "998",
-
     maxHeight: "100%",
-
-    display: "grid",
-    userSelect: "none",
-    placeItems: "center",
-
-    pointerEvents: "all",
+    paddingBottom: "env(keyboard-inset-height)",
 
     animationName: "scrimFadeIn",
     animationDuration: "0.1s",
@@ -150,17 +159,6 @@ Dialog.Scrim = styled("div", {
         background: "transparent",
       },
     },
-    padding: {
-      true: {
-        padding: "80px",
-        _phone: { padding: "30px" },
-      },
-    },
-    overflow: {
-      true: {
-        overflowY: "auto",
-      },
-    },
     dark: {
       true: {
         "--background": "rgba(0, 0, 0, 0.9)",
@@ -172,9 +170,35 @@ Dialog.Scrim = styled("div", {
   },
   defaultVariants: {
     show: true,
+    dark: false,
+  },
+});
+
+const ScrimPad = styled("div", {
+  base: {
+    width: "100%",
+    height: "100%",
+    display: "grid",
+    userSelect: "none",
+    placeItems: "center",
+    pointerEvents: "all",
+  },
+  variants: {
+    padding: {
+      true: {
+        padding: "80px",
+        _phone: { padding: "30px" },
+      },
+    },
+    overflow: {
+      true: {
+        overflowY: "auto",
+      },
+    },
+  },
+  defaultVariants: {
     padding: true,
     overflow: true,
-    dark: false,
   },
 });
 

--- a/packages/client/components/ui/components/design/Dialog.tsx
+++ b/packages/client/components/ui/components/design/Dialog.tsx
@@ -118,7 +118,7 @@ export function Dialog(props: Props) {
  */
 Dialog.Scrim = (
   props: Omit<
-    Parameters<typeof Scrim>[0] & Parameters<typeof ScrimPad>[0],
+    Parameters<typeof Scrim>[0] & Parameters<typeof ScrimSurface>[0],
     "class"
   >,
 ) => {
@@ -130,7 +130,7 @@ Dialog.Scrim = (
 
   return (
     <Scrim {...remote} class="dialog_scrim">
-      <ScrimPad {...local} />
+      <ScrimSurface {...local} />
     </Scrim>
   );
 };
@@ -174,7 +174,7 @@ const Scrim = styled("div", {
   },
 });
 
-const ScrimPad = styled("div", {
+const ScrimSurface = styled("div", {
   base: {
     width: "100%",
     height: "100%",

--- a/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/CompositionMediaPicker.tsx
@@ -192,7 +192,8 @@ const Base = styled("div", {
     width: "400px",
     height: "400px",
     maxWidth: "100%",
-    maxHeight: "calc(100% - 72px)",
+    maxHeight: "calc(100% - max(env(keyboard-inset-height), 72px))",
+    marginBottom: "env(keyboard-inset-height)",
   },
 });
 

--- a/packages/client/components/ui/components/layout/Main.tsx
+++ b/packages/client/components/ui/components/layout/Main.tsx
@@ -20,6 +20,7 @@ export const main = cva({
     marginBlockEnd: "var(--gap-md)",
     borderRadius: "var(--borderRadius-xl)",
     background: "var(--md-sys-color-surface-container-lowest)",
+    paddingBottom: "env(keyboard-inset-height)",
 
     _tablet: {
       margin: 0,


### PR DESCRIPTION
Thanks to the **POWAH** of the new [VirtualKeyboard API](https://developer.mozilla.org/en-US/docs/Web/API/VirtualKeyboard), we can finally fix the annoying little flicker and momentary frame-rate stutter that happens whenever you open the virtual keyboard on mobile!

This happens because the viewport is being resized by the browser as the keyboard opens, which takes it a bit to process, whereas a native app doesn't actually resize the viewport- the keyboard overlays the content, but UI elements move to adjust to its size and position. This updates the app to use a similar strategy on supported devices, falling back to the current approach otherwise.

There should (hopefully) be no other visual changes to take screenshots of.

## How was this PR tested?

With Android fone. iOS not supported yet but allegedly coming soon in a future Safari release.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Sorry, the dog ate my LLM 🙀

- `main` <!-- branch-stack -->
  - \#1375 :point\_left:
