### PR TITLE
chore: use limits from useInstance hook for maximum file size display

### DIFF
--- a/packages/client/components/app/interface/settings/channel/Overview.tsx
+++ b/packages/client/components/app/interface/settings/channel/Overview.tsx
@@ -111,10 +111,7 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
           <Form2.FileInput
             control={editGroup.controls.icon}
             accept="image/*"
-            maxSize={
-              client().configuration?.features.limits.default
-                .file_upload_size_limits["icons"] ?? 2.5e6
-            }
+            maxSize={instance.limits().file_upload_size_limits["icons"]}
           />
           <Form2.TextField
             minlength={1}

--- a/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
+++ b/packages/client/components/app/interface/settings/channel/webhooks/ViewWebhook.tsx
@@ -97,10 +97,7 @@ export function ViewWebhook(props: { webhook: ChannelWebhook }) {
             accept="image/*"
             label={t`Webhook Icon`}
             imageJustify={false}
-            maxSize={
-              client().configuration?.features.limits.default
-                .file_upload_size_limits["icons"] ?? 4e6
-            }
+            maxSize={instance.limits().file_upload_size_limits["icons"]}
           />
           <Form2.TextField
             name="name"

--- a/packages/client/components/app/interface/settings/server/Overview.tsx
+++ b/packages/client/components/app/interface/settings/server/Overview.tsx
@@ -224,10 +224,7 @@ export default function ServerOverview(props: ServerSettingsProps) {
             accept="image/*"
             label={t`Server Icon`}
             imageJustify={false}
-            maxSize={
-              client().configuration?.features.limits.default
-                .file_upload_size_limits["icons"] ?? 2.5e5
-            }
+            maxSize={instance.limits().file_upload_size_limits["icons"]}
           />
           <Form2.FileInput
             control={editGroup.controls.banner}
@@ -236,10 +233,7 @@ export default function ServerOverview(props: ServerSettingsProps) {
             imageAspect="232/100"
             imageRounded={false}
             imageJustify={false}
-            maxSize={
-              client().configuration?.features.limits.default
-                .file_upload_size_limits["banners"] ?? 6e6
-            }
+            maxSize={instance.limits().file_upload_size_limits["banners"]}
           />
           <Form2.TextField
             minlength={1}

--- a/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
+++ b/packages/client/components/app/interface/settings/server/emojis/EmojiList.tsx
@@ -81,10 +81,7 @@ export function EmojiList(props: { server: Server }) {
                 accept="image/*"
                 imageJustify={false}
                 allowRemoval={false}
-                maxSize={
-                  client().configuration?.features.limits.default
-                    .file_upload_size_limits["emojis"] ?? 5e5
-                }
+                maxSize={instance.limits().file_upload_size_limits["emojis"]}
                 hideErrors={true}
               />
             </Column>

--- a/packages/client/components/app/interface/settings/server/roles/ServerRoleEditor.tsx
+++ b/packages/client/components/app/interface/settings/server/roles/ServerRoleEditor.tsx
@@ -202,6 +202,7 @@ export function ServerRoleEditor(props: { context: Server; roleId: string }) {
             accept="image/*"
             label={t`Role Icon`}
             imageJustify={false}
+            maxSize={instance.limits().file_upload_size_limits["icons"]}
           />
 
           <Column>

--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -160,10 +160,7 @@ export function UserProfileEditor(props: Props) {
           accept="image/*"
           label={t`Avatar`}
           imageJustify={false}
-          maxSize={
-            client().configuration?.features.limits.default
-              .file_upload_size_limits["avatars"] ?? 4e6
-          }
+          maxSize={instance.limits().file_upload_size_limits["avatars"]}
         />
         <Form2.FileInput
           control={editGroup.controls.banner}
@@ -172,10 +169,7 @@ export function UserProfileEditor(props: Props) {
           imageAspect="232/100"
           imageRounded={false}
           imageJustify={false}
-          maxSize={
-            client().configuration?.features.limits.default
-              .file_upload_size_limits["background"] ?? 6e6
-          }
+          maxSize={instance.limits().file_upload_size_limits["background"]}
         />
         <Form2.TextField
           minlength={2}

--- a/packages/client/components/modal/modals/ServerIdentity.tsx
+++ b/packages/client/components/modal/modals/ServerIdentity.tsx
@@ -118,10 +118,7 @@ export function ServerIdentityModal(
               accept="image/*"
               label={t`Server Avatar`}
               imageJustify={false}
-              maxSize={
-                client().configuration?.features.limits.default
-                  .file_upload_size_limits["avatars"] ?? 4e6
-              }
+              maxSize={instance.limits().file_upload_size_limits["avatars"]}
             />
           </Show>
           <Form2.TextField


### PR DESCRIPTION
Limits are now fetched using the `useInstance()` hook rather than getting them from the client itself.

## How was this PR tested?

- [x] Limits across all file inputs that require this display the proper values.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No AI-generated code was used to create this PR.
