### PR TITLE
fix: ability to send DM's to bots

### DIFF
--- a/packages/client/components/app/menus/UserContextMenu.tsx
+++ b/packages/client/components/app/menus/UserContextMenu.tsx
@@ -387,7 +387,7 @@ export function UserContextMenu(props: {
           <Trans>Profile</Trans>
         </ContextMenuButton>
       </Show>
-      <Show when={props.user.relationship === "Friend"}>
+      <Show when={props.user.relationship === "Friend" || props.user.bot}>
         <ContextMenuButton icon={MdChat} onClick={openDm}>
           <Trans>Message</Trans>
         </ContextMenuButton>


### PR DESCRIPTION
<!-- Describe your changes -->

Backend allows the ability to exchange DMs with bots, the UI assumes we can't
Fixes # (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Opened a DM with a bot user

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

Before <img width="265" height="530" alt="resim" src="https://github.com/user-attachments/assets/0748bb2c-fc5c-4d72-b37d-bcc9f587a57b" />
After <img width="257" height="448" alt="resim" src="https://github.com/user-attachments/assets/a6ff9f9b-b038-4db6-b8c5-1052bd52bccb" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None used

- `main` <!-- branch-stack -->
  - \#1409 :point\_left:
