### PR TITLE
fix: Don't jump back to New Tab page on first-load backend connect error

### DIFF
--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -22,6 +22,7 @@ export const DefaultHost = DefaultURL.host;
 const DefRoute = `/i/${DefaultHost}/`;
 
 const instanceContext = createContext<Instance>();
+let appLoadedOnce = false;
 
 export function InstanceContext(props: { children?: JSXElement }) {
   const params = useParams();
@@ -47,7 +48,7 @@ export function InstanceContext(props: { children?: JSXElement }) {
   function onError(e: unknown) {
     console.error(e);
     if ((e as Error).message === "Failed to fetch") {
-      const hStr = `'${host}'`;
+      const hStr = `'${host || DefaultHost}'`;
       e = t`Couldn't fetch Stoat configuration from ${hStr}.`;
     }
     snackbar.show({
@@ -56,7 +57,7 @@ export function InstanceContext(props: { children?: JSXElement }) {
       closeable: true,
       autoCloseDelay: 30000,
     });
-    history.back();
+    if (appLoadedOnce) nav(-1);
   }
 
   (async () => {
@@ -76,6 +77,7 @@ export function InstanceContext(props: { children?: JSXElement }) {
     } catch (e) {
       onError(e);
     }
+    appLoadedOnce = true;
   })();
 
   //Finish init in reactive scope


### PR DESCRIPTION
This is the infinite-navigate-back on first load fail hotfix from multiuser, I forgot to push to instance before merge, it turns out the affected code for this bug is in instance and not multiuser PR so ideally it should be separate, can happen when you have a whole layer of PRs based on each other lol

## How was this PR tested?

Been on my self host for a while

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

How could you tell? The Light Lump in my Mind was indeed used for creating this PR.

- `main` <!-- branch-stack -->
  - \#1443 :point\_left:
