### PR TITLE
fix: Persist storage to prevent repeated logouts when disk space is low

### DIFF
--- a/packages/client/components/app/interface/settings/Settings.tsx
+++ b/packages/client/components/app/interface/settings/Settings.tsx
@@ -163,7 +163,10 @@ export function Settings(props: SettingsProps & SettingsConfiguration<never>) {
                       easing: [0.17, 0.67, 0.58, 0.98],
                     }}
                   >
-                    {props.render({ page }, props.context)}
+                    {props.render(
+                      { page, onClose: props.onClose },
+                      props.context,
+                    )}
                   </Motion.div>
                 </Rerun>
               </Presence>

--- a/packages/client/components/app/interface/settings/UserSettings.tsx
+++ b/packages/client/components/app/interface/settings/UserSettings.tsx
@@ -77,7 +77,7 @@ const Config: SettingsConfiguration<{ server: Server }> = {
 
     switch (id) {
       case "account":
-        return <MyAccount />;
+        return <MyAccount onClose={props.onClose} />;
       case "appearance":
         return <AppearanceMenu />;
       case "advanced":

--- a/packages/client/components/app/interface/settings/index.tsx
+++ b/packages/client/components/app/interface/settings/index.tsx
@@ -26,7 +26,10 @@ export type SettingsConfiguration<T> = {
    * @param props State information
    */
   render: (
-    props: { page: Accessor<undefined | string> },
+    props: {
+      page: Accessor<undefined | string>;
+      onClose?: () => void;
+    },
     context: T,
   ) => JSX.Element;
 };

--- a/packages/client/components/app/interface/settings/user/Account.tsx
+++ b/packages/client/components/app/interface/settings/user/Account.tsx
@@ -13,19 +13,19 @@ import { CategoryButton, Column, Row, iconSize, useSnackbar } from "@revolt/ui";
 import MdAlternateEmail from "@material-design-icons/svg/outlined/alternate_email.svg?component-solid";
 import MdBlock from "@material-design-icons/svg/outlined/block.svg?component-solid";
 import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
+import MdAddUser from "@material-design-icons/svg/outlined/group_add.svg?component-solid";
 import MdLock from "@material-design-icons/svg/outlined/lock.svg?component-solid";
 import MdMail from "@material-design-icons/svg/outlined/mail.svg?component-solid";
 import MdPassword from "@material-design-icons/svg/outlined/password.svg?component-solid";
 import MdVerifiedUser from "@material-design-icons/svg/outlined/verified_user.svg?component-solid";
 
 import { useSettingsNavigation } from "../Settings";
-
 import { UserSummary } from "./account/index";
 
 /**
  * Account Page
  */
-export function MyAccount() {
+export function MyAccount(props: { onClose?: () => void }) {
   const client = useClient();
   const profile = createOwnProfileResource();
   const { navigate } = useSettingsNavigation();
@@ -38,7 +38,7 @@ export function MyAccount() {
         onEdit={() => navigate("profile")}
         showBadges
       />
-      <EditAccount />
+      <EditAccount onClose={props.onClose} />
       <MultiFactorAuth />
       <ManageAccount />
     </Column>
@@ -48,13 +48,27 @@ export function MyAccount() {
 /**
  * Edit account details
  */
-function EditAccount() {
+function EditAccount(props: { onClose?: () => void }) {
   const client = useClient();
   const { openModal } = useModals();
+  const { stow } = useClientLifecycle();
   const [email, setEmail] = createSignal("•••••••••••@•••••••••••");
 
   return (
     <CategoryButton.Group>
+      <CategoryButton
+        action="chevron"
+        onClick={() => {
+          props.onClose?.();
+          stow();
+        }}
+        icon={<MdAddUser {...iconSize(22)} />}
+        description={
+          <Trans>Add an additional account login for fast-switching</Trans>
+        }
+      >
+        <Trans>Add an account</Trans>
+      </CategoryButton>
       <CategoryButton
         action="chevron"
         onClick={() =>

--- a/packages/client/components/auth/src/AuthPage.tsx
+++ b/packages/client/components/auth/src/AuthPage.tsx
@@ -1,14 +1,17 @@
 import { BiLogosGithub } from "solid-icons/bi";
-import { JSX } from "solid-js";
+import { JSX, Show } from "solid-js";
 
 import { Trans } from "@lingui/solid/macro";
 import { styled } from "styled-system/jsx";
 
 import { Titlebar } from "@revolt/app/interface/desktop/Titlebar";
+import { useClientLifecycle } from "@revolt/client";
+import { State } from "@revolt/client/Controller";
 import { useState } from "@revolt/state";
 import { IconButton, iconSize } from "@revolt/ui";
 
 import MdDarkMode from "@material-design-icons/svg/filled/dark_mode.svg?component-solid";
+import MdArrowBack from "@material-design-icons/svg/outlined/arrow_back.svg?component-solid";
 
 import background from "./background.jpg";
 import { FlowBase } from "./flows/Flow";
@@ -30,9 +33,8 @@ const Base = styled("div", {
     flexDirection: "column",
     justifyContent: "space-between",
 
-    mdDown: {
-      padding: "30px 20px",
-    },
+    _tablet: { padding: "30px 20px" },
+    _phone: { padding: "10px 5px" },
   },
 });
 
@@ -75,7 +77,6 @@ const NavItems = styled("div", {
     gap: "10px",
     display: "flex",
     alignItems: "center",
-
     fontSize: "0.9em",
   },
   variants: {
@@ -86,9 +87,8 @@ const NavItems = styled("div", {
         },
       },
       stack: {
-        md: {
-          flexDirection: "column",
-        },
+        flexDirection: "column",
+        _tablet: { flexDirection: "row" },
       },
     },
   },
@@ -109,13 +109,14 @@ const LinkWithIcon = styled("a", {
  */
 const Bullet = styled("div", {
   base: {
+    display: "none",
     height: "5px",
     width: "5px",
     background: "grey",
     borderRadius: "50%",
 
-    md: {
-      display: "none",
+    _tablet: {
+      display: "block",
     },
   },
 });
@@ -124,7 +125,8 @@ const Bullet = styled("div", {
  * Authentication page
  */
 export function AuthPage(props: { children: JSX.Element }) {
-  const state = useState();
+  const state = useState(),
+    ctrl = useClientLifecycle();
 
   return (
     <Root>
@@ -134,7 +136,17 @@ export function AuthPage(props: { children: JSX.Element }) {
         css={{ scrollbar: "hidden" }}
       >
         <Nav>
-          <div />
+          <Show
+            when={
+              ctrl.lifecycle.state() === State.Ready &&
+              state.auth.hasMultiSession()
+            }
+            fallback={<div />}
+          >
+            <IconButton variant="tonal" onPress={() => ctrl.loginCached(true)}>
+              <MdArrowBack {...iconSize("24px")} />
+            </IconButton>
+          </Show>
           <IconButton
             variant="tonal"
             onPress={() =>

--- a/packages/client/components/auth/src/flows/Flow.tsx
+++ b/packages/client/components/auth/src/flows/Flow.tsx
@@ -20,7 +20,6 @@ export const FlowBase = styled("div", {
     background: "var(--md-sys-color-surface-container)",
     color: "var(--md-sys-color-on-surface)",
     maxWidth: "360px",
-    maxHeight: "600px",
     padding: "45px 40px",
     borderRadius: "32px",
     marginTop: "20px",
@@ -30,7 +29,7 @@ export const FlowBase = styled("div", {
 
     _phone: {
       background: "none",
-      padding: 0,
+      padding: "20px",
     },
   },
 });

--- a/packages/client/components/auth/src/flows/FlowHome.tsx
+++ b/packages/client/components/auth/src/flows/FlowHome.tsx
@@ -5,10 +5,11 @@ import { css } from "styled-system/css";
 
 import { useClientLifecycle } from "@revolt/client";
 import { State, TransitionType } from "@revolt/client/Controller";
+import { useError } from "@revolt/i18n";
 import { Navigate } from "@revolt/routing";
+import { useState } from "@revolt/state";
 import { Button, CircularProgress, Column } from "@revolt/ui";
 
-import { useState } from "@revolt/state";
 import Wordmark from "../../../../public/assets/web/wordmark.svg?component-solid";
 
 /**
@@ -17,6 +18,7 @@ import Wordmark from "../../../../public/assets/web/wordmark.svg?component-solid
 export default function FlowHome() {
   const state = useState();
   const { lifecycle, isLoggedIn, isError } = useClientLifecycle();
+  const error = useError();
 
   return (
     <Switch
@@ -88,12 +90,7 @@ export default function FlowHome() {
         <CircularProgress />
       </Match>
       <Match when={isError()}>
-        <Show
-          when={lifecycle.permanentError === "InvalidSession"}
-          fallback={lifecycle.permanentError || "An unknown error occurred."}
-        >
-          <Trans>You were logged out!</Trans>
-        </Show>
+        {error(lifecycle.permanentError)}
         <Button
           variant="filled"
           onPress={() =>

--- a/packages/client/components/auth/src/flows/FlowHome.tsx
+++ b/packages/client/components/auth/src/flows/FlowHome.tsx
@@ -4,9 +4,9 @@ import { Trans } from "@lingui/solid/macro";
 import { css } from "styled-system/css";
 
 import { useClientLifecycle } from "@revolt/client";
-import { TransitionType } from "@revolt/client/Controller";
+import { State, TransitionType } from "@revolt/client/Controller";
 import { Navigate } from "@revolt/routing";
-import { Button, Column } from "@revolt/ui";
+import { Button, CircularProgress, Column } from "@revolt/ui";
 
 import { useState } from "@revolt/state";
 import Wordmark from "../../../../public/assets/web/wordmark.svg?component-solid";
@@ -84,15 +84,16 @@ export default function FlowHome() {
         </>
       }
     >
+      <Match when={lifecycle.state() === State.LoggingIn}>
+        <CircularProgress />
+      </Match>
       <Match when={isError()}>
-        <Switch fallback={"an unknown error occurred"}>
-          <Match when={lifecycle.permanentError === "InvalidSession"}>
-            <h1>
-              <Trans>You were logged out!</Trans>
-            </h1>
-          </Match>
-        </Switch>
-
+        <Show
+          when={lifecycle.permanentError === "InvalidSession"}
+          fallback={lifecycle.permanentError || "An unknown error occurred."}
+        >
+          <Trans>You were logged out!</Trans>
+        </Show>
         <Button
           variant="filled"
           onPress={() =>

--- a/packages/client/components/auth/src/flows/FlowVerify.tsx
+++ b/packages/client/components/auth/src/flows/FlowVerify.tsx
@@ -65,16 +65,12 @@ export default function FlowVerify() {
    */
   async function performLogin() {
     const v = state();
-    if (v.state === "success" && v.mfa_ticket) {
-      await login(
-        {
-          mfa_ticket: v.mfa_ticket,
-        },
-        modals,
-      );
-
+    if (
+      v.state === "success" &&
+      v.mfa_ticket &&
+      (await login({ mfa_ticket: v.mfa_ticket }, modals))
+    )
       navigate("/login/auth", { replace: true });
-    }
   }
 
   return (

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -87,7 +87,7 @@ class Lifecycle {
   >;
   #policyAttentionRequired: Setter<undefined | PolicyAttentionRequired>;
 
-  client: Client;
+  private client: Client;
 
   #connectionFailures = 0;
   #permanentError: string | undefined;
@@ -119,9 +119,7 @@ class Lifecycle {
     this.dispose();
   }
 
-  private dispose(logout = false) {
-    if (logout) this.client.logout();
-
+  private dispose() {
     this.client = this.#controller.instance.newClient();
 
     this.client.options.channelIsMuted = (ch) =>
@@ -150,18 +148,18 @@ class Lifecycle {
 
     switch (nextState) {
       case State.LoggingIn:
-        this.client.api.get("/onboard/hello").then(({ onboarding }) => {
-          if (onboarding) {
-            this.transition({
-              type: TransitionType.NoUser,
-            });
-          } else {
-            this.client.connect();
-          }
-        });
-
+        this.#controller.initUserState();
+        this.client.api
+          .get("/onboard/hello")
+          .then(({ onboarding }) => {
+            if (onboarding) this.transition({ type: TransitionType.NoUser });
+            else this.client.connect();
+          })
+          .catch((e) => this.showError(e));
         break;
       case State.Connecting:
+        this.#controller.initUserState();
+      // eslint-disable-next-line no-fallthrough
       case State.Reconnecting:
         this.client.connect();
         break;
@@ -171,11 +169,13 @@ class Lifecycle {
         this.#connectionFailures = 0;
         break;
       case State.Dispose:
-        this.dispose(true);
-        this.transition({
-          type: TransitionType.Ready,
-        });
-        this.#setLoadedOnce(false);
+        this.dispose();
+        if (this.#controller.state.auth.getSession()) {
+          this.#controller.loginCached();
+        } else {
+          this.transition({ type: TransitionType.Ready });
+          this.#setLoadedOnce(false);
+        }
         break;
       case State.Disconnected:
         this.#connectionFailures++;
@@ -206,31 +206,54 @@ class Lifecycle {
     }
   }
 
+  private logout() {
+    this.client.logout();
+    this.#enter(State.Dispose);
+  }
+
   transition(transition: Transition) {
     console.debug("Received transition", transition.type);
 
-    if (transition.type === TransitionType.DisposeOnly) {
-      this.dispose();
-      return;
+    switch (transition.type) {
+      case TransitionType.DisposeOnly:
+        this.dispose();
+        return;
+      case TransitionType.Dispose:
+        this.#enter(State.Dispose);
+        return;
+      case TransitionType.Logout:
+        this.logout();
+        return;
+      case TransitionType.PermanentFailure:
+        this.#permanentError = transition.error;
+        this.#enter(State.Error);
+        return;
     }
 
     const currentState = this.state();
     switch (currentState) {
+      case State.Dispose:
+        if (transition.type === TransitionType.Ready) {
+          this.#enter(State.Ready);
+        }
+      // eslint-disable-next-line no-fallthrough
       case State.Ready:
-        if (transition.type === TransitionType.LoginUncached) {
-          this.client.useExistingSession({
-            ...transition.session,
-            user_id: transition.session.userId,
-          });
+        switch (transition.type) {
+          case TransitionType.LoginUncached:
+            this.client.useExistingSession({
+              ...transition.session,
+              user_id: transition.session.userId,
+            });
 
-          this.#enter(State.LoggingIn);
-        } else if (transition.type === TransitionType.LoginCached) {
-          this.client.useExistingSession({
-            ...transition.session,
-            user_id: transition.session.userId,
-          });
+            this.#enter(State.LoggingIn);
+            break;
+          case TransitionType.LoginCached:
+            this.client.useExistingSession({
+              ...transition.session,
+              user_id: transition.session.userId,
+            });
 
-          this.#enter(State.Connecting);
+            this.#enter(State.Connecting);
         }
         break;
       case State.LoggingIn:
@@ -241,28 +264,20 @@ class Lifecycle {
           case TransitionType.NoUser:
             this.#enter(State.Onboarding);
             break;
-          case TransitionType.PermanentFailure:
-          case TransitionType.TemporaryFailure:
-            // TODO: relay error
-            this.#enter(State.Error);
-            break;
         }
         break;
       case State.Onboarding:
         if (transition.type === TransitionType.UserCreated) {
           this.#enter(State.Connecting);
         } else if (transition.type === TransitionType.Cancel) {
-          this.#enter(State.Dispose);
+          this.logout();
         }
         break;
       case State.Error:
         if (transition.type === TransitionType.Dismiss) {
-          this.#enter(State.Dispose);
-        }
-        break;
-      case State.Dispose:
-        if (transition.type === TransitionType.Ready) {
-          this.#enter(State.Ready);
+          if (this.permanentError === "InvalidSession")
+            this.#controller.state.auth.removeSession();
+          this.logout();
         }
         break;
       case State.Connecting:
@@ -273,22 +288,12 @@ class Lifecycle {
           case TransitionType.TemporaryFailure:
             this.#enter(State.Disconnected);
             break;
-          case TransitionType.PermanentFailure:
-            this.#permanentError = transition.error;
-            this.#enter(State.Error);
-            break;
-          case TransitionType.Logout:
-            this.#enter(State.Dispose);
-            break;
         }
         break;
       case State.Connected:
         switch (transition.type) {
           case TransitionType.TemporaryFailure:
             this.#enter(State.Disconnected);
-            break;
-          case TransitionType.Logout:
-            this.#enter(State.Dispose);
             break;
         }
         break;
@@ -300,9 +305,6 @@ class Lifecycle {
           case TransitionType.Retry:
             this.#enter(State.Reconnecting);
             break;
-          case TransitionType.Logout:
-            this.#enter(State.Dispose);
-            break;
         }
         break;
       case State.Reconnecting:
@@ -313,13 +315,6 @@ class Lifecycle {
           case TransitionType.TemporaryFailure:
             this.#enter(State.Disconnected);
             break;
-          case TransitionType.PermanentFailure:
-            // TODO: relay error
-            this.#enter(State.Error);
-            break;
-          case TransitionType.Logout:
-            this.#enter(State.Dispose);
-            break;
         }
         break;
       case State.Offline:
@@ -329,9 +324,6 @@ class Lifecycle {
             break;
           case TransitionType.Retry:
             this.#enter(State.Reconnecting);
-            break;
-          case TransitionType.Logout:
-            this.#enter(State.Dispose);
             break;
         }
         break;
@@ -368,23 +360,13 @@ class Lifecycle {
       case ConnectionState.Disconnected:
         if (this.client.events.lastError) {
           if (this.client.events.lastError.type === "revolt") {
-            if (this.client.events.lastError.data.type == "InvalidSession") {
-              this.#controller.state.auth.removeSession();
-            }
-
-            this.transition({
-              type: TransitionType.PermanentFailure,
-              error: this.client.events.lastError.data.type,
-            });
-
+            this.showError(this.client.events.lastError.data.type);
             break;
           }
         }
-
         this.transition({
           type: TransitionType.TemporaryFailure,
         });
-
         break;
     }
   }
@@ -394,6 +376,14 @@ class Lifecycle {
    */
   get permanentError() {
     return this.#permanentError!;
+  }
+
+  /** Redirect to client error page */
+  showError(e: string) {
+    this.transition({
+      type: TransitionType.PermanentFailure,
+      error: e,
+    });
   }
 }
 
@@ -417,6 +407,8 @@ export default class ClientController {
   readonly state: ApplicationState;
 
   isLoggedIn: Accessor<boolean>;
+  #swapping = false;
+  #setReady: Setter<boolean>;
 
   /** Stoat instance the client belongs to. Also accessible via `useInstance()` */
   readonly instance: Instance;
@@ -424,9 +416,14 @@ export default class ClientController {
   /**
    * Construct new client controller
    */
-  constructor(state: ApplicationState, instance: Instance) {
+  constructor(
+    state: ApplicationState,
+    instance: Instance,
+    setReady: Setter<boolean>,
+  ) {
     this.state = state;
     this.instance = instance;
+    this.#setReady = setReady;
     this.api = new API.API({
       baseURL: instance.apiUrl,
     });
@@ -435,8 +432,11 @@ export default class ClientController {
 
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
+    this.stow = this.stow.bind(this);
+    this.swapAccount = this.swapAccount.bind(this);
     this.selectUsername = this.selectUsername.bind(this);
     this.isError = this.isError.bind(this);
+    this.isSwapping = this.isSwapping.bind(this);
 
     //A memo to prevent isLoggedIn from bouncing when reconnecting
     this.isLoggedIn = createMemo(() =>
@@ -449,20 +449,24 @@ export default class ClientController {
       ].includes(this.lifecycle.state()),
     );
 
-    this.loginCached();
+    this.loginCached(false, true);
   }
 
   isError() {
     return this.lifecycle.state() === State.Error;
   }
 
-  loginCached() {
-    const session = this.state.auth.getSession();
+  loginCached(unhold = false, cached = unhold) {
+    const session = this.state.auth.getSession(unhold);
     if (!session) return;
     this.lifecycle.transition({
-      type: TransitionType.LoginCached,
+      type: cached ? TransitionType.LoginCached : TransitionType.LoginUncached,
       session,
     });
+  }
+
+  initUserState() {
+    this.state.hydrate().then(() => this.#setReady(true));
   }
 
   /**
@@ -526,15 +530,11 @@ export default class ClientController {
         }
       }
 
-      if (session.result === "MFA") {
-        throw "Cancelled";
-      }
+      if (session.result === "MFA") throw "Cancelled";
     }
 
     if (session.result === "Disabled") {
-      // TODO
-      alert("Account is disabled, run special logic here.");
-      return;
+      return this.lifecycle.showError("This account is disabled.");
     }
 
     const createdSession = {
@@ -544,11 +544,16 @@ export default class ClientController {
       valid: false,
     };
 
-    this.state.auth.setSession(createdSession);
-    this.lifecycle.transition({
-      type: TransitionType.LoginUncached,
-      session: createdSession,
-    });
+    try {
+      this.state.auth.addSession(createdSession);
+      this.lifecycle.transition({
+        type: TransitionType.LoginUncached,
+        session: createdSession,
+      });
+      return true;
+    } catch (e) {
+      modals.openModal({ type: "error2", error: e });
+    }
   }
 
   async selectUsername(username: string) {
@@ -561,6 +566,44 @@ export default class ClientController {
     });
   }
 
+  #cacheUserInfo() {
+    const user = this.instance.client.user;
+    if (user) this.state.auth.cacheUserInfo(user);
+  }
+
+  /** True if the user session is about to be swapped */
+  isSwapping() {
+    return this.#swapping;
+  }
+
+  #swapSession(userId: string) {
+    try {
+      this.#cacheUserInfo();
+      this.#swapping = true;
+      this.state.auth.swapSession(userId);
+    } catch (e) {
+      this.#swapping = false;
+      throw e;
+    }
+  }
+
+  swapAccount(userId: string) {
+    this.#swapSession(userId);
+    this.lifecycle.transition({
+      type: TransitionType.Dispose,
+    });
+  }
+
+  /** Stow current session and display the login screen */
+  stow(dispose = true) {
+    this.#cacheUserInfo();
+    this.state.auth.holdSession();
+    if (dispose)
+      this.lifecycle.transition({
+        type: TransitionType.Dispose,
+      });
+  }
+
   logout() {
     this.state.settings.resetNotificationsState();
     killServiceWorkerSubscription(this.instance.client, true);
@@ -571,6 +614,7 @@ export default class ClientController {
   }
 
   dispose() {
+    this.#cacheUserInfo();
     this.lifecycle.transition({
       type: TransitionType.DisposeOnly,
     });

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -280,7 +280,9 @@ class Lifecycle {
         break;
       case State.Error:
         if (transition.type === TransitionType.Dismiss) {
-          if (this.permanentError === "InvalidSession")
+          if (
+            (this.permanentError as { type: string })?.type === "InvalidSession"
+          )
             this.#controller.state.auth.removeSession(true);
           this.logout();
         }
@@ -462,7 +464,7 @@ export default class ClientController {
 
   loginCached(unhold = false, cached = unhold) {
     const session = this.state.auth.getSession(unhold);
-    if (!session) return;
+    if (!session) return this.initUserState();
     this.lifecycle.transition({
       type: cached ? TransitionType.LoginCached : TransitionType.LoginUncached,
       session,

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -6,6 +6,7 @@ import { API, Client, ConnectionState, ProtocolV1 } from "stoat.js";
 import { ModalControllerExtended } from "@revolt/modal";
 import type { State as ApplicationState } from "@revolt/state";
 import type { Session } from "@revolt/state/stores/Auth";
+import { useSnackbar } from "@revolt/ui";
 import { useNavigate } from "@solidjs/router";
 
 import Instance from "../instance/Instance";
@@ -454,6 +455,22 @@ export default class ClientController {
         State.Reconnecting,
       ].includes(this.lifecycle.state()),
     );
+
+    //User switch request
+    if (location.hash.startsWith("#uid=")) {
+      try {
+        this.state.auth.swapSession(location.hash.slice(5));
+        location.hash = "";
+      } catch (e) {
+        useSnackbar().show({
+          message: `${e}`,
+          placement: "bottom",
+          closeable: true,
+          autoCloseDelay: 30000,
+        });
+      }
+      this.state.auth.holdSession();
+    }
 
     this.loginCached(false, true);
   }

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -276,7 +276,7 @@ class Lifecycle {
       case State.Error:
         if (transition.type === TransitionType.Dismiss) {
           if (this.permanentError === "InvalidSession")
-            this.#controller.state.auth.removeSession();
+            this.#controller.state.auth.removeSession(true);
           this.logout();
         }
         break;

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -6,6 +6,7 @@ import { API, Client, ConnectionState, ProtocolV1 } from "stoat.js";
 import { ModalControllerExtended } from "@revolt/modal";
 import type { State as ApplicationState } from "@revolt/state";
 import type { Session } from "@revolt/state/stores/Auth";
+import { useNavigate } from "@solidjs/router";
 
 import Instance from "../instance/Instance";
 import { killServiceWorkerSubscription } from "./NotificationsController";
@@ -49,7 +50,7 @@ export type Transition =
     }
   | {
       type: TransitionType.PermanentFailure;
-      error: string;
+      error: unknown;
     }
   | {
       type:
@@ -90,11 +91,13 @@ class Lifecycle {
   private client: Client;
 
   #connectionFailures = 0;
-  #permanentError: string | undefined;
+  #permanentError: unknown | undefined;
   #retryTimeout: number | undefined;
+  #nav;
 
   constructor(controller: ClientController) {
     this.#controller = controller;
+    this.#nav = useNavigate();
 
     this.onState = this.onState.bind(this);
     this.onReady = this.onReady.bind(this);
@@ -203,6 +206,8 @@ class Lifecycle {
           }, retryIn * 1e3) as never;
         }
         break;
+      case State.Error:
+        this.#nav("/login");
     }
   }
 
@@ -356,18 +361,17 @@ class Lifecycle {
   }
 
   private onState(state: ConnectionState) {
-    switch (state) {
-      case ConnectionState.Disconnected:
-        if (this.client.events.lastError) {
-          if (this.client.events.lastError.type === "revolt") {
-            this.showError(this.client.events.lastError.data.type);
-            break;
-          }
-        }
-        this.transition({
-          type: TransitionType.TemporaryFailure,
-        });
-        break;
+    if (state === ConnectionState.Disconnected) {
+      if (this.client.events.lastError) {
+        const revolt = this.client.events.lastError.type === "revolt";
+        if (revolt || !this.loadedOnce())
+          return this.showError(
+            revolt
+              ? this.client.events.lastError.data
+              : { type: "SocketError" },
+          );
+      }
+      this.transition({ type: TransitionType.TemporaryFailure });
     }
   }
 
@@ -375,11 +379,11 @@ class Lifecycle {
    * Get the permanent error
    */
   get permanentError() {
-    return this.#permanentError!;
+    return this.#permanentError;
   }
 
   /** Redirect to client error page */
-  showError(e: string) {
+  showError(e: unknown) {
     this.transition({
       type: TransitionType.PermanentFailure,
       error: e,

--- a/packages/client/components/client/NotificationsController.ts
+++ b/packages/client/components/client/NotificationsController.ts
@@ -7,9 +7,13 @@ import { useState } from "@revolt/state";
 import { useSnackbar } from "@revolt/ui";
 
 import { IS_DEV, useClient } from ".";
+import pushWorker from "/src/pushWorker?worker&url";
+
+const PushPrefix = "/?@";
+const pwPath = pushWorker.slice(0, pushWorker.lastIndexOf("/")) + PushPrefix;
 
 export function useNotifications() {
-  const { settings } = useState();
+  const { settings, auth } = useState();
   const { t } = useLingui();
   const getClient = useClient();
   const snackbar = useSnackbar();
@@ -27,7 +31,7 @@ export function useNotifications() {
     await killServiceWorkerSubscription(getClient());
   };
 
-  const notificationStateMismatch = (): boolean => {
+  const notificationStateMismatch = async () => {
     const areNotificationsAllowed =
       settings.desktopNotificationsState === "allowed" ||
       settings.pushNotificationsState === "allowed";
@@ -35,13 +39,16 @@ export function useNotifications() {
     const notificationPermissionGranted =
       !supportsNotification || Notification.permission === "granted";
 
-    return areNotificationsAllowed && !notificationPermissionGranted;
+    return (
+      areNotificationsAllowed &&
+      (!notificationPermissionGranted || !(await getPushWorker(getClient())))
+    );
   };
 
   const initNotifications = async () => {
     if (
       settings.desktopNotificationsState === "default" ||
-      notificationStateMismatch()
+      (await notificationStateMismatch())
     ) {
       // We do this before permission checking because the constructor will still work fine if we don't have permission.
       if (supportsNotification) {
@@ -72,6 +79,20 @@ export function useNotifications() {
         }
       } else {
         await enablePushSubscription();
+      }
+    }
+
+    //Unproductive workers will not be tolerated in Soviet Russia
+    const sesList = auth.getSessions().map((s) => pwPath + s.userId);
+    for (const worker of await navigator.serviceWorker.getRegistrations()) {
+      if (worker.scope.indexOf(PushPrefix) !== -1) {
+        const wUrl = new URL(worker.scope);
+        if (!sesList.includes(wUrl.pathname + wUrl.search)) {
+          console.warn(
+            `[push] Unregistered dead worker for ${wUrl.search.slice(1)}`,
+          );
+          worker.unregister();
+        }
       }
     }
   };
@@ -132,20 +153,31 @@ async function setUpServiceWorkerSubscription(client: Client) {
     return;
   }
 
-  if (!client.configured() || !client.configuration) {
+  if (!client.configured() || !client.user) {
     throw "Client not configured";
   }
 
-  const registration = await navigator.serviceWorker.getRegistration(
-    import.meta.env.BASE_URL ?? undefined,
-  );
-  if (!registration) {
-    throw "Failed to get service worker";
+  const worker = await navigator.serviceWorker.register(pushWorker, {
+    scope: pwPath + client.user.id,
+    type: "module",
+  });
+
+  if (!worker) {
+    throw "Failed to add push worker";
   }
 
+  if (!worker.active)
+    await new Promise<void>((res, rej) => {
+      const sw = (worker.installing || worker.waiting)!;
+      sw.addEventListener("statechange", () => {
+        if (sw.state === "activated") res();
+        if (sw.state === "redundant") rej("Failed to activate push worker");
+      });
+    });
+
   const subscription =
-    (await registration.pushManager.getSubscription()) ||
-    (await registration.pushManager.subscribe({
+    (await worker.pushManager.getSubscription()) ||
+    (await worker.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: client.configuration!.vapid,
     }));
@@ -166,6 +198,16 @@ function arrayBufferToBase64URL(buffer: ArrayBuffer): string {
   return intArray.toBase64({ alphabet: "base64url" });
 }
 
+async function getPushWorker(client: Client) {
+  const scope = client.user && pwPath + client.user.id;
+  if (!scope) return;
+  const worker = await navigator.serviceWorker.getRegistration(scope);
+  if (!worker) return;
+  const wUrl = new URL(worker.scope);
+  //Check if scope *actually* matches, because root worker may be returned
+  if (wUrl.pathname + wUrl.search === scope) return worker;
+}
+
 /** Exported for the client controller. Don't use this unless you have to. */
 export async function killServiceWorkerSubscription(
   client: Client,
@@ -176,12 +218,11 @@ export async function killServiceWorkerSubscription(
     return;
   }
 
-  const registration = await navigator.serviceWorker.getRegistration(
-    import.meta.env.BASE_URL ?? undefined,
-  );
-  if (!registration) return;
-  const subscription = await registration.pushManager.getSubscription();
-  if (await subscription?.unsubscribe()) {
-    if (!loggingOut) await client.api.post("/push/unsubscribe");
+  const worker = await getPushWorker(client);
+  if (!worker) return;
+  const subscription = await worker.pushManager.getSubscription();
+  if ((await subscription?.unsubscribe()) && !loggingOut) {
+    await client.api.post("/push/unsubscribe");
   }
+  await worker.unregister();
 }

--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -15,11 +15,11 @@ import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
 import { fetchLatestChangelog } from "@revolt/modal/modals/Changelog";
 import { useState } from "@revolt/state";
+import { LoadingScreen } from "@revolt/ui";
 
 import ClientController from "./Controller";
 
 export type { default as ClientController } from "./Controller";
-
 export { useNotifications } from "./NotificationsController";
 export { SoundContext, SoundController, useSound } from "./Sounds";
 
@@ -70,7 +70,9 @@ export function ClientContext(props: { children: JSXElement }) {
 
   return (
     <clientContext.Provider value={controller}>
-      <Show when={ready()}>{props.children}</Show>
+      <Show when={ready()} fallback={<LoadingScreen />}>
+        {props.children}
+      </Show>
     </clientContext.Provider>
   );
 }

--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -28,7 +28,10 @@ const clientContext = createContext(null! as ClientController);
 /**
  * Mount the modal controller
  */
-export function ClientContext(props: { children: JSXElement }) {
+export function ClientContext(props: {
+  children: JSXElement;
+  preLoad: JSXElement;
+}) {
   const { openModal } = useModals();
   const state = useState();
   const instance = useInstance();
@@ -73,6 +76,7 @@ export function ClientContext(props: { children: JSXElement }) {
       <Show when={ready()} fallback={<LoadingScreen />}>
         {props.children}
       </Show>
+      {props.preLoad}
     </clientContext.Provider>
   );
 }

--- a/packages/client/components/client/index.tsx
+++ b/packages/client/components/client/index.tsx
@@ -3,7 +3,9 @@ import {
   Accessor,
   createContext,
   createEffect,
+  createSignal,
   onCleanup,
+  Show,
   useContext,
 } from "solid-js";
 
@@ -30,8 +32,9 @@ export function ClientContext(props: { children: JSXElement }) {
   const { openModal } = useModals();
   const state = useState();
   const instance = useInstance();
+  const [ready, setReady] = createSignal(false);
 
-  const controller = new ClientController(state, instance);
+  const controller = new ClientController(state, instance, setReady);
   onCleanup(() => controller.dispose());
 
   let fetchedChangelog = false;
@@ -67,7 +70,7 @@ export function ClientContext(props: { children: JSXElement }) {
 
   return (
     <clientContext.Provider value={controller}>
-      {props.children}
+      <Show when={ready()}>{props.children}</Show>
     </clientContext.Provider>
   );
 }

--- a/packages/client/components/i18n/errors.tsx
+++ b/packages/client/components/i18n/errors.tsx
@@ -4,9 +4,7 @@ import { API } from "stoat.js";
 
 const RE_BREAK = /\s*\n\s*/g;
 
-function cleanError(
-  error: unknown,
-): { type?: never } | { message?: never } | string | undefined {
+function cleanError(error: unknown) {
   // Attempt to parse the incoming error as JSON if it is a string,
   // as some errors (e.g on login) are sent to this function as a string,
   // which then causes the error message to be unlocalised and unhelpful.
@@ -15,11 +13,9 @@ function cleanError(
       return JSON.parse(error);
     } catch {
       // Ignore JSON parse errors
-      return error;
     }
   }
-
-  return error as { type?: never } | { message?: never } | undefined;
+  return error;
 }
 
 /**
@@ -30,15 +26,13 @@ export function useError() {
 
   return (error: unknown) => {
     error = cleanError(error);
+    console.error(error);
 
     // TODO: HTTP errors
 
     // handle Revolt API errors
-    if (
-      (error as { type?: never } | undefined)?.type &&
-      typeof (error as { type: never }).type === "string"
-    ) {
-      const err = error as API.Error;
+    if (typeof (error as { type: never })?.type === "string") {
+      const err = error as API.Error | { type: "SocketError" };
 
       switch (err.type) {
         case "AlreadyFriends":
@@ -96,7 +90,7 @@ export function useError() {
         case "InvalidCredentials":
           return t`Provided email or password is wrong.`;
         case "InvalidSession":
-          return t`Please log in again.`;
+          return t`You were logged out!`;
         case "InvalidUsername":
           return t`This username is not allowed.`;
         case "MissingPermission":
@@ -132,6 +126,8 @@ export function useError() {
           return t`This account is not activated! Please check your account's inbox and try again.`;
         case "TotpAlreadyEnabled":
           return t`Multi-factor authentication is already enabled for this account.`;
+        case "SocketError":
+          return t`The web socket was unable to connect to the backend.`;
 
         // unreachable errors (in theory)
         case "FileTooLarge":
@@ -169,10 +165,7 @@ export function useError() {
     }
 
     // pass-through pre-localised errors with new Error({ message: <> })
-    if (
-      (error as { message?: never } | undefined)?.message &&
-      typeof (error as { message: never }).message === "string"
-    ) {
+    if (typeof (error as { message: never })?.message === "string") {
       const message = (error as { message: string }).message.trim();
       if (message) return message;
     } else if (typeof error === "string") {

--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -84,7 +84,8 @@ export default class Instance {
    * @param path Defaults to `location.pathname` (non-reactive,
    * try `useLocation().pathname` if you need reactivity)
    */
-  static relPath = (path = location.pathname) => path.replace(R_RelPath, "");
+  static relPath = (path = location.pathname) =>
+    path.replace(R_RelPath, "") || "/";
 
   /** Switch to a new instance and redirect the client */
   switchTo = (host: string) =>

--- a/packages/client/components/modal/modals.tsx
+++ b/packages/client/components/modal/modals.tsx
@@ -58,6 +58,7 @@ import { ServerInfoModal } from "./modals/ServerInfo";
 import { SettingsModal } from "./modals/Settings";
 import { SignOutSessionsModal } from "./modals/SignOutSessions";
 import { SignedOutModal } from "./modals/SignedOut";
+import { SwapUserModal } from "./modals/SwapUser";
 import { UserProfileModal } from "./modals/UserProfile";
 import { UserProfileMutualFriendsModal } from "./modals/UserProfileMutualFriends";
 import { UserProfileMutualGroupsModal } from "./modals/UserProfileMutualGroups";
@@ -198,6 +199,9 @@ export function RenderModal(props: ActiveModal & { onClose: () => void }) {
       return <ScreenShareSettingsModal {...modalProps} />;
     case "screen_share_picker":
       return <ScreenSharePickerModal {...modalProps} />;
+    case "swap_user":
+      return <SwapUserModal {...modalProps} />;
+
     default:
       console.error(
         "Failed to create modal for",

--- a/packages/client/components/modal/modals/EditCategory.tsx
+++ b/packages/client/components/modal/modals/EditCategory.tsx
@@ -1,8 +1,7 @@
-import { Trans } from "@lingui/solid/macro";
-
-import { t } from "@lingui/core/macro";
-import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
+import { Trans, useLingui } from "@lingui/solid/macro";
 import { createFormControl, createFormGroup } from "solid-forms";
+
+import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
 import { useModals } from "..";
 import { Modals } from "../types";
 
@@ -12,6 +11,7 @@ import { Modals } from "../types";
 export function EditCategoryModal(
   props: DialogProps & Modals & { type: "edit_category" },
 ) {
+  const { t } = useLingui();
   const { showError } = useModals();
 
   /* eslint-disable solid/reactivity */

--- a/packages/client/components/modal/modals/SwapUser.tsx
+++ b/packages/client/components/modal/modals/SwapUser.tsx
@@ -1,6 +1,6 @@
 import { For, Show } from "solid-js";
 
-import { Trans } from "@lingui-solid/solid/macro";
+import { Trans } from "@lingui/solid/macro";
 
 import { useClientLifecycle } from "@revolt/client";
 import { useState } from "@revolt/state";

--- a/packages/client/components/modal/modals/SwapUser.tsx
+++ b/packages/client/components/modal/modals/SwapUser.tsx
@@ -1,0 +1,44 @@
+import { For, Show } from "solid-js";
+
+import { Trans } from "@lingui-solid/solid/macro";
+
+import { useClientLifecycle } from "@revolt/client";
+import { useState } from "@revolt/state";
+import { Avatar, Dialog, DialogProps, MenuButton } from "@revolt/ui";
+
+import { Modals } from "../types";
+
+export function SwapUserModal(
+  props: DialogProps & Modals & { type: "swap_user" },
+) {
+  const { auth } = useState();
+  const { swapAccount } = useClientLifecycle();
+
+  return (
+    <Dialog
+      show={props.show}
+      onClose={props.onClose}
+      title={<Trans>Choose an account</Trans>}
+      actions={[{ text: <Trans>Close</Trans> }]}
+    >
+      <For each={auth.getSaved()}>
+        {(ses) => (
+          <MenuButton
+            noDrawer
+            icon={
+              <Show when={ses.cachedAvatar}>
+                <Avatar src={ses.cachedAvatar} size={32} />
+              </Show>
+            }
+            onClick={() => {
+              props.onClose();
+              swapAccount(ses.userId);
+            }}
+          >
+            {ses.cachedName || `User ${ses.userId}`}
+          </MenuButton>
+        )}
+      </For>
+    </Dialog>
+  );
+}

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -350,4 +350,7 @@ export type Modals =
   | {
       type: "edit_bot_username";
       bot: Bot;
+    }
+  | {
+      type: "swap_user";
     };

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -153,17 +153,17 @@ export class State {
 
     //Read-only before init
     if (!global && !dbLocal) return;
-    const db = global ? localforage : dbLocal!;
-    key = (db.config().storeName || "") + "|" + key;
+    const db = global ? localforage : dbLocal!,
+      qKey = (db.config().storeName || "") + "|" + key;
 
     // remove existing queued task if it exists
-    if (WriteQueue[key]) clearTimeout(WriteQueue[key]);
+    if (WriteQueue[qKey]) clearTimeout(WriteQueue[qKey]);
 
     // queue for writing to disk
-    WriteQueue[key] = setTimeout(
+    WriteQueue[qKey] = setTimeout(
       () => {
         // remove from write queue
-        delete WriteQueue[key];
+        delete WriteQueue[qKey];
 
         // write the entire key to storage
         db.setItem(

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -48,6 +48,8 @@ const DISK_WRITE_WAIT_MS = 1200;
  */
 const IGNORE_WRITE_DELAY = ["auth"];
 
+const GLOBAL_DB_NAME = "localforage";
+
 /**
  * Global application state
  */
@@ -56,6 +58,8 @@ export class State {
   private store: Store;
   private setStore: SetStoreFunction<Store>;
   private writeQueue: Record<string, number>;
+  private readonly dbGlobal: LocalForage;
+  private db!: LocalForage;
 
   appDrawer;
   setAppDrawer;
@@ -123,6 +127,7 @@ export class State {
    * Construct the global application state
    */
   constructor() {
+    this.dbGlobal = localforage.createInstance({ name: GLOBAL_DB_NAME });
     const [store, setStore] = createStore(this.defaults() as Store);
     this.store = store as never;
     this.setStore = setStore;
@@ -140,12 +145,9 @@ export class State {
   /**
    * Write some data to the store and disk
    */
-  private write: SetStoreFunction<Store> = (...args: unknown[]) => {
+  private write = (key: string, global: boolean, ...args: unknown[]) => {
     // pass the data to the store
-    (this.setStore as (...args: unknown[]) => void)(...args);
-
-    // resolve key
-    const key = args[0] as string;
+    (this.setStore as (...args: unknown[]) => void)(key, ...args);
 
     // touch the key if syncable
     this.sync.touchIfSyncable(key);
@@ -162,7 +164,7 @@ export class State {
         delete this.writeQueue[key];
 
         // write the entire key to storage
-        localforage.setItem(
+        (global ? this.dbGlobal : this.db).setItem(
           key,
           JSON.parse(
             JSON.stringify((this.store as Record<string, unknown>)[key]),
@@ -180,14 +182,12 @@ export class State {
   /**
    * Write data to store / disk and then synchronise it
    */
-  set: SetStoreFunction<Store> = (...args: unknown[]) => {
+  set = (key: string, global: boolean, ...args: unknown[]) => {
     // write to store and storage
-    (this.write as (...args: unknown[]) => void)(...args);
+    this.write(key, global, ...args);
 
     // run side-effects
-    if (import.meta.env.DEV) {
-      console.debug("[store] updated data", args[0]);
-    }
+    if (import.meta.env.DEV) console.debug("[store] updated data", args[0]);
   };
 
   /**
@@ -202,28 +202,43 @@ export class State {
   /**
    * Hydrate the state from disk and run side-effects
    */
-  async hydrate() {
+  async hydrate(global = false) {
+    if (!global) {
+      const ses = this.store.auth.session;
+
+      //If session exists, use session store
+      this.db = ses
+        ? localforage.createInstance({
+            name: `@${ses.userId}`,
+          })
+        : this.dbGlobal;
+
+      //TODO Clear unused localforage instances w/ no session here
+    }
+
     // load all data first
-    for (const store of this.iterStores()) {
-      const data = await localforage.getItem(store.getKey());
+    for (const store of this.iterStores())
+      if (store.global === global) {
+        const data = await (store.global ? this.dbGlobal : this.db).getItem(
+          store.getKey(),
+        );
 
-      if (data) {
-        // validate the incoming data
-        const cleanData = store.clean(data);
+        if (data) {
+          // validate the incoming data
+          const cleanData = store.clean(data);
 
-        if (!equal(data, cleanData)) {
-          // write back to disk if it has changed
-          this.write(store.getKey(), cleanData);
-        } else {
-          this.setStore(store.getKey(), data);
+          if (!equal(data, cleanData)) {
+            // write back to disk if it has changed
+            this.write(store.getKey(), store.global, cleanData);
+          } else {
+            this.setStore(store.getKey(), data);
+          }
         }
       }
-    }
 
     // then run side-effects
-    for (const store of this.iterStores()) {
-      store.hydrate();
-    }
+    for (const store of this.iterStores())
+      if (store.global === global) store.hydrate();
   }
 }
 
@@ -239,7 +254,7 @@ export function StateContext(props: { children: JSX.Element }) {
   const stateLocal = new State();
   const [ready, setReady] = createSignal(false);
 
-  onMount(() => stateLocal.hydrate().then(() => setReady(true)));
+  onMount(() => stateLocal.hydrate(true).then(() => setReady(true)));
 
   return (
     <stateContext.Provider value={stateLocal}>

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -15,6 +15,7 @@ import { createDateNow } from "@solid-primitives/date";
 import equal from "fast-deep-equal";
 import localforage from "localforage";
 
+import { LoadingScreen } from "@revolt/ui";
 import { SlideDrawer } from "@revolt/ui/components/navigation/SlideDrawer";
 
 import { AbstractStore, Store } from "./stores";
@@ -48,6 +49,8 @@ const DISK_WRITE_WAIT_MS = 1200;
  */
 const IGNORE_WRITE_DELAY = ["auth"];
 
+const WriteQueue: Record<string, NodeJS.Timeout> = {};
+
 /**
  * Global application state
  */
@@ -55,7 +58,6 @@ export class State {
   // internal data management
   private store: Store;
   private setStore: SetStoreFunction<Store>;
-  private writeQueue: Record<string, number>;
   private readonly dbGlobal: LocalForage;
   private db?: LocalForage;
 
@@ -129,7 +131,6 @@ export class State {
     const [store, setStore] = createStore(this.defaults() as Store);
     this.store = store as never;
     this.setStore = setStore;
-    this.writeQueue = {};
 
     const [ad, setAd] = createSignal<SlideDrawer>();
     this.appDrawer = ad;
@@ -154,15 +155,13 @@ export class State {
     this.sync.touchIfSyncable(key);
 
     // remove existing queued task if it exists
-    if (this.writeQueue[key]) {
-      clearTimeout(this.writeQueue[key]);
-    }
+    if (WriteQueue[key]) clearTimeout(WriteQueue[key]);
 
     // queue for writing to disk
-    this.writeQueue[key] = setTimeout(
+    WriteQueue[key] = setTimeout(
       () => {
         // remove from write queue
-        delete this.writeQueue[key];
+        delete WriteQueue[key];
 
         // write the entire key to storage
         (global ? this.dbGlobal : db!).setItem(
@@ -175,7 +174,7 @@ export class State {
         if (import.meta.env.DEV) console.info(`[store] Wrote ${key} to disk`);
       },
       IGNORE_WRITE_DELAY.includes(key) ? 0 : DISK_WRITE_WAIT_MS,
-    ) as unknown as number;
+    );
   };
 
   /**
@@ -199,35 +198,30 @@ export class State {
   }
 
   /**
-   * Hydrate the state from disk and run side-effects
+   * Hydrate the state from disk and run side-effects.
+   * Global should only run on init; Local runs whenever session changes
    */
   async hydrate(global = false) {
-    if (!global) {
-      const ses = this.store.auth.session,
-        sesName = ses && `@${ses.userId}`;
-
+    if (global) {
+      //Wait for write queue to finish
+      if (Object.keys(WriteQueue).length)
+        await new Promise<void>((res) => {
+          const tmr = setInterval(() => {
+            if (Object.keys(WriteQueue).length) return;
+            clearInterval(tmr);
+            res();
+          }, 50);
+        });
+    } else {
       //Reset defaults
       if (this.db)
         for (const [key, data] of Object.entries(this.defaults(true)))
           this.setStore(key as keyof Store, data);
 
       //If session exists, use session store
-      this.db = ses && localforage.createInstance({ storeName: sesName });
-
-      //Clear old sessions via some hackery
-      if (ses) {
-        const stores = (this.dbGlobal as { _dbInfo?: { db?: IDBDatabase } })
-          ._dbInfo?.db?.objectStoreNames;
-        if (stores) {
-          const sesNames = this.store.auth.saved.map((s) => `@${s.userId}`);
-          if (sesName) sesNames.push(sesName);
-          for (const key of stores)
-            if (key.indexOf("@") !== -1 && !sesNames.includes(key)) {
-              console.warn(`[store] Deleted unused db ${key}`);
-              await localforage.dropInstance({ storeName: key });
-            }
-        }
-      }
+      const ses = this.store.auth.session;
+      this.db =
+        ses && localforage.createInstance({ storeName: `@${ses.userId}` });
     }
 
     // load all data first
@@ -254,6 +248,23 @@ export class State {
     // then run side-effects
     for (const store of this.iterStores())
       if (store.global === global) store.hydrate();
+
+    //Clear old sessions via some hackery
+    if (global) {
+      const stores = (localforage as { _dbInfo?: { db?: IDBDatabase } })._dbInfo
+        ?.db?.objectStoreNames;
+      if (stores) {
+        const ses = this.store.auth.session,
+          sesNames = [...(ses ? [ses] : []), ...this.store.auth.saved].map(
+            (s) => `@${s.userId}`,
+          );
+        for (const key of stores)
+          if (key.indexOf("@") !== -1 && !sesNames.includes(key)) {
+            console.warn(`[store] Deleted unused db ${key}`);
+            await localforage.dropInstance({ storeName: key });
+          }
+      }
+    }
   }
 }
 
@@ -273,7 +284,9 @@ export function StateContext(props: { children: JSX.Element }) {
 
   return (
     <stateContext.Provider value={stateLocal}>
-      <Show when={ready()}>{props.children}</Show>
+      <Show when={ready()} fallback={<LoadingScreen />}>
+        {props.children}
+      </Show>
     </stateContext.Provider>
   );
 }

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -227,6 +227,9 @@ export class State {
       const ses = this.store.auth.session;
       this.db =
         ses && localforage.createInstance({ storeName: `@${ses.userId}` });
+
+      //Try to enable persistent storage
+      if (ses) navigator.storage?.persist().catch(() => {});
     }
 
     // load all data first

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -49,7 +49,7 @@ const DISK_WRITE_WAIT_MS = 1200;
  */
 const IGNORE_WRITE_DELAY = ["auth"];
 
-const WriteQueue: Record<string, NodeJS.Timeout> = {};
+const WriteQueue = new Map<string, NodeJS.Timeout>();
 
 /**
  * Global application state
@@ -157,25 +157,28 @@ export class State {
       qKey = (db.config().storeName || "") + "|" + key;
 
     // remove existing queued task if it exists
-    if (WriteQueue[qKey]) clearTimeout(WriteQueue[qKey]);
+    clearTimeout(WriteQueue.get(qKey));
 
     // queue for writing to disk
-    WriteQueue[qKey] = setTimeout(
-      () => {
-        // remove from write queue
-        delete WriteQueue[qKey];
+    WriteQueue.set(
+      qKey,
+      setTimeout(
+        () => {
+          // remove from write queue
+          WriteQueue.delete(qKey);
 
-        // write the entire key to storage
-        db.setItem(
-          key,
-          JSON.parse(
-            JSON.stringify((this.store as Record<string, unknown>)[key]),
-          ),
-        );
+          // write the entire key to storage
+          db.setItem(
+            key,
+            JSON.parse(
+              JSON.stringify((this.store as Record<string, unknown>)[key]),
+            ),
+          );
 
-        if (import.meta.env.DEV) console.info(`[store] Wrote ${key} to disk`);
-      },
-      IGNORE_WRITE_DELAY.includes(key) ? 0 : DISK_WRITE_WAIT_MS,
+          if (import.meta.env.DEV) console.info(`[store] Wrote ${key} to disk`);
+        },
+        IGNORE_WRITE_DELAY.includes(key) ? 0 : DISK_WRITE_WAIT_MS,
+      ),
     );
   };
 
@@ -206,10 +209,10 @@ export class State {
   async hydrate(global = false) {
     if (global) {
       //Wait for write queue to finish
-      if (Object.keys(WriteQueue).length)
+      if (WriteQueue.size)
         await new Promise<void>((res) => {
           const tmr = setInterval(() => {
-            if (Object.keys(WriteQueue).length) return;
+            if (WriteQueue.size) return;
             clearInterval(tmr);
             res();
           }, 50);
@@ -279,13 +282,13 @@ const stateContext = createContext<State>(null! as State);
  * Mount state context
  */
 export function StateContext(props: { children: JSX.Element }) {
-  const stateLocal = new State();
+  const state = new State();
   const [ready, setReady] = createSignal(false);
 
-  onMount(() => stateLocal.hydrate(true).then(() => setReady(true)));
+  onMount(() => state.hydrate(true).then(() => setReady(true)));
 
   return (
-    <stateContext.Provider value={stateLocal}>
+    <stateContext.Provider value={state}>
       <Show when={ready()} fallback={<LoadingScreen />}>
         {props.children}
       </Show>

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -58,7 +58,6 @@ export class State {
   // internal data management
   private store: Store;
   private setStore: SetStoreFunction<Store>;
-  private readonly dbGlobal: LocalForage;
   private db?: LocalForage;
 
   appDrawer;
@@ -127,7 +126,6 @@ export class State {
    * Construct the global application state
    */
   constructor() {
-    this.dbGlobal = localforage.createInstance({});
     const [store, setStore] = createStore(this.defaults() as Store);
     this.store = store as never;
     this.setStore = setStore;
@@ -164,7 +162,7 @@ export class State {
         delete WriteQueue[key];
 
         // write the entire key to storage
-        (global ? this.dbGlobal : db!).setItem(
+        (global ? localforage : db!).setItem(
           key,
           JSON.parse(
             JSON.stringify((this.store as Record<string, unknown>)[key]),
@@ -228,7 +226,7 @@ export class State {
     if (global || this.db)
       for (const store of this.iterStores())
         if (store.global === global) {
-          const data = await (store.global ? this.dbGlobal : this.db!).getItem(
+          const data = await (store.global ? localforage : this.db!).getItem(
             store.getKey(),
           );
 

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -143,14 +143,18 @@ export class State {
    * Write some data to the store and disk
    */
   private write = (key: string, global: boolean, ...args: unknown[]) => {
-    const db = this.db; //Cache in case it changes before timeout
-    if (!global && !db) return; //Read-only before init
+    const dbLocal = this.db; //Cache in case it changes before timeout
 
     // pass the data to the store
     (this.setStore as (...args: unknown[]) => void)(key, ...args);
 
     // touch the key if syncable
     this.sync.touchIfSyncable(key);
+
+    //Read-only before init
+    if (!global && !dbLocal) return;
+    const db = global ? localforage : dbLocal!;
+    key = (db.config().storeName || "") + "|" + key;
 
     // remove existing queued task if it exists
     if (WriteQueue[key]) clearTimeout(WriteQueue[key]);
@@ -162,7 +166,7 @@ export class State {
         delete WriteQueue[key];
 
         // write the entire key to storage
-        (global ? localforage : db!).setItem(
+        db.setItem(
           key,
           JSON.parse(
             JSON.stringify((this.store as Record<string, unknown>)[key]),

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -48,8 +48,6 @@ const DISK_WRITE_WAIT_MS = 1200;
  */
 const IGNORE_WRITE_DELAY = ["auth"];
 
-const GLOBAL_DB_NAME = "localforage";
-
 /**
  * Global application state
  */
@@ -59,7 +57,7 @@ export class State {
   private setStore: SetStoreFunction<Store>;
   private writeQueue: Record<string, number>;
   private readonly dbGlobal: LocalForage;
-  private db!: LocalForage;
+  private db?: LocalForage;
 
   appDrawer;
   setAppDrawer;
@@ -113,12 +111,12 @@ export class State {
    * Generate all store defaults / initial store
    * @returns Defaults object
    */
-  private defaults() {
+  private defaults(localOnly = false) {
     const defaults: Partial<Store> = {};
 
-    for (const store of this.iterStores()) {
-      defaults[store.getKey()] = store.default() as never;
-    }
+    for (const store of this.iterStores())
+      if (!localOnly || !store.global)
+        defaults[store.getKey()] = store.default() as never;
 
     return defaults;
   }
@@ -127,7 +125,7 @@ export class State {
    * Construct the global application state
    */
   constructor() {
-    this.dbGlobal = localforage.createInstance({ name: GLOBAL_DB_NAME });
+    this.dbGlobal = localforage.createInstance({});
     const [store, setStore] = createStore(this.defaults() as Store);
     this.store = store as never;
     this.setStore = setStore;
@@ -146,6 +144,9 @@ export class State {
    * Write some data to the store and disk
    */
   private write = (key: string, global: boolean, ...args: unknown[]) => {
+    const db = this.db; //Cache in case it changes before timeout
+    if (!global && !db) return; //Read-only before init
+
     // pass the data to the store
     (this.setStore as (...args: unknown[]) => void)(key, ...args);
 
@@ -164,16 +165,14 @@ export class State {
         delete this.writeQueue[key];
 
         // write the entire key to storage
-        (global ? this.dbGlobal : this.db).setItem(
+        (global ? this.dbGlobal : db!).setItem(
           key,
           JSON.parse(
             JSON.stringify((this.store as Record<string, unknown>)[key]),
           ),
         );
 
-        if (import.meta.env.DEV) {
-          console.info("[store.save] Wrote state to disk.");
-        }
+        if (import.meta.env.DEV) console.info(`[store] Wrote ${key} to disk`);
       },
       IGNORE_WRITE_DELAY.includes(key) ? 0 : DISK_WRITE_WAIT_MS,
     ) as unknown as number;
@@ -204,37 +203,53 @@ export class State {
    */
   async hydrate(global = false) {
     if (!global) {
-      const ses = this.store.auth.session;
+      const ses = this.store.auth.session,
+        sesName = ses && `@${ses.userId}`;
+
+      //Reset defaults
+      if (this.db)
+        for (const [key, data] of Object.entries(this.defaults(true)))
+          this.setStore(key as keyof Store, data);
 
       //If session exists, use session store
-      this.db = ses
-        ? localforage.createInstance({
-            name: `@${ses.userId}`,
-          })
-        : this.dbGlobal;
+      this.db = ses && localforage.createInstance({ storeName: sesName });
 
-      //TODO Clear unused localforage instances w/ no session here
+      //Clear old sessions via some hackery
+      if (ses) {
+        const stores = (this.dbGlobal as { _dbInfo?: { db?: IDBDatabase } })
+          ._dbInfo?.db?.objectStoreNames;
+        if (stores) {
+          const sesNames = this.store.auth.saved.map((s) => `@${s.userId}`);
+          if (sesName) sesNames.push(sesName);
+          for (const key of stores)
+            if (key.indexOf("@") !== -1 && !sesNames.includes(key)) {
+              console.warn(`[store] Deleted unused db ${key}`);
+              await localforage.dropInstance({ storeName: key });
+            }
+        }
+      }
     }
 
     // load all data first
-    for (const store of this.iterStores())
-      if (store.global === global) {
-        const data = await (store.global ? this.dbGlobal : this.db).getItem(
-          store.getKey(),
-        );
+    if (global || this.db)
+      for (const store of this.iterStores())
+        if (store.global === global) {
+          const data = await (store.global ? this.dbGlobal : this.db!).getItem(
+            store.getKey(),
+          );
 
-        if (data) {
-          // validate the incoming data
-          const cleanData = store.clean(data);
+          if (data) {
+            // validate the incoming data
+            const cleanData = store.clean(data);
 
-          if (!equal(data, cleanData)) {
-            // write back to disk if it has changed
-            this.write(store.getKey(), store.global, cleanData);
-          } else {
-            this.setStore(store.getKey(), data);
+            if (!equal(data, cleanData)) {
+              // write back to disk if it has changed
+              this.write(store.getKey(), store.global, cleanData);
+            } else {
+              this.setStore(store.getKey(), data);
+            }
           }
         }
-      }
 
     // then run side-effects
     for (const store of this.iterStores())

--- a/packages/client/components/state/stores/Auth.ts
+++ b/packages/client/components/state/stores/Auth.ts
@@ -1,13 +1,17 @@
-import { CONFIGURATION } from "@revolt/common";
+import { t } from "@lingui/core/macro";
 
-import { State } from "..";
+import { CONFIGURATION } from "@revolt/common";
+import { User } from "stoat.js";
 
 import { AbstractStore } from ".";
+import { State } from "..";
 
 export type Session = {
   _id: string;
   token: string;
   userId: string;
+  cachedName?: string;
+  cachedAvatar?: string;
   valid: boolean;
 };
 
@@ -16,7 +20,32 @@ export type TypeAuth = {
    * Session information
    */
   session?: Session;
+  saved: Array<Session>;
 };
+
+function strOrNone(str?: string) {
+  if (typeof str === "string" && str) return str;
+  return undefined;
+}
+
+function cleanSes(inSes?: Session): Session | undefined {
+  if (
+    typeof inSes === "object" &&
+    typeof inSes._id === "string" &&
+    typeof inSes.token === "string" &&
+    typeof inSes.userId === "string" &&
+    inSes.valid
+  ) {
+    return {
+      _id: inSes._id,
+      token: inSes.token,
+      userId: inSes.userId,
+      cachedName: strOrNone(inSes.cachedName),
+      cachedAvatar: strOrNone(inSes.cachedAvatar),
+      valid: true,
+    };
+  }
+}
 
 /**
  * Authentication details store
@@ -27,7 +56,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
    * @param state State
    */
   constructor(state: State) {
-    super(state, "auth");
+    super(state, "auth", true);
   }
 
   /**
@@ -35,7 +64,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
    */
   hydrate(): void {
     if (CONFIGURATION.DEVELOPMENT_TOKEN && CONFIGURATION.DEVELOPMENT_USER_ID) {
-      this.setSession({
+      this.addSession({
         _id: CONFIGURATION.DEVELOPMENT_SESSION_ID ?? "0",
         token: CONFIGURATION.DEVELOPMENT_TOKEN,
         userId: CONFIGURATION.DEVELOPMENT_USER_ID,
@@ -50,6 +79,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
   default(): TypeAuth {
     return {
       session: undefined,
+      saved: [],
     };
   }
 
@@ -57,49 +87,120 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
    * Validate the given data to see if it is compliant and return a compliant object
    */
   clean(input: Partial<TypeAuth>): TypeAuth {
-    let session;
-    if (typeof input.session === "object") {
-      if (
-        typeof input.session._id === "string" &&
-        typeof input.session.token === "string" &&
-        typeof input.session.userId === "string" &&
-        input.session.valid
-      ) {
-        session = {
-          _id: input.session._id,
-          token: input.session.token,
-          userId: input.session.userId,
-          valid: true,
-        };
+    const saved = [];
+    let ses;
+    if (Array.isArray(input.saved))
+      for (ses of input.saved) {
+        ses = cleanSes(ses);
+        if (ses) saved.push(ses);
       }
-    }
 
     return {
-      session,
+      session: cleanSes(input.session),
+      saved,
+    };
+  }
+
+  #read(): TypeAuth {
+    const data = this.get();
+    return {
+      session: data.session,
+      saved: [...data.saved],
     };
   }
 
   /**
-   * Get current session.
+   * Get current session
+   * @param unhold Try to resume held session if true
    * @returns Session
    */
-  getSession() {
-    return this.get().session;
+  getSession(unhold: boolean = false) {
+    const data = unhold ? this.#read() : this.get();
+    if (unhold && !data.session) {
+      data.session = data.saved.pop();
+      this.set(data);
+    }
+    return data.session;
   }
 
   /**
-   * Add a new session to the auth manager.
+   * Get saved sessions
+   */
+  getSaved() {
+    return this.get().saved;
+  }
+
+  /**
+   * True if there are multiple saved sessions
+   */
+  hasMultiSession() {
+    return this.get().saved.length > 0;
+  }
+
+  /**
+   * Add a new session to the auth manager
    * @param session Session
    */
-  setSession(session: Session) {
-    this.set("session", session);
+  addSession(newSes: Session) {
+    const data = this.#read();
+    if (data.session)
+      throw t`Encountered a problem while saving previous session.`;
+    data.session = newSes;
+    for (const ses of data.saved)
+      if (ses.userId === newSes.userId)
+        throw t`Whoops, you're already logged in as this user!`;
+    this.set(data);
   }
 
   /**
-   * Remove existing session.
+   * Remove existing session
    */
   removeSession() {
-    this.set("session", undefined!);
+    const data = this.#read();
+    data.session = data.saved.pop();
+    this.set(data);
+  }
+
+  /**
+   * Place current session on hold
+   */
+  holdSession() {
+    const data = this.#read();
+    if (!data.session) return;
+    data.saved.push(data.session);
+    data.session = undefined;
+    this.set(data);
+  }
+
+  /**
+   * Switch to a saved session
+   */
+  swapSession(userId: string) {
+    const data = this.#read(),
+      saved = data.saved;
+    for (let i = 0, l = saved.length; i < l; ++i)
+      if (saved[i].userId === userId) {
+        if (data.session) saved.push(data.session);
+        data.session = saved[i];
+        saved.splice(i, 1);
+        this.set(data);
+        return;
+      }
+    throw t`User session not found, try logging in again.`;
+  }
+
+  /**
+   * Cache username and avatar for account switcher
+   */
+  cacheUserInfo(user: User) {
+    const ses = this.get().session;
+    if (!ses) return;
+    this.set(
+      "session",
+      "cachedName",
+      `${user.displayName} (@${user.username}#${user.discriminator})`,
+    );
+    this.set("session", "cachedAvatar", user.avatarURL);
   }
 
   /**

--- a/packages/client/components/state/stores/Auth.ts
+++ b/packages/client/components/state/stores/Auth.ts
@@ -130,6 +130,14 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
   }
 
   /**
+   * Get all sessions, including current and saved
+   */
+  getSessions() {
+    const data = this.get();
+    return [...(data.session ? [data.session] : []), ...data.saved];
+  }
+
+  /**
    * True if there are multiple saved sessions
    */
   hasMultiSession() {
@@ -191,7 +199,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
         return this.set(data);
       }
     const { t } = useLingui();
-    throw t`User session not found, try logging in again.`;
+    throw t`User session not found. Try switching users or logging in again.`;
   }
 
   /**

--- a/packages/client/components/state/stores/Auth.ts
+++ b/packages/client/components/state/stores/Auth.ts
@@ -1,5 +1,4 @@
-import { t } from "@lingui/core/macro";
-
+import { useLingui } from "@lingui-solid/solid/macro";
 import { CONFIGURATION } from "@revolt/common";
 import { User } from "stoat.js";
 
@@ -117,7 +116,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
   getSession(unhold = false) {
     const data = unhold ? this.#read() : this.get();
     if (unhold && !data.session) {
-      data.session = data.saved.pop();
+      data.session = data.saved.shift();
       this.set(data);
     }
     return data.session;
@@ -143,12 +142,16 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
    */
   addSession(newSes: Session) {
     const data = this.#read();
-    if (data.session)
+    if (data.session) {
+      const { t } = useLingui();
       throw t`Encountered a problem while saving previous session.`;
+    }
     data.session = newSes;
     for (const ses of data.saved)
-      if (ses.userId === newSes.userId)
+      if (ses.userId === newSes.userId) {
+        const { t } = useLingui();
         throw t`Whoops, you're already logged in as this user!`;
+      }
     this.set(data);
   }
 
@@ -158,7 +161,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
    */
   removeSession(unhold = false) {
     const data = this.#read();
-    data.session = unhold ? data.saved.pop() : undefined;
+    data.session = unhold ? data.saved.shift() : undefined;
     this.set(data);
   }
 
@@ -168,7 +171,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
   holdSession() {
     const data = this.#read();
     if (!data.session) return;
-    data.saved.push(data.session);
+    data.saved.unshift(data.session);
     data.session = undefined;
     this.set(data);
   }
@@ -181,12 +184,13 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
       saved = data.saved;
     for (let i = 0, l = saved.length; i < l; ++i)
       if (saved[i].userId === userId) {
-        if (data.session) saved.push(data.session);
+        const old = data.session;
         data.session = saved[i];
         saved.splice(i, 1);
-        this.set(data);
-        return;
+        if (old) saved.unshift(old);
+        return this.set(data);
       }
+    const { t } = useLingui();
     throw t`User session not found, try logging in again.`;
   }
 
@@ -194,23 +198,20 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
    * Cache username and avatar for account switcher
    */
   cacheUserInfo(user: User) {
-    const ses = this.get().session;
-    if (!ses) return;
-    this.set(
-      "session",
-      "cachedName",
-      `${user.displayName} (@${user.username}#${user.discriminator})`,
-    );
-    this.set("session", "cachedAvatar", user.avatarURL);
+    const data = this.#read();
+    for (const s of [data.session, ...data.saved])
+      if (s && s.userId === user.id) {
+        s.cachedName = `${user.displayName} (@${user.username}#${user.discriminator})`;
+        s.cachedAvatar = user.avatarURL;
+        return this.set(data);
+      }
   }
 
   /**
    * Mark current session as valid
    */
   markValid() {
-    const session = this.get().session;
-    if (session && !session.valid) {
-      this.set("session", "valid", true);
-    }
+    const ses = this.get().session;
+    if (ses && !ses.valid) this.set("session", "valid", true);
   }
 }

--- a/packages/client/components/state/stores/Auth.ts
+++ b/packages/client/components/state/stores/Auth.ts
@@ -198,7 +198,7 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
    * Cache username and avatar for account switcher
    */
   cacheUserInfo(user: User) {
-    const data = this.#read();
+    const data = JSON.parse(JSON.stringify(this.get()));
     for (const s of [data.session, ...data.saved])
       if (s && s.userId === user.id) {
         s.cachedName = `${user.displayName} (@${user.username}#${user.discriminator})`;

--- a/packages/client/components/state/stores/Auth.ts
+++ b/packages/client/components/state/stores/Auth.ts
@@ -111,10 +111,10 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
 
   /**
    * Get current session
-   * @param unhold Try to resume held session if true
+   * @param unhold Try to resume held session
    * @returns Session
    */
-  getSession(unhold: boolean = false) {
+  getSession(unhold = false) {
     const data = unhold ? this.#read() : this.get();
     if (unhold && !data.session) {
       data.session = data.saved.pop();
@@ -154,10 +154,11 @@ export class Auth extends AbstractStore<"auth", TypeAuth> {
 
   /**
    * Remove existing session
+   * @param unhold Try to resume held session
    */
-  removeSession() {
+  removeSession(unhold = false) {
     const data = this.#read();
-    data.session = data.saved.pop();
+    data.session = unhold ? data.saved.pop() : undefined;
     this.set(data);
   }
 

--- a/packages/client/components/state/stores/Auth.ts
+++ b/packages/client/components/state/stores/Auth.ts
@@ -1,4 +1,4 @@
-import { useLingui } from "@lingui-solid/solid/macro";
+import { useLingui } from "@lingui/solid/macro";
 import { CONFIGURATION } from "@revolt/common";
 import { User } from "stoat.js";
 

--- a/packages/client/components/state/stores/Sync.ts
+++ b/packages/client/components/state/stores/Sync.ts
@@ -177,7 +177,7 @@ export class Sync extends AbstractStore<"sync", TypeSynchronisation> {
       // if ts is newer, hydrate the store with it
       this.set("revision", key, ts);
       this.#blockSync.add(key);
-      this.state.set(key, false, parsed);
+      this.state.set(key, this.global, parsed);
     } else if (ts !== this.ts(key)) {
       // if ts is old, trigger write to synchronise to remote, but only if the data has been updated
       if (

--- a/packages/client/components/state/stores/Sync.ts
+++ b/packages/client/components/state/stores/Sync.ts
@@ -177,7 +177,7 @@ export class Sync extends AbstractStore<"sync", TypeSynchronisation> {
       // if ts is newer, hydrate the store with it
       this.set("revision", key, ts);
       this.#blockSync.add(key);
-      this.state.set(key, parsed);
+      this.state.set(key, false, parsed);
     } else if (ts !== this.ts(key)) {
       // if ts is old, trigger write to synchronise to remote, but only if the data has been updated
       if (

--- a/packages/client/components/state/stores/index.ts
+++ b/packages/client/components/state/stores/index.ts
@@ -43,7 +43,7 @@ export abstract class AbstractStore<T extends keyof Store, D> {
   /**
    * Marker used to determine whether this is a store
    */
-  private readonly _storeHint = true;
+  readonly _storeHint = true;
 
   /**
    * Reference to the current state

--- a/packages/client/components/state/stores/index.ts
+++ b/packages/client/components/state/stores/index.ts
@@ -48,20 +48,23 @@ export abstract class AbstractStore<T extends keyof Store, D> {
   /**
    * Reference to the current state
    */
-  protected readonly state: State;
+  protected readonly state;
 
   /**
    * This store's key
    */
-  private readonly key: T;
+  private readonly key;
+  readonly global;
 
   /**
    * Construct a new store
    * @param state Reference to current state
    * @param key This store's key
+   * @param global Use global data store
    */
-  constructor(state: State, key: T) {
+  constructor(state: State, key: T, global = false) {
     this.state = state;
+    this.global = global;
     this.key = key;
   }
 
@@ -77,10 +80,7 @@ export abstract class AbstractStore<T extends keyof Store, D> {
    * Set some value in this store
    */
   protected set: SetStoreFunction<Store[T]> = (...args: unknown[]) => {
-    (this.state.set as unknown as (...args: unknown[]) => void)(
-      this.key,
-      ...args,
-    );
+    this.state.set(this.key, this.global, ...args);
   };
 
   /**

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -123,8 +123,7 @@ function MountContext(props: { children?: JSX.Element }) {
     <StateContext>
       <KeybindContext>
         <ModalContext>
-          <ClientContext>
-            <LoadTheme />
+          <ClientContext preLoad={<LoadTheme />}>
             <SoundContext>
               <VoiceContext>
                 <QueryClientProvider client={client}>

--- a/packages/client/src/interface/navigation/servers/UserMenu.tsx
+++ b/packages/client/src/interface/navigation/servers/UserMenu.tsx
@@ -27,6 +27,7 @@ import { useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
 import { Avatar, Column, Row, Text, UserStatus, iconSize } from "@revolt/ui";
 
+import MdSwap from "@material-design-icons/svg/outlined/autorenew.svg?component-solid";
 import MdContactPage from "@material-design-icons/svg/outlined/contact_page.svg?component-solid";
 import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
 import MdEditNote from "@material-design-icons/svg/outlined/edit_note.svg?component-solid";
@@ -139,6 +140,14 @@ export function UserMenu(props: Props) {
                   </Column>
                 </Row>
               </ContextMenuItem>
+              <Show when={state.auth.hasMultiSession()}>
+                <ContextMenuButton
+                  icon={MdSwap}
+                  onClick={() => openModal({ type: "swap_user" })}
+                >
+                  <Trans>Switch Accounts</Trans>
+                </ContextMenuButton>
+              </Show>
 
               <ContextMenuDivider />
 

--- a/packages/client/src/pushWorker.ts
+++ b/packages/client/src/pushWorker.ts
@@ -1,0 +1,59 @@
+/// <reference lib="webworker" />
+export {}; //Prevents type error
+
+declare let self: ServiceWorkerGlobalScope;
+
+interface ChannelPartial {
+  channel_type: string;
+  name?: string;
+}
+
+interface StoatPushNotification {
+  title?: string;
+  author?: string;
+  body: string;
+  icon?: string;
+  channel?: ChannelPartial;
+  url?: string;
+}
+
+const scope = new URL(self.registration.scope),
+  root = scope.origin,
+  userId = scope.search.slice(2);
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  if (typeof event.notification.data === "string") {
+    event.waitUntil(self.clients.openWindow(event.notification.data));
+  }
+});
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+  const payload = event.data.text();
+  const notification: StoatPushNotification = JSON.parse(payload);
+
+  if (!notification.title) {
+    if (notification.channel) {
+      if (notification.channel.channel_type === "DirectMessage") {
+        notification.title = notification.author || "Stoat";
+      } else {
+        notification.title = `${notification.author} in ${notification.channel.name}`;
+      }
+    } else {
+      notification.title = "Stoat";
+    }
+  }
+
+  //Redirect instance URL
+  const url = notification.url && new URL(notification.url);
+  notification.url = `${root}${url ? `/i/${url.host}${url.pathname}` : ""}#uid=${userId}`;
+
+  event.waitUntil(
+    self.registration.showNotification(notification.title || "Stoat", {
+      icon: notification.icon,
+      body: notification.body,
+      data: notification.url,
+    }),
+  );
+});

--- a/packages/client/src/serviceWorker.ts
+++ b/packages/client/src/serviceWorker.ts
@@ -3,58 +3,8 @@ import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
 
 declare let self: ServiceWorkerGlobalScope;
 
-interface ChannelPartial {
-  channel_type: string;
-  name?: string;
-}
-
-interface StoatPushNotification {
-  title?: string;
-  author?: string;
-  body: string;
-  icon?: string;
-  channel?: ChannelPartial;
-  url?: string;
-}
-
 self.addEventListener("message", (event) => {
   if (event.data && event.data.type === "SKIP_WAITING") self.skipWaiting();
-});
-
-self.addEventListener("notificationclick", (event) => {
-  event.notification.close();
-  if (typeof event.notification.data === "string") {
-    event.waitUntil(self.clients.openWindow(event.notification.data));
-  }
-});
-
-self.addEventListener("push", (event) => {
-  if (!event.data) return;
-  const payload = event.data.text();
-
-  const notification: StoatPushNotification = JSON.parse(payload);
-
-  if (!notification.title) {
-    if (notification.channel) {
-      if (notification.channel.channel_type === "DirectMessage") {
-        notification.title = notification.author || "Stoat";
-      } else {
-        notification.title = `${notification.author} in ${notification.channel.name}`;
-      }
-    } else {
-      notification.title = "Stoat";
-    }
-  }
-
-  notification.url ||= self.registration.scope;
-
-  event.waitUntil(
-    self.registration.showNotification(notification.title || "Stoat", {
-      icon: notification.icon,
-      body: notification.body,
-      data: notification.url,
-    }),
-  );
 });
 
 cleanupOutdatedCaches();


### PR DESCRIPTION
**NOTE:** Probably will delete this, couldn't get it to work consistently, so I'm just going with a brute-force 'make a backup of auth in localStorage which isn't subject to mobile device cache clears' approach instead.

Prerequisites:

- \#1217 (Due to extensive state/store changes)

Originally I thought this was an issue with the state changes in multiuser, but it turns out that Android just clears IndexedDB whenever your disk space is low (mine is lol) as, unlike LocalStorage, which is considered persistent by default, it considers IndexedDB to be "cache" storage and auto-clears it. Need to check if there are any other implications to requesting this permission, eg. not clearing the file cache/other caches in the PWA (very bad!)

- `main` <!-- branch-stack -->
  - \#1477 :point\_left:
