### PR TITLE
fix: Make the mute icon not red when streaming your own stream

### DIFF
--- a/packages/client/components/ui/components/features/voice/callCard/ParticipantTile.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/ParticipantTile.tsx
@@ -60,7 +60,7 @@ export function ParticipantTile(props: TileProps) {
   });
 
   const isScreenShareAudioUserMuted = () =>
-    state.voice.getScreenShareMuted(user().user!.id)
+    !user().user!.self && state.voice.getScreenShareMuted(user().user!.id)
       ? "by-user"
       : isScreenShareAudioMuted() || false;
 


### PR DESCRIPTION
Many users are confused when their own stream shows up as muted. This PR changes the behavior to never show your own stream as user-muted (red)

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Sharing a stream with audio: <img width="811" height="466" alt="image" src="https://github.com/user-attachments/assets/80ecb4b2-4282-46ad-87ca-83ddd4bde231" />

Sharing a stream without audio: <img width="811" height="466" alt="image" src="https://github.com/user-attachments/assets/494e3015-9e7d-4a7c-b4ca-79440a6438fd" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1420 :point\_left:
