### PR TITLE
fix: Sometimes I18n provider would load before activate

### DIFF
--- a/packages/client/components/i18n/index.tsx
+++ b/packages/client/components/i18n/index.tsx
@@ -7,10 +7,7 @@ import { type LocaleOptions, Language, Languages } from "./Languages";
 import { messages as en } from "./catalogs/en/messages";
 import { initTime, loadTimeLocale } from "./dayjs";
 
-/**
- * Initialise i18n engine
- */
-export function initI18n() {
+export function I18nProvider(props: { children: JSX.Element }) {
   i18n.load({
     en,
   });
@@ -18,10 +15,6 @@ export function initI18n() {
   i18n.activate("en");
 
   initTime();
-}
-
-export function I18nProvider(props: { children: JSX.Element }) {
-  initI18n();
 
   return <LinguiProvider i18n={i18n}>{props.children}</LinguiProvider>;
 }

--- a/packages/client/components/i18n/index.tsx
+++ b/packages/client/components/i18n/index.tsx
@@ -7,7 +7,22 @@ import { type LocaleOptions, Language, Languages } from "./Languages";
 import { messages as en } from "./catalogs/en/messages";
 import { initTime, loadTimeLocale } from "./dayjs";
 
+/**
+ * Initialise i18n engine
+ */
+export function initI18n() {
+  i18n.load({
+    en,
+  });
+
+  i18n.activate("en");
+
+  initTime();
+}
+
 export function I18nProvider(props: { children: JSX.Element }) {
+  initI18n();
+
   return <LinguiProvider i18n={i18n}>{props.children}</LinguiProvider>;
 }
 
@@ -58,18 +73,3 @@ export function browserPreferredLanguage() {
     Language.ENGLISH
   );
 }
-
-/**
- * Initialise i18n engine
- */
-export function initI18n() {
-  i18n.load({
-    en,
-  });
-
-  i18n.activate("en");
-
-  initTime();
-}
-
-initI18n();


### PR DESCRIPTION
I don't know what's causing it, but sometimes the indexdb fails to load and that combined with a race condition in I18N loading caused a permanent empty screen. This PR makes absolute sure that activate is called before the I18N provider renders.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1413 :point\_left:
