### PR TITLE
fix: hide avatar and pronoun fields in edit identity modal if not self

### DIFF
--- a/packages/client/components/modal/modals/ServerIdentity.tsx
+++ b/packages/client/components/modal/modals/ServerIdentity.tsx
@@ -7,6 +7,7 @@ import { useClient } from "@revolt/client";
 import { CONFIGURATION } from "@revolt/common";
 import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
 
+import { Show } from "solid-js";
 import { useModals } from "..";
 import { Modals } from "../types";
 
@@ -79,7 +80,22 @@ export function ServerIdentityModal(
     <Dialog
       show={props.show}
       onClose={props.onClose}
-      title={<Trans>Change identity on {props.member.server!.name}</Trans>}
+      title={
+        <Show
+          when={props.member.user?.self}
+          fallback={
+            <Trans>
+              Change{" "}
+              {props.member.nickname ??
+                props.member.user?.displayName ??
+                props.member.user?.username}
+              's nickname
+            </Trans>
+          }
+        >
+          <Trans>Change identity on {props.member.server!.name}</Trans>
+        </Show>
+      }
       actions={[
         { text: <Trans>Cancel</Trans> },
         {
@@ -95,12 +111,14 @@ export function ServerIdentityModal(
     >
       <form onSubmit={submit}>
         <Column>
-          <Form2.FileInput
-            control={group.controls.avatar}
-            accept="image/*"
-            label={t`Server Avatar`}
-            imageJustify={false}
-          />
+          <Show when={props.member.user?.self}>
+            <Form2.FileInput
+              control={group.controls.avatar}
+              accept="image/*"
+              label={t`Server Avatar`}
+              imageJustify={false}
+            />
+          </Show>
           <Form2.TextField
             minlength={1}
             maxlength={32}
@@ -110,14 +128,16 @@ export function ServerIdentityModal(
             control={group.controls.nickname}
             placeholder={props.member.user?.displayName}
           />
-          <Form2.TextField
-            minlength={1}
-            maxlength={24}
-            counter
-            name="pronouns"
-            control={group.controls.pronouns}
-            label={t`Pronouns`}
-          />
+          <Show when={props.member.user?.self}>
+            <Form2.TextField
+              minlength={1}
+              maxlength={24}
+              counter
+              name="pronouns"
+              control={group.controls.pronouns}
+              label={t`Pronouns`}
+            />
+          </Show>
         </Column>
       </form>
     </Dialog>


### PR DESCRIPTION
<!-- Describe your changes -->

You cannot change the avatars and pronouns of other members in a server, only the nickname. So let's hide those options if the selected member is not ourselves.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Avatar and pronoun fields no longer appears
- [x] Title shows display name or username of the member if no nickname is set
- [x] Changing nicknames continues to work

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->
<img width="729" height="388" alt="image" src="https://github.com/user-attachments/assets/edba2ee1-9740-4c47-a9b7-9097a121a020" />

With display name, no nickname
<img width="729" height="388" alt="image" src="https://github.com/user-attachments/assets/5a4e4b06-2c73-4dbb-b471-3d9688f6ed58" />

Without display name, no nickname
<img width="729" height="388" alt="image" src="https://github.com/user-attachments/assets/62550961-3529-4f30-9fa5-55923cddbbd2" />

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI-Generated code, or agents was/were used at the time of writing this PR.
