### PR TITLE
fix: Fix memory leak w/ new timer system in State

### DIFF
--- a/packages/client/components/markdown/plugins/timestamps.tsx
+++ b/packages/client/components/markdown/plugins/timestamps.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onCleanup, onMount } from "solid-js";
+import { createEffect, createSignal, on, onMount } from "solid-js";
 
 import { type Dayjs } from "dayjs";
 import type { Handler } from "mdast-util-to-hast";
@@ -11,7 +11,7 @@ import { useState } from "@revolt/state";
 import { time as Time } from "../elements";
 
 export function RenderTimestamp(props: { format: string; date: Dayjs }) {
-  const state = useState();
+  const { datePerMinute } = useState();
 
   /**
    * Format a time string
@@ -35,11 +35,12 @@ export function RenderTimestamp(props: { format: string; date: Dayjs }) {
 
   // Signal for current value
   const [value, setValue] = createSignal(format());
-  const update = () => setValue(format());
 
   // Update every minute if rendering relative time
-  onMount(() => props.format === "R" && state.perMinute(update));
-  onCleanup(() => props.format === "R" && state.clearPerMinute(update));
+  onMount(() => {
+    if (props.format === "R")
+      createEffect(on(datePerMinute, () => setValue(format())));
+  });
 
   return (
     <time

--- a/packages/client/components/markdown/plugins/timestamps.tsx
+++ b/packages/client/components/markdown/plugins/timestamps.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal } from "solid-js";
+import { createSignal, onCleanup, onMount } from "solid-js";
 
 import { type Dayjs } from "dayjs";
 import type { Handler } from "mdast-util-to-hast";
@@ -6,10 +6,13 @@ import { Plugin } from "unified";
 import { visit } from "unist-util-visit";
 
 import { dayjs, timeLocale } from "@revolt/i18n/dayjs";
+import { useState } from "@revolt/state";
 
 import { time as Time } from "../elements";
 
 export function RenderTimestamp(props: { format: string; date: Dayjs }) {
+  const state = useState();
+
   /**
    * Format a time string
    */
@@ -34,13 +37,9 @@ export function RenderTimestamp(props: { format: string; date: Dayjs }) {
   const [value, setValue] = createSignal(format());
   const update = () => setValue(format());
 
-  createEffect(() => {
-    // Update every second if we are rendering relative time
-    if (props.format === "R") {
-      const interval = setInterval(update, 1000);
-      return () => clearInterval(interval);
-    }
-  });
+  // Update every minute if rendering relative time
+  onMount(() => props.format === "R" && state.perMinute(update));
+  onCleanup(() => props.format === "R" && state.clearPerMinute(update));
 
   return (
     <time

--- a/packages/client/components/markdown/plugins/timestamps.tsx
+++ b/packages/client/components/markdown/plugins/timestamps.tsx
@@ -11,7 +11,7 @@ import { useState } from "@revolt/state";
 import { time as Time } from "../elements";
 
 export function RenderTimestamp(props: { format: string; date: Dayjs }) {
-  const { datePerMinute } = useState();
+  const { datePerDay } = useState();
 
   /**
    * Format a time string
@@ -36,10 +36,10 @@ export function RenderTimestamp(props: { format: string; date: Dayjs }) {
   // Signal for current value
   const [value, setValue] = createSignal(format());
 
-  // Update every minute if rendering relative time
+  // Update if relative time & day changes
   onMount(() => {
     if (props.format === "R")
-      createEffect(on(datePerMinute, () => setValue(format())));
+      createEffect(on(datePerDay, () => setValue(format())));
   });
 
   return (

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -3,6 +3,7 @@ import {
   Show,
   createContext,
   createSignal,
+  onCleanup,
   onMount,
   useContext,
 } from "solid-js";
@@ -53,6 +54,7 @@ export class State {
   private store: Store;
   private setStore: SetStoreFunction<Store>;
   private writeQueue: Record<string, number>;
+  _timers: (() => void)[] = [];
 
   appDrawer;
   setAppDrawer;
@@ -210,6 +212,17 @@ export class State {
       store.hydrate();
     }
   }
+
+  /** Add an interval timer that runs once per minute, but is cleaned up on logout */
+  perMinute(func: () => void) {
+    this._timers.push(func);
+  }
+
+  /** Remove a timer added with `setPerMinute` */
+  clearPerMinute(func: () => void) {
+    const i = this._timers.indexOf(func);
+    if (i !== -1) this._timers.splice(i, 1);
+  }
 }
 
 /**
@@ -221,13 +234,20 @@ const stateContext = createContext<State>(null! as State);
  * Mount state context
  */
 export function StateContext(props: { children: JSX.Element }) {
-  const stateLocal = new State();
+  const state = new State();
   const [ready, setReady] = createSignal(false);
+  let tmr: NodeJS.Timeout;
 
-  onMount(() => stateLocal.hydrate().then(() => setReady(true)));
+  onMount(() => {
+    state.hydrate().then(() => setReady(true));
+    tmr = setInterval(() => {
+      for (const fn of state._timers) fn();
+    }, 6e4);
+  });
+  onCleanup(() => clearInterval(tmr));
 
   return (
-    <stateContext.Provider value={stateLocal}>
+    <stateContext.Provider value={state}>
       <Show when={ready()}>{props.children}</Show>
     </stateContext.Provider>
   );

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -3,12 +3,12 @@ import {
   Show,
   createContext,
   createSignal,
-  onCleanup,
   onMount,
   useContext,
 } from "solid-js";
 import { SetStoreFunction, createStore } from "solid-js/store";
 
+import { createDateNow } from "@solid-primitives/date";
 import equal from "fast-deep-equal";
 import localforage from "localforage";
 
@@ -31,10 +31,9 @@ import { Sync } from "./stores/Sync";
 import { Theme } from "./stores/Theme";
 import { Voice } from "./stores/Voice";
 
+export { ALLOWED_IMAGE_TYPES } from "./stores/Draft";
 export type { Sounds, TypeSounds } from "./stores/Sounds";
 export { SyncWorker } from "./SyncWorker";
-
-export { ALLOWED_IMAGE_TYPES } from "./stores/Draft";
 
 /**
  * Introduce some delay before writing state to disk
@@ -54,12 +53,14 @@ export class State {
   private store: Store;
   private setStore: SetStoreFunction<Store>;
   private writeQueue: Record<string, number>;
-  _timers = new Map<() => void, 1>();
 
   appDrawer;
   setAppDrawer;
   diagDrawer;
   setDiagDrawer;
+
+  /** A reactive Date() that updates once per minute */
+  datePerMinute = createDateNow(6e4)[0];
 
   // define all stores
   auth = new Auth(this);
@@ -212,16 +213,6 @@ export class State {
       store.hydrate();
     }
   }
-
-  /** Add an interval timer that runs once per minute, but is cleaned up on logout */
-  perMinute(func: () => void) {
-    this._timers.set(func, 1);
-  }
-
-  /** Remove a timer added with `setPerMinute` */
-  clearPerMinute(func: () => void) {
-    this._timers.delete(func);
-  }
 }
 
 /**
@@ -233,20 +224,13 @@ const stateContext = createContext<State>(null! as State);
  * Mount state context
  */
 export function StateContext(props: { children: JSX.Element }) {
-  const state = new State();
+  const stateLocal = new State();
   const [ready, setReady] = createSignal(false);
-  let tmr: NodeJS.Timeout;
 
-  onMount(() => {
-    state.hydrate().then(() => setReady(true));
-    tmr = setInterval(() => {
-      for (const fn of state._timers.keys()) fn();
-    }, 6e4);
-  });
-  onCleanup(() => clearInterval(tmr));
+  onMount(() => stateLocal.hydrate().then(() => setReady(true)));
 
   return (
-    <stateContext.Provider value={state}>
+    <stateContext.Provider value={stateLocal}>
       <Show when={ready()}>{props.children}</Show>
     </stateContext.Provider>
   );

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -54,7 +54,7 @@ export class State {
   private store: Store;
   private setStore: SetStoreFunction<Store>;
   private writeQueue: Record<string, number>;
-  _timers: (() => void)[] = [];
+  _timers = new Map<() => void, 1>();
 
   appDrawer;
   setAppDrawer;
@@ -215,13 +215,12 @@ export class State {
 
   /** Add an interval timer that runs once per minute, but is cleaned up on logout */
   perMinute(func: () => void) {
-    this._timers.push(func);
+    this._timers.set(func, 1);
   }
 
   /** Remove a timer added with `setPerMinute` */
   clearPerMinute(func: () => void) {
-    const i = this._timers.indexOf(func);
-    if (i !== -1) this._timers.splice(i, 1);
+    this._timers.delete(func);
   }
 }
 
@@ -241,7 +240,7 @@ export function StateContext(props: { children: JSX.Element }) {
   onMount(() => {
     state.hydrate().then(() => setReady(true));
     tmr = setInterval(() => {
-      for (const fn of state._timers) fn();
+      for (const fn of state._timers.keys()) fn();
     }, 6e4);
   });
   onCleanup(() => clearInterval(tmr));

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -1,7 +1,10 @@
 import {
+  Accessor,
   JSX,
   Show,
   createContext,
+  createEffect,
+  createMemo,
   createSignal,
   onMount,
   useContext,
@@ -60,7 +63,16 @@ export class State {
   setDiagDrawer;
 
   /** A reactive Date() that updates once per minute */
-  datePerMinute = createDateNow(6e4)[0];
+  datePerMinute: Accessor<Date> = createDateNow(6e4)[0];
+
+  /** A reactive Date() that updates only when the day changes */
+  datePerDay: Accessor<Date> = (() => {
+    const poll = createDateNow(1000)[0];
+    const [get, set] = createSignal();
+    createEffect(() => set(poll().getDay()));
+    const date = createMemo(() => (get(), new Date()));
+    return date;
+  })();
 
   // define all stores
   auth = new Auth(this);

--- a/packages/client/components/state/stores/NotificationOptions.ts
+++ b/packages/client/components/state/stores/NotificationOptions.ts
@@ -1,10 +1,9 @@
-import { Accessor, createSignal } from "solid-js";
+import { Accessor, createMemo } from "solid-js";
 
 import { Channel, Server } from "stoat.js";
 
-import { State } from "..";
-
 import { AbstractStore } from ".";
+import { State } from "..";
 
 /**
  * Possible notification states
@@ -66,8 +65,6 @@ export class NotificationOptions extends AbstractStore<
   "notifications",
   TypeNotificationOptions
 > {
-  private activeNotifications: Record<string, Notification> = {};
-
   #now: Accessor<number>;
 
   /**
@@ -76,11 +73,8 @@ export class NotificationOptions extends AbstractStore<
   constructor(state: State) {
     super(state, "notifications");
 
-    const [now, setNow] = createSignal<number>(+new Date());
-    this.#now = now;
-
     // update every minute
-    state.perMinute(() => setNow(+new Date()));
+    this.#now = createMemo(() => +state.datePerMinute());
   }
 
   /**

--- a/packages/client/components/state/stores/NotificationOptions.ts
+++ b/packages/client/components/state/stores/NotificationOptions.ts
@@ -76,13 +76,11 @@ export class NotificationOptions extends AbstractStore<
   constructor(state: State) {
     super(state, "notifications");
 
-    // memory leak? -- maybe this should be a global util somewhere
-    // todo: refactor
     const [now, setNow] = createSignal<number>(+new Date());
     this.#now = now;
 
     // update every minute
-    setInterval(() => setNow(+new Date()), 6e3);
+    state.perMinute(() => setNow(+new Date()));
   }
 
   /**

--- a/packages/client/components/ui/components/utils/Time.tsx
+++ b/packages/client/components/ui/components/utils/Time.tsx
@@ -37,14 +37,10 @@ export function formatTime(
       case "calendar":
         return dayjs(options.value).calendar(options.referenceTime);
       case "datetime":
-        return `${formatTime(
-          dayjs,
-          {
-            format: "date",
-            value: options.value,
-          },
-          date,
-        )} ${formatTime(dayjs, { format: "time", value: options.value }, date)}`;
+        return `${formatTime(dayjs, {
+          format: "date",
+          value: options.value,
+        })} ${formatTime(dayjs, { format: "time", value: options.value })}`;
       case "date":
       case "dateNormal":
         return dayjs(options.value).format("DD/MM/YYYY");
@@ -71,10 +67,16 @@ export function formatTime(
 
 export function Time(props: Props) {
   const dayjs = useTime();
-  const { datePerMinute } = useState();
+  const { datePerDay } = useState();
 
-  //Auto-updating time format
-  const time = createMemo(() => formatTime(dayjs, props, datePerMinute()));
+  const time = createMemo(() =>
+    formatTime(
+      dayjs,
+      props,
+      //Reactively update time only if relative date (param unused for other formats)
+      props.format === "relative" ? datePerDay() : undefined,
+    ),
+  );
 
   return (
     <time

--- a/packages/client/components/ui/components/utils/Time.tsx
+++ b/packages/client/components/ui/components/utils/Time.tsx
@@ -1,6 +1,7 @@
-import { type JSX, createSignal, onCleanup } from "solid-js";
+import { type JSX, createSignal, onCleanup, onMount } from "solid-js";
 
 import { useTime } from "@revolt/i18n";
+import { useState } from "@revolt/state";
 
 interface Props {
   value: number | Date | string | JSX.Element;
@@ -65,16 +66,13 @@ export function formatTime(
 
 export function Time(props: Props) {
   const dayjs = useTime();
+  const state = useState();
   const [time, setTime] = createSignal(formatTime(dayjs, props));
 
-  const timer = setInterval(() => {
-    const value = formatTime(dayjs, props);
-    if (value !== time()) {
-      setTime(value);
-    }
-  }, 1000);
+  const timer = () => setTime(formatTime(dayjs, props));
 
-  onCleanup(() => clearInterval(timer));
+  onMount(() => state.perMinute(timer));
+  onCleanup(() => state.clearPerMinute(timer));
 
   return (
     <time

--- a/packages/client/components/ui/components/utils/Time.tsx
+++ b/packages/client/components/ui/components/utils/Time.tsx
@@ -1,4 +1,4 @@
-import { type JSX, createSignal, onCleanup, onMount } from "solid-js";
+import { type JSX, createMemo } from "solid-js";
 
 import { useTime } from "@revolt/i18n";
 import { useState } from "@revolt/state";
@@ -26,6 +26,7 @@ interface Props {
 export function formatTime(
   dayjs: ReturnType<typeof useTime>,
   options: Props,
+  date?: Date,
 ): JSX.Element | string | undefined | null {
   if (
     options.value instanceof Date ||
@@ -36,10 +37,14 @@ export function formatTime(
       case "calendar":
         return dayjs(options.value).calendar(options.referenceTime);
       case "datetime":
-        return `${formatTime(dayjs, {
-          format: "date",
-          value: options.value,
-        })} ${formatTime(dayjs, { format: "time", value: options.value })}`;
+        return `${formatTime(
+          dayjs,
+          {
+            format: "date",
+            value: options.value,
+          },
+          date,
+        )} ${formatTime(dayjs, { format: "time", value: options.value }, date)}`;
       case "date":
       case "dateNormal":
         return dayjs(options.value).format("DD/MM/YYYY");
@@ -49,7 +54,7 @@ export function formatTime(
         return dayjs(options.value).format("YYYY-MM-DD");
       case "relative":
         return dayjs(options.value).from(
-          options.referenceTime ?? Date.now(),
+          options.referenceTime ?? date?.getTime() ?? Date.now(),
           options.hideSuffix,
         );
       case "time12":
@@ -66,13 +71,10 @@ export function formatTime(
 
 export function Time(props: Props) {
   const dayjs = useTime();
-  const state = useState();
-  const [time, setTime] = createSignal(formatTime(dayjs, props));
+  const { datePerMinute } = useState();
 
-  const timer = () => setTime(formatTime(dayjs, props));
-
-  onMount(() => state.perMinute(timer));
-  onCleanup(() => state.clearPerMinute(timer));
+  //Auto-updating time format
+  const time = createMemo(() => formatTime(dayjs, props, datePerMinute()));
 
   return (
     <time


### PR DESCRIPTION
I'm sure this is not the only memory leak we have but it should at least improve performance not constantly registering and deregistering so many damn setIntervals.

We also don't need to regenerate relative timestamps literally every second. These only change at time boundaries and it's not a big deal for them to have a delay. Even Discord takes 30+ seconds for your message to go from "Sent Today" to "Sent Yesterday" when the clock strikes midnight.

## How was this PR tested?

Left stoat open for a while in foreground and background to check performance and memory usage.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

You can ask my favorite chemical compound, Sodium Hypobromite. Also known as NaBrO

- `main` <!-- branch-stack -->
  - \#1460 :point\_left:
