### PR TITLE
fix: Enable MFA modal is now cancelable

### DIFF
--- a/packages/client/components/app/interface/settings/user/Account.tsx
+++ b/packages/client/components/app/interface/settings/user/Account.tsx
@@ -1,6 +1,6 @@
 import { Match, Show, Switch, createMemo, createSignal } from "solid-js";
 
-import { Trans } from "@lingui-solid/solid/macro";
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
 
 import { useClient, useClientLifecycle } from "@revolt/client";
 import {
@@ -8,7 +8,7 @@ import {
   createOwnProfileResource,
 } from "@revolt/client/resources";
 import { useModals } from "@revolt/modal";
-import { CategoryButton, Column, Row, iconSize } from "@revolt/ui";
+import { CategoryButton, Column, Row, iconSize, useSnackbar } from "@revolt/ui";
 
 import MdAlternateEmail from "@material-design-icons/svg/outlined/alternate_email.svg?component-solid";
 import MdBlock from "@material-design-icons/svg/outlined/block.svg?component-solid";
@@ -118,6 +118,8 @@ function EditAccount() {
 function MultiFactorAuth() {
   const client = useClient();
   const mfa = createMfaResource();
+  const snackbar = useSnackbar();
+  const { t } = useLingui();
   const { openModal, mfaFlow, mfaEnableTOTP, showError } = useModals();
 
   /**
@@ -155,6 +157,10 @@ function MultiFactorAuth() {
    */
   async function setupAuthenticatorApp() {
     const ticket = await mfaFlow(mfa.data!);
+    if (!ticket) {
+      snackbar.show({ message: t`MFA setup canceled.` });
+      return;
+    }
     const secret = await ticket!.generateAuthenticatorSecret();
 
     let success;
@@ -167,6 +173,11 @@ function MultiFactorAuth() {
           success = true;
         }
       } catch (err) {
+        // If the modal was closed (ie. promise was rejected) quit the loop
+        if (err === "MFACancelled") {
+          snackbar.show({ message: t`MFA setup canceled.` });
+          return;
+        }
         showError(err);
       }
     }

--- a/packages/client/components/modal/index.tsx
+++ b/packages/client/components/modal/index.tsx
@@ -165,12 +165,13 @@ export class ModalControllerExtended extends ModalController {
    * @param client Client
    */
   mfaEnableTOTP(secret: string, identifier: string) {
-    return new Promise((callback: (value?: string) => void) =>
+    return new Promise((resolve: (value?: string) => void, reject) =>
       this.openModal({
         type: "mfa_enable_totp",
         identifier,
         secret,
-        callback,
+        callback: resolve,
+        reject,
       }),
     );
   }

--- a/packages/client/components/modal/modals/MFAEnableTOTP.tsx
+++ b/packages/client/components/modal/modals/MFAEnableTOTP.tsx
@@ -75,7 +75,7 @@ export function MFAEnableTOTPModal(
         {
           text: <Trans>Cancel</Trans>,
           onClick() {
-            props.callback();
+            props.reject?.("MFACancelled");
           },
         },
         {

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -186,6 +186,7 @@ export type Modals =
       identifier: string;
       secret: string;
       callback: (code?: string) => void;
+      reject?: (reason?: string) => void;
     }
   | ({
       type: "mfa_flow";


### PR DESCRIPTION
Fixes the MFA enable modal to actually be cancelable now. Adds a snack bar that says "MFA setup canceled." when you click cancel.

## How was this PR tested?

Clicked some buttons and closed some modals. Also ensured regular flow still worked.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1417 :point\_left:
