### PR TITLE
fix(messaging): show edited indicator in compact mode

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -11,6 +11,7 @@ import { Column, Row } from "@revolt/ui/components/layout";
 import {
   NonBreakingText,
   OverflowingText,
+  Symbol,
   Time,
 } from "@revolt/ui/components/utils";
 
@@ -377,14 +378,26 @@ export function MessageContainer(props: Props) {
                     tooltip: {
                       placement: "top",
                       content: () => (
-                        <>
-                          {t`Sent`}{" "}
-                          <Time
-                            format="datetime"
-                            value={props.timestamp}
-                            referenceTime={props._referenceTime}
-                          />
-                        </>
+                        <Column>
+                          <span>
+                            {t`Sent`}{" "}
+                            <Time
+                              format="datetime"
+                              value={props.timestamp}
+                              referenceTime={props._referenceTime}
+                            />
+                          </span>
+                          <Show when={props.edited}>
+                            <span>
+                              {t`Edited`}{" "}
+                              <Time
+                                format="datetime"
+                                value={props.edited}
+                                referenceTime={props._referenceTime}
+                              />
+                            </span>
+                          </Show>
+                        </Column>
                       ),
                       aria: "",
                     },
@@ -398,6 +411,9 @@ export function MessageContainer(props: Props) {
                 </div>
                 {props.username}
                 {props.info}
+                <Show when={props.edited}>
+                  <Symbol size={16}>edit</Symbol>
+                </Show>
               </CompactInfo>
             </Match>
             <Match when={props.tail}>


### PR DESCRIPTION
Compact mode rendered the timestamp tooltip with no edited handling, so edited messages showed no "(edited)" marker and the tooltip only listed "Sent". Mirror the tail and full-header branches: wrap the tooltip in a Column with Sent + Edited lines, and append a "(edited)" marker next to the time.

<!-- Describe your changes -->

`packages/client/components/ui/components/features/messaging/elements/Container.tsx`: in the compact branch, wrap the timestamp tooltip in a `Column` with a "Sent" line plus a `<Show when={props.edited}>` "Edited" line, and append a `<Show when={props.edited}>(edited)</Show>` marker next to the time. Mirrors the existing pattern in the tail/full-header branches.

Fixes #1337

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] `prettier` and `eslint` pass on the changed file.
- [x] `tsc --noEmit` passes on the changed file (other pre-existing errors come from unbuilt workspace deps, unrelated to this change).
- [x] Couldn't run the client end-to-end for a screenshot: local registration needs an Captcha sitekey that isn't in `.env.example`, and I don't have a Stoat account. Happy to add screenshots given a way past captcha / an invite.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None

...
