### PR TITLE
fix(instance): Docker build injection fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,13 +66,4 @@ COPY --from=builder /build/packages/client/dist ./dist
 
 EXPOSE 5000
 
-# Runtime env vars (overridden by Helm chart / docker run)
-ENV VITE_HOST=""
-ENV VITE_API_URL=""
-ENV VITE_DEV_WS_URL=""
-ENV VITE_DEV_MEDIA_URL=""
-ENV VITE_DEV_PROXY_URL=""
-ENV VITE_DEV_GIFBOX_URL=""
-ENV VITE_RNNOISE_WORKLET_CDN_URL=""
-
 CMD ["npm", "start"]

--- a/docker/inject.js
+++ b/docker/inject.js
@@ -14,14 +14,13 @@ const OUT_DIR = "dist_injected";
 // At build time, Vite replaces import.meta.env.VITE_X with the literal string value.
 // We build with placeholder values like "__VITE_API_URL__" so they appear in the output.
 const REPLACEMENTS = {
-  __VITE_HOST__: process.env.VITE_HOST || "",
-  __VITE_API_URL__: process.env.VITE_API_URL || "",
-  __VITE_WS_URL__: process.env.VITE_DEV_WS_URL || "",
-  __VITE_MEDIA_URL__: process.env.VITE_DEV_MEDIA_URL || "",
-  __VITE_PROXY_URL__: process.env.VITE_DEV_PROXY_URL || "",
-  __VITE_GIFBOX_URL__: process.env.VITE_DEV_GIFBOX_URL || "",
-  __VITE_RNNOISE_WORKLET_CDN_URL__:
-    process.env.VITE_RNNOISE_WORKLET_CDN_URL || "",
+  __VITE_HOST__: process.env.VITE_HOST,
+  __VITE_API_URL__: process.env.VITE_API_URL,
+  __VITE_WS_URL__: process.env.VITE_DEV_WS_URL,
+  __VITE_MEDIA_URL__: process.env.VITE_DEV_MEDIA_URL,
+  __VITE_PROXY_URL__: process.env.VITE_DEV_PROXY_URL,
+  __VITE_GIFBOX_URL__: process.env.VITE_DEV_GIFBOX_URL,
+  __VITE_RNNOISE_WORKLET_CDN_URL__: process.env.VITE_RNNOISE_WORKLET_CDN_URL,
 };
 
 console.log("Preparing injected build...");
