### PR TITLE
feat: Add a virtual mic for linux wayland screen sharing

### DIFF
--- a/packages/client/components/app/interface/settings/user/Native.tsx
+++ b/packages/client/components/app/interface/settings/user/Native.tsx
@@ -41,6 +41,7 @@ declare global {
         ) => void,
       ): void;
       screenPickerCallback(idx: number, audio: boolean): void;
+      isWayland?(): boolean;
     };
 
     desktopConfig: {

--- a/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
+++ b/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
@@ -4,6 +4,7 @@ import { useMediaDeviceSelect } from "solid-livekit-components";
 import { Trans } from "@lingui/solid/macro";
 
 import { useInstance } from "@revolt/instance";
+import { stoatSinkName } from "@revolt/rtc";
 import { useState } from "@revolt/state";
 import {
   CategoryButton,
@@ -69,8 +70,11 @@ function SelectInput(props: { kind: MediaDeviceKind }) {
   const activeId = createMemo(() => state.voice[setKey()] ?? "default");
 
   const devOpts = createMemo(() => {
-    const devs = media().devices(),
-      opts: { [k in string]: CategorySelectOption } = {};
+    const opts: { [k in string]: CategorySelectOption } = {};
+    const devs = media()
+      .devices()
+      // Filter out the virtual sink
+      .filter((dev) => dev.label !== stoatSinkName);
 
     //Ensure default is at top
     let d = devs.find((d) => d.deviceId === "default");

--- a/packages/client/components/rtc/index.ts
+++ b/packages/client/components/rtc/index.ts
@@ -1,4 +1,9 @@
-export { VoiceContext, useVoice } from "./state";
+import { setupVirtualMic } from "./virtualMic";
+
+export { useVoice, VoiceContext } from "./state";
 
 export { InRoom } from "./components/InRoom";
 export { RoomAudioManager } from "./components/RoomAudioManager";
+export { stoatSinkName } from "./virtualMic";
+
+setupVirtualMic();

--- a/packages/client/components/rtc/virtualMic.ts
+++ b/packages/client/components/rtc/virtualMic.ts
@@ -1,0 +1,48 @@
+export const stoatSinkName = "stoat-virtual-source";
+
+export function setupVirtualMic() {
+  if (window.native?.isWayland?.()) {
+    const original = navigator.mediaDevices.getDisplayMedia;
+
+    async function getVirtmic() {
+      try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const audioDevice = devices.find(
+          ({ label }) => label === stoatSinkName,
+        );
+        return audioDevice?.deviceId;
+      } catch {
+        return null;
+      }
+    }
+
+    navigator.mediaDevices.getDisplayMedia = async function (opts) {
+      const stream: MediaStream = await original.call(this, opts);
+      if (opts && !opts.audio) return stream;
+      const id = await getVirtmic();
+
+      console.log("Virt mic acquired:", id);
+
+      if (id) {
+        const audio = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            deviceId: {
+              exact: id,
+            },
+            autoGainControl: false,
+            echoCancellation: false,
+            noiseSuppression: false,
+            channelCount: 2,
+            sampleRate: 48000,
+            sampleSize: 16,
+          },
+        });
+
+        stream.getAudioTracks().forEach((t) => stream.removeTrack(t));
+        stream.addTrack(audio.getAudioTracks()[0]);
+      }
+
+      return stream;
+    };
+  }
+}

--- a/packages/client/components/rtc/virtualMic.ts
+++ b/packages/client/components/rtc/virtualMic.ts
@@ -21,7 +21,7 @@ export function setupVirtualMic() {
       if (opts && !opts.audio) return stream;
       const id = await getVirtmic();
 
-      console.log("Virt mic acquired:", id);
+      console.debug("Virt mic acquired:", id);
 
       if (id) {
         const audio = await navigator.mediaDevices.getUserMedia({


### PR DESCRIPTION
Add support for virtual mic when screen sharing on Wayland.
Add an isWayland check to the native window object.

## How was this PR tested?

I am streaming sound in my self host with this PR and a PR on for-desktop

No UI changes.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1438 :point\_left:
