### PR TITLE
fix: PWA scope is set to "" in non-production builds

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -12,7 +12,7 @@ import solidSvg from "vite-plugin-solid-svg";
 import codegenPlugin from "./codegen.plugin";
 
 const base = process.env.BASE_PATH ?? "/";
-const pwaScope = process.env.PWA_SCOPE ?? base;
+const pwaScope = process.env.PWA_SCOPE || base;
 
 export default defineConfig({
   base,


### PR DESCRIPTION
Fixes this log in non-production builds

<img width="786" height="43" alt="image" src="https://github.com/user-attachments/assets/90977c29-68bb-47cb-b2e6-5a562ad99132" />

## How was this PR tested?

I made sure `"" || "/"` == `/` (not guaranteed! Javascript is a wild ride.)

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1376 :point\_left:
