### PR TITLE
fix: Jump ui to last message when pressing up to edit last message

### DIFF
--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -881,11 +881,20 @@ export function Messages(props: Props) {
   createEffect(
     on(
       () => state.draft.editingMessageId,
-      (shouldSetEditingMessageId) =>
-        shouldSetEditingMessageId === true &&
-        state.draft.setEditingMessage(
-          messages().find((message) => message.author?.self),
-        ),
+      (shouldSetEditingMessageId) => {
+        if (shouldSetEditingMessageId === true) {
+          const chosenMessage = messages().find(
+            (message) => message.author?.self,
+          );
+          state.draft.setEditingMessage(chosenMessage);
+          if (chosenMessage) {
+            // Wait until the next render pass to allow the edit message ui to
+            // fill the messages screen. This prevents the message box from
+            // jumping up the height of the edit message ui.
+            setTimeout(() => caseJumpToMessage(chosenMessage?.id), 1);
+          }
+        }
+      },
     ),
   );
 


### PR DESCRIPTION
When pressing up, direct the window to the message being edited.

Fixes #1299

## How was this PR tested?

pressed up and edited some messages

No UI changes.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1390 :point\_left:
