### PR TITLE
feat: update icons to symbols in more places

### DIFF
--- a/packages/client/components/app/interface/settings/ChannelSettings.tsx
+++ b/packages/client/components/app/interface/settings/ChannelSettings.tsx
@@ -1,10 +1,3 @@
-import {
-  BiRegularListUl,
-  BiSolidCloud,
-  BiSolidInfoCircle,
-  BiSolidTrash,
-} from "solid-icons/bi";
-
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { Channel } from "stoat.js";
 
@@ -12,6 +5,7 @@ import { useClient } from "@revolt/client";
 import { TextWithEmoji } from "@revolt/markdown";
 import { useModals } from "@revolt/modal";
 import { ColouredText } from "@revolt/ui";
+import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
 import { SettingsConfiguration } from ".";
 import ChannelOverview from "./channel/Overview";
@@ -111,7 +105,7 @@ const Config: SettingsConfiguration<Channel> = {
           entries: [
             {
               id: "overview",
-              icon: <BiSolidInfoCircle size={20} />,
+              icon: <Symbol size={20}>info</Symbol>,
               title: <Trans>Overview</Trans>,
             },
             {
@@ -119,7 +113,7 @@ const Config: SettingsConfiguration<Channel> = {
                 channel.type === "SavedMessages" ||
                 !channel.havePermission("ManagePermissions"),
               id: "permissions",
-              icon: <BiRegularListUl size={20} />,
+              icon: <Symbol size={20}>page_info</Symbol>,
               title: <Trans>Permissions</Trans>,
             },
             {
@@ -127,7 +121,7 @@ const Config: SettingsConfiguration<Channel> = {
                 !channel.havePermission("ManageWebhooks") &&
                 import.meta.env.DEV,
               id: "webhooks",
-              icon: <BiSolidCloud size={20} />,
+              icon: <Symbol size={20}>webhook</Symbol>,
               title: <Trans>Webhooks</Trans>,
             },
           ],
@@ -139,7 +133,9 @@ const Config: SettingsConfiguration<Channel> = {
           entries: [
             {
               icon: (
-                <BiSolidTrash size={20} color="var(--md-sys-color-error)" />
+                <Symbol size={20} color="var(--md-sys-color-error)">
+                  delete
+                </Symbol>
               ),
               title: (
                 <ColouredText colour="var(--md-sys-color-error)">

--- a/packages/client/components/app/interface/settings/ServerSettings.tsx
+++ b/packages/client/components/app/interface/settings/ServerSettings.tsx
@@ -1,13 +1,3 @@
-import {
-  BiSolidEnvelope,
-  BiSolidFlagAlt,
-  BiSolidGroup,
-  BiSolidHappyBeaming,
-  BiSolidInfoCircle,
-  BiSolidTrash,
-  BiSolidUserX,
-} from "solid-icons/bi";
-
 import { Trans, useLingui } from "@lingui-solid/solid/macro";
 import { Server } from "stoat.js";
 
@@ -15,6 +5,7 @@ import { useUser } from "@revolt/client";
 import { TextWithEmoji } from "@revolt/markdown";
 import { useModals } from "@revolt/modal";
 import { ColouredText } from "@revolt/ui";
+import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
 import { SettingsConfiguration } from ".";
 import { ChannelPermissionsEditor } from "./channel/permissions/ChannelPermissionsEditor";
@@ -103,7 +94,7 @@ const Config: SettingsConfiguration<Server> = {
           entries: [
             {
               id: "overview",
-              icon: <BiSolidInfoCircle size={20} />,
+              icon: <Symbol size={20}>info</Symbol>,
               title: <Trans>Overview</Trans>,
             },
           ],
@@ -114,7 +105,7 @@ const Config: SettingsConfiguration<Server> = {
           entries: [
             {
               id: "emojis",
-              icon: <BiSolidHappyBeaming size={20} />,
+              icon: <Symbol size={20}>mood</Symbol>,
               title: <Trans>Emojis</Trans>,
             },
           ],
@@ -128,7 +119,7 @@ const Config: SettingsConfiguration<Server> = {
             {
               hidden: true,
               id: "members",
-              icon: <BiSolidGroup size={20} />,
+              icon: <Symbol size={20}>group</Symbol>,
               title: <Trans>Members</Trans>,
             },
             {
@@ -137,19 +128,19 @@ const Config: SettingsConfiguration<Server> = {
                 server.havePermission("ManagePermissions")
               ),
               id: "roles",
-              icon: <BiSolidFlagAlt size={20} />,
+              icon: <Symbol size={20}>flag</Symbol>,
               title: <Trans>Roles</Trans>,
             },
             {
               hidden: !server.havePermission("ManageServer"),
               id: "invites",
-              icon: <BiSolidEnvelope size={20} />,
+              icon: <Symbol size={20}>link</Symbol>,
               title: <Trans>Invites</Trans>,
             },
             {
               hidden: !server.havePermission("BanMembers"),
               id: "bans",
-              icon: <BiSolidUserX size={20} />,
+              icon: <Symbol size={20}>gavel</Symbol>,
               title: <Trans>Bans</Trans>,
             },
           ],
@@ -159,7 +150,9 @@ const Config: SettingsConfiguration<Server> = {
           entries: [
             {
               icon: (
-                <BiSolidTrash size={20} color="var(--md-sys-color-error)" />
+                <Symbol size={20} color="var(--md-sys-color-error)">
+                  delete
+                </Symbol>
               ),
               title: (
                 <ColouredText colour="var(--md-sys-color-error)">

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -476,7 +476,7 @@ export function MessageComposition(props: Props) {
                     </Show>
                     <MessageBox.InlineIcon>
                       <IconButton onPress={triggerProps.onClickEmoji}>
-                        <Symbol>emoticon</Symbol>
+                        <Symbol>mood</Symbol>
                       </IconButton>
                     </MessageBox.InlineIcon>
                     <div ref={triggerProps.ref} />


### PR DESCRIPTION

<img width="304" height="260" alt="image" src="https://github.com/user-attachments/assets/df5ff5d1-3f30-427e-a014-4a98634d68b1" />  
  
<img width="326" height="429" alt="image" src="https://github.com/user-attachments/assets/f06edd0d-a2c1-4aa4-8975-daaf59c2b50e" />  
  
<img width="222" height="115" alt="image" src="https://github.com/user-attachments/assets/5d579691-2668-490f-bfdb-f3d3abd63516" />


- **feat: update icons to symbols in channel settings**
- **feat: update icons to symbols in server settings**
- **fix: use a more fitting symbol for emoji**

* `main` <!-- branch-stack -->
  - \#1445 :point\_left:
