### PR TITLE
fix: Partially fix autocomplete, still broken for some plugins

### DIFF
--- a/packages/client/components/auth/src/flows/Form.tsx
+++ b/packages/client/components/auth/src/flows/Form.tsx
@@ -52,6 +52,7 @@ const useFieldConfiguration = () => {
       "toggle-password": true,
       showPasswordIcon: "visibility",
       hidePasswordIcon: "visibility_off",
+      autocomplete: "current-password",
       name: () => t`Password`,
       placeholder: () => t`Enter your current password.`,
     },
@@ -113,7 +114,7 @@ export function Fields(props: FieldProps) {
           field = { field: field };
         }
         return (
-          <label>
+          <>
             {field.field === "log-out" ? (
               <Checkbox name={field.field}>
                 {fieldConfiguration[field.field].name()}
@@ -129,7 +130,7 @@ export function Fields(props: FieldProps) {
                 value={field.value}
               />
             )}
-          </label>
+          </>
         );
       }}
     </For>


### PR DESCRIPTION
I tried fixing an issue where autocomplete wasn't working with my password manager. It still isn't working for mine but this might fix some of them.

No UI changes

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1396 :point\_left:
