### PR TITLE
fix: Add file size validation and emoji name validation

### DIFF
--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -83,8 +83,8 @@ export function EmojiList(props: { server: Server }) {
                 accept="image/*"
                 imageJustify={false}
                 allowRemoval={false}
-                // TODO: Replace this with config param
-                maxSize={500 * 1024}
+                // TODO: Replace this with limit
+                maxSize={500_000}
                 hideErrors={true}
               />
             </Column>

--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -83,6 +83,9 @@ export function EmojiList(props: { server: Server }) {
                 accept="image/*"
                 imageJustify={false}
                 allowRemoval={false}
+                // TODO: Replace this with config param
+                maxSize={500 * 1024}
+                hideErrors={true}
               />
             </Column>
             <Column grow>
@@ -93,6 +96,10 @@ export function EmojiList(props: { server: Server }) {
                 name="name"
                 control={editGroup.controls.name}
                 label={t`Emoji Name`}
+                pattern="[a-z0-9_]{1,32}"
+                helper={t`Lowercase letters, numbers and underscores only.`}
+                helper-on-focus={true}
+                autocomplete="off"
               />
 
               <Row align>

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -26,7 +26,7 @@ import {
 import { TextEditor2 } from "../features/texteditor/TextEditor2";
 import { Row } from "../layout";
 
-import { FileInput } from "./files";
+import { FileInput, humanFileSize } from "./files";
 
 /**
  * Form wrapper for TextField
@@ -178,9 +178,10 @@ const FormFileInput = (
             local.maxSize &&
             files[0].size > local.maxSize
           ) {
-            const maxKB = Math.round(local.maxSize / 1024);
             local.control.setErrors({
-              error: new Error(t`File must be smaller than ${maxKB}KiB`),
+              error: new Error(
+                t`File must be smaller than ${humanFileSize(local.maxSize)}`,
+              ),
             });
             local.control.markTouched(true);
             return;

--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -10,7 +10,7 @@ import {
   splitProps,
 } from "solid-js";
 
-import { Trans } from "@lingui-solid/solid/macro";
+import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { VirtualContainer } from "@minht11/solid-virtual-container";
 import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
@@ -44,18 +44,18 @@ const FormTextField = (
         {...remote}
         value={local.control.value}
         oninput={(e) => {
+          if (!e.currentTarget.checkValidity()) {
+            // Rely on the dom and mdui to handle errors with text fields
+            local.control.setErrors({ invalid: true });
+          } else {
+            local.control.setErrors(null);
+          }
           local.control.setValue(e.currentTarget.value);
           local.control.markDirty(true);
         }}
         required={local.control.isRequired}
         disabled={local.control.isDisabled}
       />
-
-      <Show when={local.control.isTouched && !local.control.isValid}>
-        <For each={Object.keys(local.control.errors!)}>
-          {(errorMsg: string) => <small>{errorMsg}</small>}
-        </For>
-      </Show>
     </>
   );
 };
@@ -147,12 +147,21 @@ const FormFileInput = (
   props: {
     label?: string;
     control: IFormControl<File[] | string | null>;
+    maxSize?: number;
+    hideErrors?: boolean;
   } & Pick<
     ComponentProps<typeof FileInput>,
     "accept" | "imageAspect" | "imageRounded" | "imageJustify" | "allowRemoval"
   >,
 ) => {
-  const [local, remote] = splitProps(props, ["label", "control"]);
+  const [local, remote] = splitProps(props, [
+    "label",
+    "control",
+    "maxSize",
+    "hideErrors",
+  ]);
+
+  const { t } = useLingui();
 
   return (
     <>
@@ -163,17 +172,36 @@ const FormFileInput = (
         {...remote}
         file={local.control.value}
         onFiles={(files) => {
-          // TODO: do validation of files here
+          if (
+            files &&
+            files.length > 0 &&
+            local.maxSize &&
+            files[0].size > local.maxSize
+          ) {
+            const maxKB = Math.round(local.maxSize / 1024);
+            local.control.setErrors({
+              error: new Error(t`File must be smaller than ${maxKB}KiB`),
+            });
+            local.control.markTouched(true);
+            return;
+          }
 
+          local.control.setErrors(null);
           local.control.setValue(files);
           local.control.markDirty(true);
         }}
         required={local.control.isRequired}
         disabled={local.control.isDisabled}
       />
-      <Show when={local.control.isTouched && !local.control.isValid}>
+      <Show
+        when={
+          !local.hideErrors && local.control.isTouched && !local.control.isValid
+        }
+      >
         <For each={Object.keys(local.control.errors!)}>
-          {(errorMsg: string) => <small>{errorMsg}</small>}
+          {(errorMsg: string) => (
+            <small>{local.control.errors![errorMsg]}</small>
+          )}
         </For>
       </Show>
     </>


### PR DESCRIPTION
A heavily modified version of (supersedes) #990.

This PR adds emoji name validation and adds file size validation to the Form2 components. I rewrote #990 because I was not happy with the solution taken. This PR achieves the same thing by utilizing the built-in error handling of the text field with pattern matching. It also utilizes the built in error handling of the emoji list.

This PR also brings to light that error handling really needs to be refactored in Form2. I did not do a refactor of Form2 error handling in this PR as the emoji list has it's own error handling.

Fixes #1080

## How was this PR tested?

Tried to add a bunch of emojis that didn't meet the format.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Uploading a file that is too large: <img width="767" height="364" alt="image" src="https://github.com/user-attachments/assets/a1a373d8-1730-437a-bb30-582b76f82995" />

Helper that appears on focus: <img width="767" height="364" alt="image" src="https://github.com/user-attachments/assets/1ccd7261-2462-4cfa-b536-eee254e9ae57" />

Error when not following format: <img width="767" height="364" alt="image" src="https://github.com/user-attachments/assets/9e4b3320-77e8-4065-a240-b9e0cc0f0df0" />

A successful form, ready for submission: <img width="767" height="364" alt="image" src="https://github.com/user-attachments/assets/b3b0a562-446f-48e5-937e-b7d3d487f4a4" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1423 :point\_left:
