### PR TITLE
fix: don't crash rendering messages that produce no markdown output

### DIFF
--- a/packages/client/components/markdown/emoji/util.ts
+++ b/packages/client/components/markdown/emoji/util.ts
@@ -36,9 +36,11 @@ export function injectEmojiSize(
   const content = props.content ?? "";
 
   // inject emoji size information
+  // (there is no first child when content renders to nothing,
+  //  such as a message containing only link reference definitions)
   const properties = (
     hastNode as { children?: { properties: Record<string, string> }[] }
-  ).children?.[0].properties;
+  ).children?.[0]?.properties;
 
   // inject custom property
   if (properties) {


### PR DESCRIPTION
Messages consisting only of link reference definitions (e.g. `[a]: b`) parse to a hast tree with no children, since remark-rehype treats definitions as metadata and emits nothing for them.

`injectEmojiSize` accessed `children?.[0].properties` on that tree. That safely handles `children` being missing, but not an empty array, so it threw a TypeError. Because the Markdown component renders without an ErrorBoundary around the message list, the exception crashed the entire list: the message wouldn't show up and the UI locked up.

This is why the issue kept happening even after deleting the message. A failed send stays in the local outbox, gets restored as an unsent draft on reload, and hits the same rendering code again, crashing the app on startup. That's especially annoying on desktop where clearing local storage isn't straightforward. With this fix, the stranded draft renders fine so you can resend or delete it.

It's also pretty bad from a security standpoint, anyone can drop a link reference definition in a public channel and freeze the client for everyone who opens it.

Fixes #459

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Sent `[a]: b` in a channel on a dev build against prod. Before this fix, the client froze and the message disappeared; now it sends fine and the channel works normally.
- [x] Retried a draft stuck from a previous crash; it sent correctly and cleared from the outbox.
- [x] Verified that empty-rendering content (single/stacked link definitions, zero-width spaces, whitespace, empty messages) renders empty instead of throwing.
- [x] Verified regular text, broken references like `[foo]`, and emoji sizing still render properly.
- [x] Ran `tsc --noEmit`, `eslint`, and `prettier --check` (all passed).

Tested on web. Desktop uses the exact same rendering logic so it should be fine, but I haven't tested it directly on desktop.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

N/A - link definitions produce no HTML under CommonMark anyway, so there's no visual difference. It just stops crashing the view.

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None.