### PR TITLE
chore: Change minifying engine back to esbuild for now

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -101,20 +101,6 @@ export default defineConfig({
       },
     },
     sourcemap: true,
-    minify: "terser",
-    terserOptions: {
-      ecma: 2020,
-      module: true,
-      format: { inline_script: false, comments: false },
-      mangle: { properties: { regex: /^#/ } },
-      compress: {
-        passes: 2,
-        arguments: true,
-        keep_fargs: false,
-        keep_infinity: true,
-        drop_console: ["debug"],
-      },
-    },
   },
   optimizeDeps: {
     exclude: ["hast"],


### PR DESCRIPTION
Change the minify engine back to esbuild. I have reason to suspect terser to be causing an issue with lingui. We can move to oxj later when we upgrade vite.

- `main` <!-- branch-stack -->
  - \#1428 :point\_left:
