### PR TITLE
fix: Make messages non-selectable on ios to enable context menus

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -190,6 +190,13 @@ const base = cva({
       },
       hide: {},
     },
+    iOSTouch: {
+      true: {
+        "-webkit-touch-callout": "none",
+        "-webkit-user-select": "none",
+        "user-select": "none",
+      },
+    },
   },
   defaultVariants: {
     isLink: false,
@@ -321,7 +328,7 @@ const CompactInfo = styled(Row, {
 export function MessageContainer(props: Props) {
   const { t } = useLingui();
   const { message } = useMessage();
-  const { isMobile } = useDevice();
+  const { isMobile, isIOSTouch } = useDevice();
 
   return (
     <div
@@ -337,6 +344,7 @@ export function MessageContainer(props: Props) {
           highlight: props.highlight,
           sendStatus: props.sendStatus,
           isLink: props.isLink,
+          iOSTouch: isIOSTouch,
         })
       }
       use:floating={{ contextMenu: props.contextMenu }}


### PR DESCRIPTION
Try again to fix context menus on ios touch devices. You can no longer select the text in messages on ios touch devices.

## How was this PR tested?

It wasn't because I don't have an ios touch device and you can't make me get one

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1418 :point\_left:
