### PR TITLE
chore: update nix shell to latest nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,12 @@
 { pkgs ? import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/77ef7a29d276c6d8303aece3444d61118ef71ac2.tar.gz";
-    sha256 = "0pm4l48jq8plzrrrisimahxqlcpx7qqq9c99hylmf7p3zlc3phsy";
+    url = "https://github.com/NixOS/nixpkgs/archive/110ffdee50af63b1f3adb714e0d5cc679999e108.tar.gz";
+    sha256 = "1x2z0wx0mph8l29fjchl8hdnsqvklv8md28qdijg6lscdr8x3n9n";
   }) {},
 
-  # Playwright v1.57.0
+  # Playwright v1.60.0
   unstablePkgs ? import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/145b67bd0bd4e075f981c1c2b81155d9e2982de2.tar.gz";
-    sha256 = "152qwxacs6lw1dskn21985qly8ipjzwpsvicy7inzh3hhma603gg";
+    url = "https://github.com/NixOS/nixpkgs/archive/9e87430ac7e25a6ba9f5a593c300f4e114a00f57.tar.gz";
+    sha256 = "1zcfwvx89r4w2qgnlq1fqvp6zpzzq4xlc786z6i37454nj0s87rj";
   }) {},
 }:
 


### PR DESCRIPTION
<!-- Describe your changes -->

This updates the project's nix shell to use updated versions of both `mise` and `playwright` to match the ones in their respective manifests.

- mise: 2025.11.7 -> 2026.6.0
- playwright-driver: 1.57.0 -> 1.60.0

## How was this PR tested?

- [x] `nix-shell` activates correctly
- [x] `mise --version` reports 2026.6.0
- [x] `shellHook` reports installed `playwright-driver` version as 1.60.0
 
<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI-generated code was used during the creation of this PR.
