### PR TITLE
fix: don't reopen the authenticator setup modal over its own error

### DIFF
--- a/packages/client/components/app/interface/settings/user/Account.tsx
+++ b/packages/client/components/app/interface/settings/user/Account.tsx
@@ -163,23 +163,23 @@ function MultiFactorAuth() {
     }
     const secret = await ticket!.generateAuthenticatorSecret();
 
-    let success;
-    while (!success) {
-      try {
-        const code = await mfaEnableTOTP(secret, client().user!.username);
+    try {
+      const enabled = await mfaEnableTOTP(
+        secret,
+        client().user!.username,
+        (code) => mfa.data!.enableAuthenticator(code),
+      );
 
-        if (code) {
-          await mfa.data!.enableAuthenticator(code);
-          success = true;
-        }
-      } catch (err) {
-        // If the modal was closed (ie. promise was rejected) quit the loop
-        if (err === "MFACancelled") {
-          snackbar.show({ message: t`MFA setup canceled.` });
-          return;
-        }
-        showError(err);
+      if (!enabled) {
+        snackbar.show({ message: t`MFA setup canceled.` });
       }
+    } catch (err) {
+      if (err === "MFACancelled") {
+        snackbar.show({ message: t`MFA setup canceled.` });
+        return;
+      }
+
+      showError(err);
     }
   }
 

--- a/packages/client/components/modal/index.tsx
+++ b/packages/client/components/modal/index.tsx
@@ -162,15 +162,29 @@ export class ModalControllerExtended extends ModalController {
 
   /**
    * Open TOTP secret modal
-   * @param client Client
+   *
+   * The modal stays open until the code is accepted or the user backs out, so
+   * a rejected code can be reported without the dialog closing underneath it.
+   * @param secret Secret to display
+   * @param identifier Account identifier shown in the authenticator app
+   * @param enable Called with the entered code, should throw if it is rejected
+   * @returns Whether the authenticator was enabled
    */
-  mfaEnableTOTP(secret: string, identifier: string) {
-    return new Promise((resolve: (value?: string) => void, reject) =>
+  mfaEnableTOTP(
+    secret: string,
+    identifier: string,
+    enable: (code: string) => Promise<void>,
+  ) {
+    return new Promise((resolve: (value: boolean) => void, reject) =>
       this.openModal({
         type: "mfa_enable_totp",
         identifier,
         secret,
-        callback: resolve,
+        async callback(code) {
+          if (!code) return resolve(false);
+          await enable(code);
+          resolve(true);
+        },
         reject,
       }),
     );

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -185,7 +185,7 @@ export type Modals =
       type: "mfa_enable_totp";
       identifier: string;
       secret: string;
-      callback: (code?: string) => void;
+      callback: (code?: string) => Promise<void>;
       reject?: (reason?: string) => void;
     }
   | ({


### PR DESCRIPTION
`setupAuthenticatorApp` wrapped the TOTP modal in a `while (!success)` retry loop, which led to a couple of broken UX behaviors.

If a code was rejected, `enableAuthenticator` threw, triggering `showError` right before the loop immediately reopened the modal on top of it. The error dialog got covered instantly, so to the user, the setup screen just looked like it flashed and reappeared with zero feedback.

Dismissing the modal had a similar issue. The retry loop only broke on explicit cancellation (which rejected with `MFACancelled`). Closing the dialog via Escape, backdrop click, or the close button routed through `onClose` and called `callback()` with no arguments. Because this resolved to `undefined`, `success` remained falsy and the modal reopened right away, locking the user in the setup flow unless they specifically clicked "Cancel".

`MFAEnableTOTP` actually already contained a `try`/`catch` around `props.callback(code)` meant to display `showError` while keeping the dialog open. However, because `callback` was just `resolve`, it was unreachable and never threw.

This fix passes the enable handler directly into the modal so that catch block runs as intended, allowing us to drop the retry loop entirely. An invalid code now displays the error while keeping the modal open and the input field preserved. Dismissing the dialog via any method now cleanly cancels setup instead of looping.

Fixes #810
Related to #828, which reports InvalidToken when enabling 2FA. This doesn't fix that, the error originates server-side, but it does make the failure readable instead of flashing past, so a rejected code is distinguishable from the modal simply looping.

## How was this PR tested?

- [x] Entered an invalid code: verified the error message stays visible and readable with the entered code preserved in the input field (previously flashed and reset the modal).
- [x] Dismissed via backdrop click: verified it cancels cleanly and shows the "MFA setup canceled" snackbar (previously re-prompted endlessly).
- [x] Dismissed via Escape key: closes cleanly.
- [x] Clicked Cancel button: works as expected and shows the cancellation snackbar.
- [x] Entered a valid code: successfully completes setup.
- [x] Ran `tsc --noEmit`, `eslint`, and `prettier --check` (all passed).

Tested on web against prod with a dev build. Desktop loads the same client, so it should behave identically, though I haven't tested it there directly.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

N/A - Control flow fix. The key visual change is that the error state remains visible rather than immediately flashing away.

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None.