### PR TITLE
fix: Fix fullscreen logic in voice calls to allow context menus

### DIFF
--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -605,7 +605,7 @@ class Voice {
       channel.isVoice &&
       (this.channel()?.id === channel.id ||
         channel.type === "TextChannel" ||
-        channel.voiceParticipants.size)
+        !!channel.voiceParticipants.size)
     );
   }
 

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -43,6 +43,7 @@ const callCardContext = createContext<(info?: Info) => void>();
 /** Voice call card context */
 export function VoiceCallCardContext(props: { children: JSX.Element }) {
   const voice = useVoice();
+  const inCall = () => !!voice.channel();
 
   const [mode, setMode] = createSignal<Mode>();
   const [info, setInfo] = createSignal<Info>();
@@ -99,14 +100,17 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     events = null;
   }
 
-  const channel = createMemo(() => {
+  createEffect(() => {
     const inf = info();
-
     if (!ref) return;
     const sty = ref.style;
 
     //Set mode based on state
-    if (inf?.pos && (!inf.drawer || inf.drawer === SlideState.SHOWN)) {
+    if (voice.fullscreen()) {
+      sty.transform = ``;
+      sty.width = `100%`;
+      setMode();
+    } else if (inf?.pos && (!inf.drawer || inf.drawer === SlideState.SHOWN)) {
       sty.transform = `translate(${inf.pos.x}px, ${inf.pos.y}px)`;
       sty.width = `${inf.pos.width}px`;
       setMode();
@@ -115,6 +119,10 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
       sty.transform = `translate(${innerWidth + 50}px, ${y}px)`;
       setMode();
     } else if (!mode()) setFloat("tr");
+  });
+
+  const channel = createMemo(() => {
+    const inf = info();
 
     resetEvents();
     return inf?.channel;
@@ -131,17 +139,54 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
 
   onCleanup(resetEvents);
 
+  onMount(() => {
+    document
+      .getElementById("floating")
+      ?.addEventListener("fullscreenchange", () => {
+        if (!document.fullscreenElement) {
+          voice.toggleFullscreen(false);
+        }
+      });
+  });
+
+  createEffect(() => {
+    if (voice.fullscreen() && inCall()) {
+      if (
+        !document
+          .getElementById("floating")
+          ?.isSameNode(document.fullscreenElement)
+      ) {
+        if (document.fullscreenElement) {
+          document.exitFullscreen();
+        }
+        document.getElementById("floating")?.requestFullscreen();
+      }
+    } else if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+  });
+
   return (
     <callCardContext.Provider value={setInfo}>
       {props.children}
-      <Portal ref={document.getElementById("floating")! as HTMLDivElement}>
-        <Float ref={ref} mode={mode()} onPointerDown={mouseDown}>
+      <Portal mount={document.getElementById("floating")! as HTMLDivElement}>
+        <Float
+          ref={ref}
+          mode={mode()}
+          onPointerDown={mouseDown}
+          fullscreen={voice.fullscreen()}
+        >
           <Switch>
             <Match when={mode()}>
               <VoiceCallCardPiP />
             </Match>
             <Match when={channel()}>
-              <VoiceCallCard channel={channel()!} />
+              <VoiceCallCard
+                channel={channel()!}
+                inCall={inCall()}
+                showCard={voice.showCard(channel()!)}
+                fullscreen={voice.fullscreen()}
+              />
             </Match>
           </Switch>
         </Float>
@@ -166,6 +211,15 @@ const Float = styled("div", {
         cursor: "grabbing",
         transition: "none",
       },
+    },
+    fullscreen: {
+      true: {
+        zIndex: 100,
+        height: "100vh",
+        top: 0,
+        // Width is set by floating logic in effect above
+      },
+      false: {},
     },
   },
   compoundVariants: [
@@ -219,39 +273,18 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
 /**
  * Call card
  */
-function VoiceCallCard(props: { channel: Channel }) {
-  const voice = useVoice();
-  const inCall = () => !!voice.channel();
-
-  let viewRef: HTMLDivElement | undefined;
-
-  onMount(() => {
-    viewRef?.addEventListener("fullscreenchange", () => {
-      if (!document.fullscreenElement) {
-        voice.toggleFullscreen(false);
-      }
-    });
-  });
-
-  createEffect(() => {
-    if (voice.fullscreen() && inCall()) {
-      if (!viewRef?.isSameNode(document.fullscreenElement)) {
-        if (document.fullscreenElement) {
-          document.exitFullscreen();
-        }
-        viewRef?.requestFullscreen();
-      }
-    } else if (document.fullscreenElement) {
-      document.exitFullscreen();
-    }
-  });
-
+function VoiceCallCard(props: {
+  channel: Channel;
+  inCall: boolean;
+  showCard: boolean;
+  fullscreen: boolean;
+}) {
   return (
-    <Show when={voice.showCard(props.channel)}>
-      <Base>
-        <Card ref={viewRef} active={inCall()}>
+    <Show when={props.showCard}>
+      <Base fullscreen={props.fullscreen}>
+        <Card active={props.inCall} fullscreen={props.fullscreen}>
           <Show
-            when={inCall()}
+            when={props.inCall}
             fallback={<VoiceCallCardPreview channel={props.channel} />}
           >
             <VoiceCallCardActiveRoom />
@@ -278,6 +311,15 @@ const Base = styled("div", {
     alignItems: "center",
     flexDirection: "column",
   },
+  variants: {
+    fullscreen: {
+      true: {
+        top: 0,
+        height: "100%",
+        padding: 0,
+      },
+    },
+  },
 });
 
 const Card = styled("div", {
@@ -295,7 +337,6 @@ const Card = styled("div", {
     active: {
       true: {
         width: "100%",
-        height: "40vh",
       },
       false: {
         width: "360px",
@@ -303,8 +344,25 @@ const Card = styled("div", {
         cursor: "pointer",
       },
     },
+    fullscreen: {
+      true: {
+        height: "100%",
+        borderRadius: 0,
+      },
+      false: {},
+    },
   },
+  compoundVariants: [
+    {
+      active: [true],
+      fullscreen: [false],
+      css: {
+        height: "40vh",
+      },
+    },
+  ],
   defaultVariants: {
     active: false,
+    fullscreen: false,
   },
 });


### PR DESCRIPTION
Refactored fullscreen logic in the voice call component to allow context menus to appear when in fullscreen.

Fixed a bug that made the voice pip not show up in the floating container.

Fixes #1136

No significant UI changes

## How was this PR tested?

Entered and exited calls, changed channels a bunch and did the same on mobile.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/c072b3c6-2786-4399-abc6-b221b6bcc9bf" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1398 :point\_left:
