### PR TITLE
chore(ci/cd): Docker image will now build on its native os

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,8 +19,7 @@ jobs:
     name: Build Docker Image
     strategy:
       matrix:
-        # os: ${{ case(github.event_name != 'pull_request', '[ubuntu-latest, ubuntu-24.04-arm]', '[ubuntu-latest]') }}
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: ${{ case(github.event_name != 'pull_request', '[ubuntu-latest, ubuntu-24.04-arm]', '[ubuntu-latest]') }}
     runs-on: ${{ matrix.os }}
 
     permissions:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,9 +19,9 @@ jobs:
     name: Build Docker Image
     strategy:
       matrix:
-        os: ${{ case(github.event_name != 'pull_request', ['ubuntu-latest', 'ubuntu-24.04-arm'], ['ubuntu-latest']) }}
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
-
+    if: matrix.os == 'ubuntu-latest' || github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        exclude:
+          - os: ${{ github.event_name == 'pull_request' && 'ubuntu-24.04-arm' || '' }}
     runs-on: ${{ matrix.os }}
-    if: matrix.os == 'ubuntu-latest' || github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build Docker Image
     strategy:
       matrix:
-        os: ${{ case(github.event_name != 'pull_request', [ubuntu-latest, ubuntu-24.04-arm], [ubuntu-latest]) }}
+        os: ${{ case(github.event_name != 'pull_request', ['ubuntu-latest', 'ubuntu-24.04-arm'], ['ubuntu-latest']) }}
     runs-on: ${{ matrix.os }}
 
     permissions:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build Docker Image
     strategy:
       matrix:
-        os: ${{ case(github.event_name != 'pull_request', '[ubuntu-latest, ubuntu-24.04-arm]', '[ubuntu-latest]') }}
+        os: ${{ case(github.event_name != 'pull_request', [ubuntu-latest, ubuntu-24.04-arm], [ubuntu-latest]) }}
     runs-on: ${{ matrix.os }}
 
     permissions:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,11 @@ env:
 jobs:
   build:
     name: Build Docker Image
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # os: ${{ case(github.event_name != 'pull_request', '[ubuntu-latest, ubuntu-24.04-arm]', '[ubuntu-latest]') }}
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
 
     permissions:
       contents: read
@@ -58,6 +62,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Docker build is taking too long in ci/cd lets try to speed it up by making it run on arm natively and by only making it run x64 when in PRs

- `main` <!-- branch-stack -->
  - \#1474 :point\_left:
