### PR TITLE
fix: HTML formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,8 @@
     "**/dist": true,
     "**/i18n": true,
     "**/styled-system": true
+  },
+  "[html]": {
+    "editor.defaultFormatter": "vscode.html-language-features"
   }
 }

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -1,25 +1,22 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, user-scalable=no, interactive-widget=resizes-content"
-    />
-    <meta name="mobile-web-app-capable" content="yes" />
-    <meta name="theme-color" content="#000000" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="./public/assets/web/icon.ico"
-    />
-    <title>Stoat</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <div id="floating"></div>
-    <script src="/src/index.tsx" type="module"></script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1, user-scalable=no, interactive-widget=resizes-content">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="theme-color" content="#000">
+  <meta http-equiv="cache-control" content="no-cache">
+  <link rel="shortcut icon" type="image/png" href="./public/assets/web/icon.ico">
+  <title>Stoat</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <div id="floating"></div>
+  <script src="/src/index.tsx" type="module"></script>
+</body>
+
 </html>


### PR DESCRIPTION
Prettier is lovely for JS/TS formatting, but at some point (maybe a dependency update?) it seems it went rogue and decided to format HTML files too. The formatting it uses is kinda wonky, and more importantly, it likes to add closing `/`'s to self-closing tags. This is part of the HTML4 spec, but deprecated/no longer recommended in the HTML5 spec, hence why most HTML formatters do not do this.

To bring the formatting closer to how it was before I've switched the default formatter from Prettier to the VSCode built in one for HTML files, and reformatted `index.html`. As a free bonus, unlike Prettier's HTML parser, it even seems to have picked up on our configured 2-spaces-for-indentation preference (I mean, tabs are *obviously superior* if you ask me but hey, the decision is already made for this repo, and consistency is important.)

## How was this PR tested?

Saving/editing HTML file

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

AI told me to Eat Pant before committing, so I've gone ahead and done that.

- `main` <!-- branch-stack -->
  - \#1427 :point\_left:
