### PR TITLE
fix: Pip will no longer error when exiting call

### DIFF
--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -5,7 +5,6 @@ import {
   Switch,
   createContext,
   createEffect,
-  createMemo,
   createSignal,
   onCleanup,
   onMount,
@@ -104,6 +103,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     const inf = info();
     if (!ref) return;
     const sty = ref.style;
+    resetEvents();
 
     //Set mode based on state
     if (voice.fullscreen()) {
@@ -114,19 +114,14 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
       sty.transform = `translate(${inf.pos.x}px, ${inf.pos.y}px)`;
       sty.width = `${inf.pos.width}px`;
       setMode();
-    } else if (!voice.channel()) {
+    } else if (!inCall()) {
       const y = inf?.pos.y ?? ref.getBoundingClientRect().y;
       sty.transform = `translate(${innerWidth + 50}px, ${y}px)`;
       setMode();
     } else if (!mode()) setFloat("tr");
   });
 
-  const channel = createMemo(() => {
-    const inf = info();
-
-    resetEvents();
-    return inf?.channel;
-  });
+  const channel = () => info()?.channel;
 
   function setFloat(float: FloatType) {
     const sty = ref!.style,
@@ -177,7 +172,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
           fullscreen={voice.fullscreen()}
         >
           <Switch>
-            <Match when={mode()}>
+            <Match when={mode() && inCall()}>
               <VoiceCallCardPiP />
             </Match>
             <Match when={channel()}>


### PR DESCRIPTION
Fixes a regression from the voice call refactor from a few days ago where pressing the exit call button on the pip would break the app

No UI changes.

## How was this PR tested?

Exited some calls with the pip up

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1421 :point\_left:
