### PR TITLE
fix: Add image type filter to image inputs, export type from draft

### DIFF
--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -33,6 +33,8 @@ export { SyncWorker } from "./SyncWorker";
 
 export type { Sounds, TypeSounds } from "./stores/Sounds";
 
+export { ALLOWED_IMAGE_TYPES } from "./stores/Draft";
+
 /**
  * Introduce some delay before writing state to disk
  */

--- a/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
@@ -4,7 +4,7 @@ import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { CONFIGURATION } from "@revolt/common";
-import { ALLOWED_IMAGE_TYPES } from "@revolt/state/stores/Draft";
+import { ALLOWED_IMAGE_TYPES } from "@revolt/state";
 import { Ripple, typography } from "@revolt/ui/components/design";
 import { OverflowingText, iconSize } from "@revolt/ui/components/utils";
 

--- a/packages/client/components/ui/components/utils/files/FileInput.tsx
+++ b/packages/client/components/ui/components/utils/files/FileInput.tsx
@@ -3,10 +3,11 @@ import { Match, Show, Switch, splitProps } from "solid-js";
 import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
-import MdClose from "@material-design-icons/svg/filled/close.svg?component-solid";
+import { ALLOWED_IMAGE_TYPES } from "@revolt/state";
 
 import { Button, Ripple } from "../../design";
 import { Row } from "../../layout";
+import { Symbol } from "../Symbol";
 
 interface Props {
   /**
@@ -48,7 +49,12 @@ interface Props {
  * Form element for collecting files
  */
 export function FileInput(props: Props) {
-  const [local, remote] = splitProps(props, ["file", "onFiles", "multiple"]);
+  const [local, remote] = splitProps(props, [
+    "file",
+    "onFiles",
+    "multiple",
+    "accept",
+  ]);
   let inputRef: HTMLInputElement | undefined;
 
   /**
@@ -103,7 +109,7 @@ export function FileInput(props: Props) {
         </>
       }
     >
-      <Match when={props.accept === "image/*"}>
+      <Match when={local.accept === "image/*"}>
         <input
           type="file"
           ref={inputRef}
@@ -111,6 +117,7 @@ export function FileInput(props: Props) {
             display: "none",
           })}
           onChange={onChange}
+          accept={ALLOWED_IMAGE_TYPES.join(",")}
           {...remote}
         />
         <Row align justify={props.imageJustify ?? true} gap="lg">
@@ -133,7 +140,7 @@ export function FileInput(props: Props) {
               onPress={onClear}
               isDisabled={!props.file}
             >
-              <MdClose />
+              <Symbol>close</Symbol>
             </Button>
           </Show>
         </Row>

--- a/packages/client/components/ui/components/utils/files/FileInput.tsx
+++ b/packages/client/components/ui/components/utils/files/FileInput.tsx
@@ -61,12 +61,24 @@ export function FileInput(props: Props) {
    * Handle file selection
    */
   function onChange(e: Event & { currentTarget: HTMLInputElement }) {
-    console.info(e.currentTarget);
     if (e.currentTarget.files) {
       // NB. need to help out with the reactivity by
       //     first removing the array, and then setting
       //     the new one; otherwise no update! ¯\_(ツ)_/¯
       local.onFiles(null);
+
+      // If accept is an image, check all the files submitted if they match our accept values
+      if (local.accept === "image/*") {
+        for (const file of e.currentTarget.files) {
+          if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+            // If they were stubborn enough to disable our filter for files then just ignore the file.
+            // No need for feedback, they know what they did.
+            local.onFiles(null);
+            e.currentTarget.files = null;
+            return;
+          }
+        }
+      }
       local.onFiles([...e.currentTarget.files]);
     }
   }


### PR DESCRIPTION
Add mime type filter to the file input when accepting images.

Also exports the allowed file types from the draft correctly.

Supersedes #868

Fixes #806
Fixes #859

No UI Changes

## How was this PR tested?

Clicked upload image before and after and observed that only the expected image types were available (unless the user selected otherwise)

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1422 :point\_left:
