### PR TITLE
fix: cursor not visible in texteditor2 code blocks

### DIFF
--- a/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
+++ b/packages/client/components/ui/components/features/texteditor/TextEditor2.tsx
@@ -349,6 +349,7 @@ const editor = css({
     padding: "0.5px 4px",
 
     color: "#c9d1d9",
+    caretColor: "currentColor",
     background: "#0d1117",
   },
 


### PR DESCRIPTION
This was bugging me for a good while because I tend to use code blocks pretty often.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Caret visible inside code blocks

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

### Before

<img width="174" height="74" alt="image" src="https://github.com/user-attachments/assets/d1045306-9a5d-4753-978b-3bb68aff82ae" />

### After

<img width="182" height="40" alt="image" src="https://github.com/user-attachments/assets/0f2f6bde-23ff-4fe7-8a88-f3e6e7f97fc0" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No ai was used to author this PR
