### PR TITLE
fix: Don't error out if one of your livekit nodes is down

### DIFF
--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -232,7 +232,7 @@ class Voice {
     });
 
     // Gather latency
-    const selected = await Promise.race(
+    const selected = await Promise.any(
       this.getClient().configuration!.features.livekit.nodes.map(
         async (node) => {
           return fetch(node.public_url.replace("wss", "https")).then(() => {


### PR DESCRIPTION
In the region select code, it fails to select a region if the first response is an error.

- `main` <!-- branch-stack -->
  - \#1403 :point\_left:
