### PR TITLE
fix: client locks up when using channel/server up and down keybinds

### DIFF
--- a/packages/client/components/keybinds/keybindHandler.tsx
+++ b/packages/client/components/keybinds/keybindHandler.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   createEffect,
   onCleanup,
+  untrack,
   useContext,
 } from "solid-js";
 
@@ -147,7 +148,7 @@ export function KeybindContext(props: { children: JSXElement }) {
           createEffect(() => {
             const _ = [...activeKeys]; // track dependency
             if (isFired(keybind)) {
-              callback();
+              untrack(callback);
             }
           });
         },

--- a/packages/client/components/keybinds/keybindSequences.ts
+++ b/packages/client/components/keybinds/keybindSequences.ts
@@ -4,7 +4,7 @@ import { KeybindAction } from "./keybindActions";
  * Sequences are a set of keys that must be pressed at the same time
  */
 export const DEFAULT_SEQUENCES: Record<KeybindAction, (string | RegExp)[]> = {
-  [KeybindAction.NAVIGATION_CHANNEL_UP]: ["Alt", "ArrowDown"],
+  [KeybindAction.NAVIGATION_CHANNEL_UP]: ["Alt", "ArrowUp"],
   [KeybindAction.NAVIGATION_CHANNEL_DOWN]: ["Alt", "ArrowDown"],
   [KeybindAction.NAVIGATION_SERVER_UP]: ["Control", "Alt", "ArrowUp"],
   [KeybindAction.NAVIGATION_SERVER_DOWN]: ["Control", "Alt", "ArrowDown"],

--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -112,7 +112,7 @@ export const ServerSidebar = (props: Props) => {
   // TODO: issue warning if nothing is found somehow? warnings can be nicer than flat out not working
   // TODO: we want it to feel smooth when navigating through channels, so we'll want to select channels immediately but not actually navigate until we're done moving through them
   /** Navigates to the channel offset from the current one, wrapping around if needed */
-  const _navigateChannel = (byOffset: number) => {
+  const navigateChannel = (byOffset: number) => {
     if (props.channelId == null) return;
 
     const channels = visibleChannels();
@@ -131,13 +131,11 @@ export const ServerSidebar = (props: Props) => {
     }
   };
 
-  // todo: I think these cause the infinite hang bug:
+  createKeybind(KeybindAction.NAVIGATION_CHANNEL_UP, () => navigateChannel(-1));
 
-  // createKeybind(KeybindAction.NAVIGATION_CHANNEL_UP, () => navigateChannel(-1));
-
-  // createKeybind(KeybindAction.NAVIGATION_CHANNEL_DOWN, () =>
-  //   navigateChannel(1),
-  // );
+  createKeybind(KeybindAction.NAVIGATION_CHANNEL_DOWN, () =>
+    navigateChannel(1),
+  );
 
   createKeybind(KeybindAction.CHAT_MARK_SERVER_AS_READ, () => {
     if (props.server.unread) {


### PR DESCRIPTION
Code adapted from https://github.com/stoatchat/for-web/pull/1119 by @mihaicm93


## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] User can navigate to channels using the <kbd>Alt</kbd> + <kbd>Up</kbd> and <kbd>Alt</kbd> + <kbd>Down</kbd> keybinds
- [x] User can navigate to servers using the <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Up</kbd> and <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Down</kbd> keybinds
- [x] No longer locks up the client

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None was used at the time of creating and writing the PR.