### PR TITLE
fix: Fix bio reactivity in profile editing for users and bots

### DIFF
--- a/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
+++ b/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
@@ -41,7 +41,7 @@ export function ViewBot(props: { bot: Bot }) {
         bannerUrl={profile.data?.animatedBannerURL}
       />
 
-      <UserProfileEditor user={props.bot.user!} />
+      <UserProfileEditor user={props.bot.user!} profile={profile.data} />
       {/* <ErrorBoundary fallback={<>Failed to load profile</>}>
         <Suspense fallback={<>loading...</>}>{profile.data?.content}</Suspense>
       </ErrorBoundary> */}

--- a/packages/client/components/app/interface/settings/user/profile/EditProfile.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/EditProfile.tsx
@@ -63,7 +63,7 @@ export function EditProfile() {
         <Text class="title" size="large">
           <Trans>Edit Global Profile</Trans>
         </Text>
-        <UserProfileEditor user={client().user!} />
+        <UserProfileEditor user={client().user!} profile={profile.data} />
       </Column>
     </Column>
   );

--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -2,8 +2,8 @@ import { createFormControl, createFormGroup } from "solid-forms";
 import { Show, createEffect, createSignal, on } from "solid-js";
 
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
-import { useQuery, useQueryClient } from "@tanstack/solid-query";
-import { API, User } from "stoat.js";
+import { useQueryClient } from "@tanstack/solid-query";
+import { API, User, UserProfile } from "stoat.js";
 
 import { useClient } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
@@ -22,20 +22,13 @@ import { useSettingsNavigation } from "../../Settings";
 
 interface Props {
   user: User;
+  profile?: UserProfile;
 }
 
 export function UserProfileEditor(props: Props) {
   const { t } = useLingui();
   const client = useClient();
   const queryClient = useQueryClient();
-
-  const profile = useQuery(() => ({
-    queryKey: ["profile", props.user.id],
-    queryFn: () => props.user.fetchProfile(),
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-  }));
-
   const { navigate } = useSettingsNavigation();
 
   /* eslint-disable solid/reactivity */
@@ -51,16 +44,12 @@ export function UserProfileEditor(props: Props) {
   });
   /* eslint-enable solid/reactivity */
 
-  // unlike the other forms, this one does not react to
-  // further changes outside of our control because it's
-  // unlikely that the user is going to be doing this
-
   const [initialBio, setInitialBio] = createSignal<readonly [string]>();
 
   // once profile data is loaded, copy it into the form
   createEffect(
     on(
-      () => profile.data,
+      () => props.profile,
       (profileData) => {
         if (profileData) {
           editGroup.controls.banner.setValue(
@@ -79,12 +68,12 @@ export function UserProfileEditor(props: Props) {
     editGroup.controls.avatar.setValue(props.user.animatedAvatarURL);
     editGroup.controls.pronouns.setValue(props.user.pronouns || "");
 
-    if (profile.data) {
+    if (props.profile) {
       editGroup.controls.banner.setValue(
-        profile.data.animatedBannerURL || null,
+        props.profile.animatedBannerURL || null,
       );
-      editGroup.controls.bio.setValue(profile.data.content || "");
-      setInitialBio([profile.data.content || ""]);
+      editGroup.controls.bio.setValue(props.profile.content || "");
+      setInitialBio([props.profile.content || ""]);
     }
   }
 
@@ -147,11 +136,15 @@ export function UserProfileEditor(props: Props) {
 
     await props.user.edit(changes);
 
-    if (editGroup.controls.banner.isDirty && profile.data) {
+    if (
+      (editGroup.controls.banner.isDirty || editGroup.controls.bio.isDirty) &&
+      props.profile
+    ) {
       queryClient.setQueryData(["profile", props.user.id], {
-        ...profile.data,
+        ...props.profile,
         animatedBannerURL: newBannerUrl,
         bannerURL: newBannerUrl,
+        content: editGroup.controls.bio.value,
       });
     }
   }

--- a/packages/client/components/client/resources.ts
+++ b/packages/client/components/client/resources.ts
@@ -1,4 +1,4 @@
-import { createQuery } from "@tanstack/solid-query";
+import { useQuery } from "@tanstack/solid-query";
 import { User } from "stoat.js";
 
 import { useClient } from ".";
@@ -10,7 +10,7 @@ import { useClient } from ".";
 export function createMfaResource() {
   const client = useClient();
 
-  return createQuery(() => ({
+  return useQuery(() => ({
     queryKey: ["mfa", client().user!.id],
     queryFn: () => client().account.mfa(),
     throwOnError: true,
@@ -23,7 +23,7 @@ export function createMfaResource() {
  * @returns User profile resource
  */
 export function createProfileResource(user: User) {
-  return createQuery(() => ({
+  return useQuery(() => ({
     queryKey: ["profile", user.id],
     queryFn: () => user!.fetchProfile(),
     throwOnError: true,
@@ -45,7 +45,7 @@ export function createOwnProfileResource() {
  */
 export function createOwnBotsResource() {
   const client = useClient();
-  return createQuery(() => ({
+  return useQuery(() => ({
     queryKey: ["bots", client().user!.id],
     queryFn: () => client().bots.fetchOwned(),
     throwOnError: true,

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -78,7 +78,7 @@ const FormTextEditor = (
         {...remote}
         onChange={(value) => {
           local.control.setValue(value);
-          local.control.markDirty(true);
+          local.control.markDirty(value !== remote.initialValue?.[0]);
         }}
         // todo: required={local.control.isRequired}
         // todo: disabled={local.control.isDisabled}


### PR DESCRIPTION
Fix the bio update reactivity when updating users and bots.

Fix a bug in the text field form (bio) that made it always dirty causing the save button to always be available.

Updated some tanstack deprecations.

Small refactor to UserProfileEditor to take a profile instead of fetching it's own, resulting in two fetches.

Fixes #869

No significant UI changes.

## How was this PR tested?

updated my bio a bit

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1387 :point\_left:
