### PR TITLE
fix: Update service worker precache with new locales

### DIFF
--- a/.mise/tasks/scripts/locale
+++ b/.mise/tasks/scripts/locale
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Generate locale list for service worker"
+set -e
+
+pnpm --filter client exec node scripts/locale.js

--- a/packages/client/scripts/locale.js
+++ b/packages/client/scripts/locale.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import { readdirSync } from "node:fs";
 
 console.log(

--- a/packages/client/scripts/locale.js
+++ b/packages/client/scripts/locale.js
@@ -1,0 +1,15 @@
+import { readdirSync } from "node:fs";
+
+console.log(
+  "var locale_keys = " +
+    JSON.stringify([
+      ...readdirSync("./node_modules/dayjs/locale")
+        .filter((x) => x.endsWith(".js"))
+        .map((x) => {
+          let v = x.split(".");
+          v.pop();
+          return v.join(".");
+        }),
+    ]) +
+    ";",
+);

--- a/packages/client/src/serviceWorker.ts
+++ b/packages/client/src/serviceWorker.ts
@@ -59,10 +59,9 @@ self.addEventListener("push", (event) => {
 
 cleanupOutdatedCaches();
 
-// Generate list using scripts/locale.js
-// TODO: update this
+// Generate list using mise scripts:locale
 // prettier-ignore
-const locale_keys = ["af","am","ar-dz","ar-kw","ar-ly","ar-ma","ar-sa","ar-tn","ar","az","be","bg","bi","bm","bn","bo","br","bs","ca","cs","cv","cy","da","de-at","de-ch","de","dv","el","en-au","en-ca","en-gb","en-ie","en-il","en-in","en-nz","en-sg","en-tt","en","eo","es-do","es-pr","es-us","es","et","eu","fa","fi","fo","fr-ca","fr-ch","fr","fy","ga","gd","gl","gom-latn","gu","he","hi","hr","ht","hu","hy-am","id","is","it-ch","it","ja","jv","ka","kk","km","kn","ko","ku","ky","lb","lo","lt","lv","me","mi","mk","ml","mn","mr","ms-my","ms","mt","my","nb","ne","nl-be","nl","nn","oc-lnc","pa-in","pl","pt-br","pt","ro","ru","rw","sd","se","si","sk","sl","sq","sr-cyrl","sr","ss","sv-fi","sv","sw","ta","te","tet","tg","th","tk","tl-ph","tlh","tr","tzl","tzm-latn","tzm","ug-cn","uk","ur","uz-latn","uz","vi","x-pseudo","yo","zh-cn","zh-hk","zh-tw","zh","ang","ar","az","be","bg","bn","bottom","br","ca","ca@valencia","ckb","contributors","cs","cy","da","de","de-CH","el","en","en-US","enchantment","enm","eo","es","et","eu","fa","fi","fil","fr","frm","ga","got","he","hi","hr","hu","id","it","ja","kmr","ko","la","lb","leet","li","lt","lv","mk","ml","ms","mt","nb-NO","nl","owo","peo","piglatin","pl","pr","pt_BR","pt_PT","ro","ro_MD","ru","si","sk","sl","sq","sr","sv","ta","te","th","tlh-qaak","tokipona","tr","uk","vec","vi","zh-Hans","zh-Hant"];
+const locale_keys = ["af","am","ar-dz","ar-iq","ar-kw","ar-ly","ar-ma","ar-sa","ar-tn","ar","az","be","bg","bi","bm","bn-bd","bn","bo","br","bs","ca","cs","cv","cy","da","de-at","de-ch","de","dv","el","en-au","en-ca","en-gb","en-ie","en-il","en-in","en-nz","en-sg","en-tt","en","eo","es-do","es-mx","es-pr","es-us","es","et","eu","fa","fi","fo","fr-ca","fr-ch","fr","fy","ga","gd","gl","gom-latn","gu","he","hi","hr","ht","hu","hy-am","id","is","it-ch","it","ja","jv","ka","kk","km","kn","ko","ku","ky","lb","lo","lt","lv","me","mi","mk","ml","mn","mr","ms-my","ms","mt","my","nb","ne","nl-be","nl","nn","oc-lnc","pa-in","pl","pt-br","pt","rn","ro","ru","rw","sd","se","si","sk","sl","sq","sr-cyrl","sr","ss","sv-fi","sv","sw","ta","te","tet","tg","th","tk","tl-ph","tlh","tr","tzl","tzm-latn","tzm","ug-cn","uk","ur","uz-latn","uz","vi","x-pseudo","yo","zh-cn","zh-hk","zh-tw","zh"];
 
 precacheAndRoute(
   self.__WB_MANIFEST.filter((entry) => {
@@ -76,10 +75,21 @@ precacheAndRoute(
           return false;
         }
 
+        // Don't cache index.html under any circumstances
+        if (fn.endsWith(".html")) {
+          return false;
+        }
+
+        // Don't cache dayjs locales
         for (const key of locale_keys) {
-          if (fn.startsWith(`${key}.`)) {
+          if (fn.startsWith(`${key}-`)) {
             return false;
           }
+        }
+
+        // Don't cache lingui translations
+        if (fn.startsWith("messages-")) {
+          return false;
         }
       }
 


### PR DESCRIPTION
Add `.html` files to precache exclusion.
Add new dayjs locales to precache exclusion.
Add lingui messages to precache exclusion.
Add script from the legacy repo for making getting locales easier.

No UI changes

## How was this PR tested?

Refreshed page after deleting service worker. Locales were not precached

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1451 :point\_left:
