### PR TITLE
fix: Make copy file link and open file use preview url

### DIFF
--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -144,14 +144,14 @@ export function MessageContextMenu(props: {
    * Opens the file preview in a new tab
    */
   function openFile() {
-    window.open(props.file?.originalUrl, "_blank");
+    window.open(props.file?.previewUrl, "_blank");
   }
 
   /**
    * Copies the link to the original url of the file
    */
   function copyFileLink() {
-    navigator.clipboard.writeText(props.file?.originalUrl ?? "");
+    navigator.clipboard.writeText(props.file?.previewUrl ?? "");
   }
 
   function copyLink() {


### PR DESCRIPTION
Previously, copying the file link would cause it to fail to embed when shared again. Changing it to the preview url allows it to embed.

Fixes #1322

No UI Changes.

## How was this PR tested?

Right clicked copied some files and ensured the url was as expected.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1389 :point\_left:
