### PR TITLE
feat: edit bot username from bot management ui

### DIFF
--- a/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
+++ b/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
@@ -3,7 +3,13 @@ import { Bot } from "stoat.js";
 
 import { createProfileResource } from "@revolt/client/resources";
 import { useModals } from "@revolt/modal";
-import { CategoryButton, Column, iconSize, useSnackbar } from "@revolt/ui";
+import {
+  CategoryButton,
+  Column,
+  iconSize,
+  Symbol,
+  useSnackbar,
+} from "@revolt/ui";
 
 import MdContentCopy from "@material-design-icons/svg/outlined/content_copy.svg?component-solid";
 import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
@@ -50,6 +56,16 @@ export function ViewBot(props: { bot: Bot }) {
           onClick={() => openModal({ type: "reset_bot_token", bot: props.bot })}
         >
           <Trans>Reset Token</Trans>
+        </CategoryButton>
+        <CategoryButton
+          description={<Trans>Change this bot's username</Trans>}
+          icon={<Symbol size={22}>badge</Symbol>}
+          action="chevron"
+          onClick={() =>
+            openModal({ type: "edit_bot_username", bot: props.bot })
+          }
+        >
+          <Trans>Change Username</Trans>
         </CategoryButton>
         <CategoryButton
           description={

--- a/packages/client/components/modal/modals.tsx
+++ b/packages/client/components/modal/modals.tsx
@@ -28,6 +28,7 @@ import { DeleteChannelModal } from "./modals/DeleteChannel";
 import { DeleteMessageModal } from "./modals/DeleteMessage";
 import { DeleteRoleModal } from "./modals/DeleteRole";
 import { DeleteServerModal } from "./modals/DeleteServer";
+import { EditBotUsernameModal } from "./modals/EditBotUsername";
 import { EditCategoryModal } from "./modals/EditCategory";
 import { EditEmailModal } from "./modals/EditEmail";
 import { EditPasswordModal } from "./modals/EditPassword";
@@ -191,7 +192,8 @@ export function RenderModal(props: ActiveModal & { onClose: () => void }) {
       return <RemoveMemberModal {...modalProps} />;
     case "pin_message":
       return <PinMessageModal {...modalProps} />;
-
+    case "edit_bot_username":
+      return <EditBotUsernameModal {...modalProps} />;
     case "screen_share_settings":
       return <ScreenShareSettingsModal {...modalProps} />;
     case "screen_share_picker":

--- a/packages/client/components/modal/modals/EditBotUsername.tsx
+++ b/packages/client/components/modal/modals/EditBotUsername.tsx
@@ -1,0 +1,78 @@
+import { createFormControl, createFormGroup } from "solid-forms";
+
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
+
+import { Column, Dialog, DialogProps, Form2, Row, Text } from "@revolt/ui";
+
+import { css } from "styled-system/css";
+import { useModals } from "..";
+import { Modals } from "../types";
+
+/**
+ * Change bot username
+ */
+export function EditBotUsernameModal(
+  props: DialogProps & Modals & { type: "edit_bot_username" },
+) {
+  const { t } = useLingui();
+  const { showError } = useModals();
+
+  const group = createFormGroup({
+    // `username` won't change until after editing it
+    // eslint-disable-next-line solid/reactivity
+    username: createFormControl(props.bot.user!.username, {
+      required: true,
+    }),
+  });
+
+  async function onSubmit() {
+    try {
+      await props.bot.edit({
+        name: group.controls.username.value,
+      });
+      props.onClose();
+    } catch (err) {
+      showError(err);
+    }
+  }
+
+  const submit = Form2.useSubmitHandler(group, onSubmit);
+
+  return (
+    <Dialog
+      show={props.show}
+      onClose={props.onClose}
+      title={<Trans>Change bot username</Trans>}
+      actions={[
+        { text: <Trans>Close</Trans> },
+        {
+          text: <Trans>Change</Trans>,
+          onClick: () => {
+            onSubmit();
+            return false;
+          },
+          isDisabled: !Form2.canSubmit(group),
+        },
+      ]}
+      isDisabled={group.isPending}
+    >
+      <form onSubmit={submit}>
+        <Column>
+          <Row align>
+            <Form2.TextField
+              minlength={1}
+              maxlength={32}
+              counter
+              name="username"
+              control={group.controls.username}
+              label={t`Username`}
+            />
+            <div class={css({ flexShrink: 0 })}>
+              <Text class="label">#{props.bot.user!.discriminator}</Text>
+            </div>
+          </Row>
+        </Column>
+      </form>
+    </Dialog>
+  );
+}

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -344,4 +344,8 @@ export type Modals =
         image?: string;
       }[];
       onCancel: () => void;
+    }
+  | {
+      type: "edit_bot_username";
+      bot: Bot;
     };


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #1383. This adds an "edit username" option to the bot management modal inside of settings.



## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Changed the username of one of my alt account's bots
- [x] After changing the username, checked if the change went through

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<img width="1021" height="113" alt="image" src="https://github.com/user-attachments/assets/375e1823-ff29-4b09-9eea-9b8af87fe3ac" />
<img width="551" height="367" alt="image" src="https://github.com/user-attachments/assets/1cbfe693-ea4a-448d-872e-af9259b71597" />
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI-generated code was used at the time of writing this PR.

## Additional Notes
Reactivity in both `ViewBot.tsx` and `MyBots.tsx` was broken before this PR was written.

I've already talked with @Dadadah in the Stoat Development server and offered himself to fix it in a separate PR.