### PR TITLE
fix: IOS context menus work now

### DIFF
--- a/packages/client/components/app/menus/ContextMenu.tsx
+++ b/packages/client/components/app/menus/ContextMenu.tsx
@@ -37,7 +37,7 @@ export function ContextMenu(props: ComponentProps<typeof Base>) {
   return (
     <Base
       // prevent context menu closing itself before click event
-      onMouseDown={(e) => e.stopImmediatePropagation()}
+      onpointerdown={(e) => e.stopImmediatePropagation()}
       {...props}
     />
   );
@@ -184,7 +184,7 @@ export function ContextMenuSubMenu(
         ref={setAnchor}
         selected={isShowing()}
         actionIcon={MdChevronRight}
-        onMouseDown={(e) => {
+        onpointerdown={(e) => {
           e.stopImmediatePropagation();
         }}
         onClick={(e) => {
@@ -219,7 +219,7 @@ export function ContextMenuSubMenu(
                 setShow((show) => (show === true ? false : show))
               }
               // stop submenu from closing context menu
-              onMouseDown={(e) => e.stopImmediatePropagation()}
+              onpointerdown={(e) => e.stopImmediatePropagation()}
             >
               <div
                 onClick={(e) => {

--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -303,7 +303,7 @@ export function UserContextMenu(props: {
       {/* Voice controls */}
       <Show when={props.inVoice && !props.user.self && !props.isScreenshare}>
         <ContextMenuButton
-          onMouseDown={(e) => e.stopImmediatePropagation()}
+          onpointerdown={(e) => e.stopImmediatePropagation()}
           onClick={(e) => e.stopImmediatePropagation()}
         >
           <Text class="label">
@@ -341,7 +341,7 @@ export function UserContextMenu(props: {
       </Show>
       <Show when={props.isScreenshare && !props.user.self}>
         <ContextMenuButton
-          onMouseDown={(e) => e.stopImmediatePropagation()}
+          onpointerdown={(e) => e.stopImmediatePropagation()}
           onClick={(e) => e.stopImmediatePropagation()}
         >
           <Text class="label">

--- a/packages/client/components/common/Device.tsx
+++ b/packages/client/components/common/Device.tsx
@@ -41,12 +41,27 @@ export class Device {
     //Other
     window.matchMedia("(display-mode: standalone)").matches;
 
+  /**
+   * Whether this device is an IOS Touch device. Relies on useragent.
+   *
+   * **Warning:** Don't use unless absolutely necessary.
+   * Granular feature-detection is preferred when possible.
+   */
+  readonly isIOSTouch = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+
   private pMedia;
   private tMedia;
   private setLayout;
 
   constructor() {
     this.isMobile = isMobileBrowser();
+
+    if (this.isIOSTouch) {
+      // Load a long press event library to replace context menus on IOS touch
+      //@ts-expect-error There are no types for this library.
+      import("long-press-event");
+      document.getElementsByTagName("body")[0].dataset.longPressDelay = "1000";
+    }
 
     const [lo, setLo] = createSignal<Layout>("desktop");
     this.layout = lo;

--- a/packages/client/components/ui/components/floating/FloatingManager.tsx
+++ b/packages/client/components/ui/components/floating/FloatingManager.tsx
@@ -33,13 +33,19 @@ export function FloatingManager() {
   /**
    * Keep track of last mouse position at all times
    */
-  function onMouseMove({ clientX, clientY }: MouseEvent) {
+  function onMouseMove({ clientX, clientY }: PointerEvent) {
     mouseX = clientX;
     mouseY = clientY;
   }
 
-  onMount(() => document.addEventListener("mousemove", onMouseMove));
-  onCleanup(() => document.addEventListener("mousemove", onMouseMove));
+  onMount(() => {
+    document.addEventListener("pointermove", onMouseMove);
+    document.addEventListener("pointerdown", onMouseMove);
+  });
+  onCleanup(() => {
+    document.removeEventListener("pointermove", onMouseMove);
+    document.removeEventListener("pointerdown", onMouseMove);
+  });
 
   /**
    * Whether a floating element is visible
@@ -143,8 +149,8 @@ function Floating(props: FloatingElement & { mouseX: number; mouseY: number }) {
   }
 
   if (props.config().contextMenu || props.config().userCard) {
-    onMount(() => document.addEventListener("mousedown", onMouseDown));
-    onCleanup(() => document.removeEventListener("mousedown", onMouseDown));
+    onMount(() => document.addEventListener("pointerdown", onMouseDown));
+    onCleanup(() => document.removeEventListener("pointerdown", onMouseDown));
   }
 
   /**

--- a/packages/client/components/ui/components/floating/index.ts
+++ b/packages/client/components/ui/components/floating/index.ts
@@ -3,8 +3,8 @@ export { Tooltip } from "./Tooltip";
 export { UserCard } from "./UserCard";
 
 /**
- * Trigger a global mousedown running the floating close logic
+ * Trigger a global pointerdown running the floating close logic
  */
 export function dismissFloatingElements() {
-  document.dispatchEvent(new Event("mousedown"));
+  document.dispatchEvent(new Event("pointerdown"));
 }

--- a/packages/client/components/ui/directives/floating.ts
+++ b/packages/client/components/ui/directives/floating.ts
@@ -1,3 +1,4 @@
+import { useDevice } from "@revolt/common";
 import {
   type Accessor,
   type JSX,
@@ -48,6 +49,8 @@ export function unregisterFloatingElement(element: HTMLElement) {
 export function floating(element: HTMLElement, accessor: Accessor<Props>) {
   const config = accessor();
   if (!config) return;
+
+  const { isIOSTouch } = useDevice();
 
   const [show, setShow] = createSignal<Props | undefined>();
   // DEBUG: createEffect(() => console.info("show:", show()));
@@ -117,7 +120,7 @@ export function floating(element: HTMLElement, accessor: Accessor<Props>) {
   /**
    * Handle context menu click
    */
-  function onContextMenu(event: MouseEvent) {
+  function onContextMenu(event: Event) {
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
@@ -197,14 +200,23 @@ export function floating(element: HTMLElement, accessor: Accessor<Props>) {
       () => accessor().contextMenu,
       (contextMenu) => {
         if (contextMenu) {
-          element.addEventListener(
-            accessor().contextMenuHandler ?? "contextmenu",
-            onContextMenu,
-          );
-
-          // TODO: iOS events for touch
+          if (
+            (accessor().contextMenuHandler ?? "contextmenu") ===
+              "contextmenu" &&
+            isIOSTouch
+          ) {
+            element.addEventListener("long-press", onContextMenu);
+          } else {
+            element.addEventListener(
+              accessor().contextMenuHandler ?? "contextmenu",
+              onContextMenu,
+            );
+          }
 
           onCleanup(() => {
+            if (isIOSTouch) {
+              element.removeEventListener("long-press", onContextMenu);
+            }
             element.removeEventListener(
               config.contextMenuHandler ?? "contextmenu",
               onContextMenu,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -107,6 +107,7 @@
     "localforage": "^1.10.0",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.isequal": "^4.5.0",
+    "long-press-event": "^2.5.2",
     "lowlight": "^3.3.0",
     "material-symbols": "^0.36.0",
     "mdast": "^3.0.0",

--- a/packages/client/src/interface/navigation/servers/UserMenu.tsx
+++ b/packages/client/src/interface/navigation/servers/UserMenu.tsx
@@ -81,8 +81,8 @@ export function UserMenu(props: Props) {
     close();
   }
 
-  onMount(() => document.addEventListener("mousedown", onMouseDown));
-  onCleanup(() => document.removeEventListener("mousedown", onMouseDown));
+  onMount(() => document.addEventListener("pointerdown", onMouseDown));
+  onCleanup(() => document.removeEventListener("pointerdown", onMouseDown));
 
   createEffect(
     on(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
+      long-press-event:
+        specifier: ^2.5.2
+        version: 2.5.2
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
@@ -5539,6 +5542,9 @@ packages:
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
+
+  long-press-event@2.5.2:
+    resolution: {integrity: sha512-FV1xg5lbE5nFF+wCOAIhheVQQJZq9kC6Uh+kX7/W8m1lGpivKJLEaTahBb8oCmkWz8uZnqUoxSwG+9eksbP82Q==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -13123,6 +13129,8 @@ snapshots:
   loglevel@1.9.1: {}
 
   loglevel@1.9.2: {}
+
+  long-press-event@2.5.2: {}
 
   longest-streak@3.1.0: {}
 


### PR DESCRIPTION
IOS Touch doesn't support context menus. This PR replaces them with a long-press interaction if the user agent is detected to be an apple touch device (iphone, ipad, or ipod).

This PR also fixes a bug where multiple context menus can be opened on mobile.

This PR adds the following dependency:
https://github.com/john-doherty/long-press-event

No significant UI changes.

## How was this PR tested?

Tested using UA overwriting in a chromium browser. Jury is still out whether it *actually* works on an IOS touch device.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1400 :point\_left:
