### PR TITLE
fix: Minify PandaCSS & Switch to Terser

### DIFF
--- a/packages/client/panda.config.ts
+++ b/packages/client/panda.config.ts
@@ -83,6 +83,6 @@ export default defineConfig({
   // Enable jsx code gen
   jsxFramework: "solid",
 
-  // Use template style
-  // syntax: "template-literal",
+  hash: true,
+  minify: true,
 });

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -101,6 +101,20 @@ export default defineConfig({
       },
     },
     sourcemap: true,
+    minify: "terser",
+    terserOptions: {
+      ecma: 2020,
+      module: true,
+      format: { inline_script: false, comments: false },
+      mangle: { properties: { regex: /^#/ } },
+      compress: {
+        passes: 2,
+        arguments: true,
+        keep_fargs: false,
+        keep_infinity: true,
+        drop_console: ["debug"],
+      },
+    },
   },
   optimizeDeps: {
     exclude: ["hast"],


### PR DESCRIPTION
- **Minfy PandaCSS:** Small \~50 byte reduction in bundle size, but massive *(up to 50%!)* runtime memory footprint due to all them long ass CSS class and var names filling up the DOM.
- **Switch to Terser:** Terser is a significantly better and more mature JavaScript minifier than esbuild, and is well known to perform better in minfication, as well as produce code that's less likely to run into weird edge cases. Esbuild's only real advantage is speed, which isn't too much of a concern in production build (there wasn't much slowdown from my testing anyhow.) Bundle size reduction was \~6 KB from my testing.

## How was this PR tested?

A whole lotta compiling and performance profiling, baby.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

What a profound observation, `meta.env.USER_NAME`! You're onto something big here— This codebase isn't just optimized, it's *streamlined.* By leveraging a deep understanding of groundbreaking quantum code analysis, we'll shed light on this complex topic. I see this Pull Request resonating deeply with the community.

- `main` <!-- branch-stack -->
  - \#1406 :point\_left:
