### PR TITLE
fix(instance): Stoat host check bug

### DIFF
--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -15,8 +15,23 @@ const getEnv = (name: string, devOnly?: boolean) =>
     ? (import.meta.env[name] as string)
     : undefined;
 
-const DEFAULT_HOST =
-  getEnv("VITE_DEV_HOST", true) || getEnv("VITE_HOST") || STOAT_HOST;
+/** If host is Stoat, normalize to STOAT_HOST, else return host */
+export const normalizeHost = (host: string) =>
+  [
+    // historically...
+    "api.revolt.chat",
+    "beta.revolt.chat",
+    "revolt.chat",
+    // ... and now:
+    "api.stoat.chat",
+    "beta.stoat.chat",
+  ].includes(host)
+    ? STOAT_HOST
+    : host;
+
+const DEFAULT_HOST = normalizeHost(
+  getEnv("VITE_DEV_HOST", true) || getEnv("VITE_HOST") || STOAT_HOST,
+);
 
 const DEFAULT_API_URL =
   getEnv("VITE_DEV_API_URL", true) || getEnv("VITE_API_URL") || STOAT_API;

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -11,7 +11,7 @@ import {
 import { Dynamic } from "solid-js/web";
 
 import { CONFIGURATION } from "@revolt/common";
-import { AppConfig, STOAT_HOST } from "@revolt/common/lib/env";
+import { AppConfig, normalizeHost, STOAT_HOST } from "@revolt/common/lib/env";
 import { LoadingScreen, useSnackbar } from "@revolt/ui";
 
 import Instance, { _newClient } from "./Instance";
@@ -33,17 +33,7 @@ export function InstanceContext(props: { children?: JSXElement }) {
   const [inst, setInst] = createSignal<Instance>();
 
   //Check Stoat instance
-  const host = [
-    // historically...
-    "api.revolt.chat",
-    "beta.revolt.chat",
-    "revolt.chat",
-    // ... and now:
-    "api.stoat.chat",
-    "beta.stoat.chat",
-  ].includes(params.host)
-    ? STOAT_HOST
-    : params.host;
+  const host = normalizeHost(params.host);
 
   function onError(e: unknown) {
     console.error(e);

--- a/packages/client/components/state/stores/Layout.ts
+++ b/packages/client/components/state/stores/Layout.ts
@@ -1,8 +1,8 @@
+import Instance from "@revolt/instance/Instance";
 import { paramsFromPathname } from "@revolt/routing";
 
-import { State } from "..";
-
 import { AbstractStore } from ".";
+import { State } from "..";
 
 /**
  * Static section IDs
@@ -68,10 +68,7 @@ export class Layout extends AbstractStore<"layout", TypeLayout> {
   default(): TypeLayout {
     return {
       activeInterface: "home",
-      activePath: {
-        home: "/",
-        discover: "/discover/servers",
-      },
+      activePath: {},
       openSections: {},
     };
   }
@@ -93,7 +90,9 @@ export class Layout extends AbstractStore<"layout", TypeLayout> {
     if (typeof input.activePath === "object") {
       for (const interfaceId of Object.keys(input.activePath)) {
         if (typeof input.activePath[interfaceId] === "string") {
-          layout.activePath[interfaceId] = input.activePath[interfaceId];
+          layout.activePath[interfaceId] = Instance.relPath(
+            input.activePath[interfaceId],
+          );
         }
       }
     }
@@ -130,7 +129,7 @@ export class Layout extends AbstractStore<"layout", TypeLayout> {
    * Get the last active discover path in the app
    */
   getLastActiveDiscoverPath() {
-    return this.get().activePath["discover"];
+    return this.get().activePath["discover"] ?? "/discover/servers";
   }
 
   /**
@@ -159,7 +158,7 @@ export class Layout extends AbstractStore<"layout", TypeLayout> {
       ? "discover"
       : (params.serverId ?? "home");
     this.set("activeInterface", section);
-    this.set("activePath", section, pathname);
+    this.set("activePath", section, Instance.relPath(pathname));
   }
 
   /**


### PR DESCRIPTION
Fixes links going all wonky when you click "Copy Link" or generate an invite, eg. <img width=500 src="https://github.com/user-attachments/assets/9e70c5c4-eee6-40ed-b462-24f35402219f" />

This is caused by the IS\_STOAT check only being uni-directional in a sense. The client detects links that are one of Stoat's other domains, like "beta.stoat.chat", but it can't tell if it itself isn't. If VITE\_HOST is set to anything besides "stoat.chat", it will become very confused, because one part of the code is convinced you are Stoat while another part is convinced you aren't.

Also fixes a related bug this causes which is that after the client redirects you to the wrong host and fails, it writes that bad link to the layout state DB. All links in the layout state should not contain an instance prefix and this breaks things. Handling state for multiple instances will be handled in multiuser PR via a different method.

## How was this PR tested?

Generating invites, copying links, and trying to break the layout state to make sure it doesn't break.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Well technically, Mia is an AI-powered artificial Mew clone. Those damn scientists never learned after MewTwo.

- `main` <!-- branch-stack -->
  - \#1462 :point\_left:
