### PR TITLE
fix: add MFA verification flow to email change modal

### DIFF
--- a/packages/client/components/modal/modals/EditEmail.tsx
+++ b/packages/client/components/modal/modals/EditEmail.tsx
@@ -4,9 +4,9 @@ import { Trans, useLingui } from "@lingui-solid/solid/macro";
 
 import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
 
+import { MFATicket } from "stoat.js";
 import { useModals } from "..";
 import { Modals } from "../types";
-import { MFATicket } from "stoat.js";
 
 /**
  * Change account email address

--- a/packages/client/components/modal/modals/EditEmail.tsx
+++ b/packages/client/components/modal/modals/EditEmail.tsx
@@ -6,6 +6,7 @@ import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
 
 import { useModals } from "..";
 import { Modals } from "../types";
+import { MFATicket } from "stoat.js";
 
 /**
  * Change account email address
@@ -14,7 +15,7 @@ export function EditEmailModal(
   props: DialogProps & Modals & { type: "edit_email" },
 ) {
   const { t } = useLingui();
-  const { showError } = useModals();
+  const { showError, mfaFlow } = useModals();
 
   const group = createFormGroup({
     email: createFormControl("", { required: true }),
@@ -23,9 +24,21 @@ export function EditEmailModal(
 
   async function onSubmit() {
     try {
+      const mfa = await props.client.account.mfa();
+
+      let ticket: MFATicket | undefined;
+      if (mfa.authenticatorEnabled) {
+        ticket = await mfaFlow(mfa);
+        // User canceled the MFA flow.
+        if (!ticket) {
+          return;
+        }
+      }
+
       await props.client.account.changeEmail(
         group.controls.email.value,
         group.controls.currentPassword.value,
+        ticket,
       );
 
       props.onClose();


### PR DESCRIPTION
This PR integrates `mfaFlow` into the `EditEmailModal` to request an MFA authentication flow when an account has MFA enabled. Without this change, accounts with MFA enabled cannot modify their email address, and get a generic error instead.

> **Note** This change depends on stoatchat/javascript-client-sdk#178 being fixed and stoatchat/javascript-client-sdk#179 merged.

Fixes #1431

## How was this PR tested?

- [x] Performed email address change with MFA **enabled**
- [x] Performed email address change with MFA **disabled**

<details><summary><h2>Screenshots & Screencasts</h2></summary>
<p>Email change MFA modal</p>
<img width="331" height="239" alt="MFA modal" src="https://github.com/user-attachments/assets/fd398f56-aee1-4048-9ee9-059a2edbaba2" />
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None.
