### PR TITLE
fix: wrong text colour on the emoji info thingy

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -360,7 +360,6 @@ const EmojiPreviewBar = styled("div", {
     alignItems: "center",
     justifyContent: "space-between",
     padding: "var(--gap-xs) var(--gap-md)",
-    borderTop: "1px solid var(--colour-component-bg-3, rgba(255,255,255,0.06))",
     minHeight: "36px",
     flexShrink: 0,
     gap: "var(--gap-sm)",
@@ -406,11 +405,11 @@ const PreviewFrom = styled("span", {
   base: {
     display: "block",
     fontSize: "0.75rem",
-    color: "var(--colour-foreground-muted, rgba(255,255,255,0.4))",
+    color: "var(--colour-foreground-muted)",
     marginTop: "1px",
 
     "& strong": {
-      color: "var(--colour-foreground-secondary, rgba(255,255,255,0.65))",
+      color: "var(--colour-foreground-secondary)",
       fontWeight: 500,
     },
   },


### PR DESCRIPTION
<!-- Describe your changes -->

im killing ispik for this /joke

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] it's readable on both modes
- [x] Test B

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

### Before

<img width="597" height="583" alt="image" src="https://github.com/user-attachments/assets/97a71600-3105-46c5-aff3-61a093cf5771" />


### After

<img width="600" height="594" alt="image" src="https://github.com/user-attachments/assets/469cc953-0d39-4b9f-91aa-9e754417f50e" />


</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

why would i use ai for a two liner, im not that lazy