@@ -41,7 +40,11 @@ for (const file of files) {
 
   for (const [placeholder, value] of Object.entries(REPLACEMENTS)) {
     if (data.includes(placeholder)) {
-      data = data.replaceAll(placeholder, value);
+      if (value === undefined) {
+        data = data.replaceAll('"' + placeholder + '"', "void 0");
+      } else {
+        data = data.replaceAll(placeholder, value);
+      }
       modified = true;
     }
   }

--- a/docker/inject.js
+++ b/docker/inject.js
@@ -40,10 +40,10 @@ for (const file of files) {
 
   for (const [placeholder, value] of Object.entries(REPLACEMENTS)) {
     if (data.includes(placeholder)) {
-      if (value === undefined) {
-        data = data.replaceAll('"' + placeholder + '"', "void 0");
-      } else {
+      if (value) {
         data = data.replaceAll(placeholder, value);
+      } else {
+        data = data.replaceAll(`"${placeholder}"`, "void 0");
       }
       modified = true;
     }

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -6,57 +6,47 @@ export interface AppConfig {
   api: string;
 }
 
+const getEnv = (name: string, devOnly?: boolean) =>
+  !devOnly || import.meta.env.DEV
+    ? (import.meta.env[name] as string)
+    : undefined;
+
 const DEFAULT_HOST =
-  (import.meta.env.DEV ? import.meta.env.VITE_DEV_HOST : undefined) ??
-  (import.meta.env.VITE_HOST as string) ??
-  STOAT_HOST;
+  getEnv("VITE_DEV_HOST", true) || getEnv("VITE_HOST") || STOAT_HOST;
 
 const DEFAULT_API_URL =
-  (import.meta.env.DEV ? import.meta.env.VITE_DEV_API_URL : undefined) ??
-  (import.meta.env.VITE_API_URL as string) ??
-  STOAT_API;
+  getEnv("VITE_DEV_API_URL", true) || getEnv("VITE_API_URL") || STOAT_API;
 
 if (DEFAULT_API_URL !== STOAT_API && DEFAULT_HOST === STOAT_HOST)
   throw "VITE_HOST required when VITE_API_URL is set!";
 
 export default {
-  /**
-   * Whether to emit additional debug information
-   */
-  DEBUG: import.meta.env.DEV || true,
   /** Default instance (without the protocol) */
   DEFAULT_HOST,
   /** API URL of default instance */
   DEFAULT_API_URL,
   /** WS server override for development */
-  DEV_WS_URL: import.meta.env.VITE_DEV_WS_URL as string | undefined,
+  DEV_WS_URL: getEnv("VITE_DEV_WS_URL"),
   /** Media server override for development */
-  DEV_MEDIA_URL: import.meta.env.VITE_DEV_MEDIA_URL as string | undefined,
+  DEV_MEDIA_URL: getEnv("VITE_DEV_MEDIA_URL"),
   /** Proxy server override for development */
-  DEV_PROXY_URL: import.meta.env.VITE_DEV_PROXY_URL as string | undefined,
+  DEV_PROXY_URL: getEnv("VITE_DEV_PROXY_URL"),
   /** Gifbox server override for development */
-  DEV_GIFBOX_URL: import.meta.env.VITE_DEV_GIFBOX_URL as string | undefined,
+  DEV_GIFBOX_URL: getEnv("VITE_DEV_GIFBOX_URL"),
   /**
    * RNNoise worklet CDN host location. Defaults to blank, which uses the url provided by the livekit-rnnoise-processor package.
    */
-  RNNOISE_WORKLET_CDN_URL:
-    (import.meta.env.VITE_RNNOISE_WORKLET_CDN_URL as string) ?? "",
+  RNNOISE_WORKLET_CDN_URL: getEnv("VITE_RNNOISE_WORKLET_CDN_URL"),
   /**
    * Session ID to set during development.
    */
-  DEVELOPMENT_SESSION_ID: import.meta.env.DEV
-    ? (import.meta.env.VITE_SESSION_ID as string)
-    : undefined,
+  DEVELOPMENT_SESSION_ID: getEnv("VITE_SESSION_ID", true),
   /**
    * Token to set during development.
    */
-  DEVELOPMENT_TOKEN: import.meta.env.DEV
-    ? (import.meta.env.VITE_TOKEN as string)
-    : undefined,
+  DEVELOPMENT_TOKEN: getEnv("VITE_TOKEN", true),
   /**
    * User ID to set during development.
    */
-  DEVELOPMENT_USER_ID: import.meta.env.DEV
-    ? (import.meta.env.VITE_USER_ID as string)
-    : undefined,
+  DEVELOPMENT_USER_ID: getEnv("VITE_USER_ID", true),
 };

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -6,6 +6,10 @@ export interface AppConfig {
   api: string;
 }
 
+/**
+ * Fetch env var by name, optionally only when in dev mode.
+ * Also prevents compiler from optimizing out injected strings in Docker
+ */
 const getEnv = (name: string, devOnly?: boolean) =>
   !devOnly || import.meta.env.DEV
     ? (import.meta.env[name] as string)

--- a/packages/client/components/modal/modals.tsx
+++ b/packages/client/components/modal/modals.tsx
@@ -1,6 +1,6 @@
 import { mergeProps, splitProps } from "solid-js";
 
-import { CONFIGURATION } from "@revolt/common";
+import { IS_DEV } from "@revolt/client";
 
 import { type ActiveModal } from ".";
 import { AddBotModal } from "./modals/AddBot";
@@ -69,7 +69,7 @@ import { UserProfileRolesModal } from "./modals/UserProfileRoles";
 /* eslint-disable solid/reactivity */
 /* eslint-disable solid/components-return-once */
 export function RenderModal(props: ActiveModal & { onClose: () => void }) {
-  if (CONFIGURATION.DEBUG) {
+  if (IS_DEV) {
     console.info(
       "components/modal — modal renderer created for type:",
       props.props.type,


### PR DESCRIPTION
Should fix the current affliction affecting `beta.stoat.chat`, which is caused not by any issue in the source code, but by the tree shaking and/or minification during build process being too "smart" for its own good and literally optimizing out certain environment variables, combing the object that contains them with the export object of `env.ts` itself, and messing things up when `inject.js` tries to do its thing.

The problem is averted by inserting *any* function code between the import of the meta vars and the exported object in env.ts, causing the build system to decide its too risky to optimize because its behavior is not 100% deterministic at build-time. (It never was deterministic at build-time though, build system just went full Joker on us.)

## How was this PR tested?

By pulling out most of my fur in rage

## Checklist:

Checklists can't save you

## Please declare, if any, LLM usage involved in creating this PR

Where is your LLM god now

- `main` <!-- branch-stack -->
  - \#1442 :point\_left:
