### PR TITLE
chore: Update solidjs to 1.9.14

### DIFF
--- a/packages/client/components/ui/components/design/Avatar.tsx
+++ b/packages/client/components/ui/components/design/Avatar.tsx
@@ -118,7 +118,6 @@ const FallbackBase = styled("div", {
 export function Avatar(props: Props) {
   return (
     <ParentBase
-      // @ts-expect-error not typed for some reason
       slot={props.slot}
       style={{
         width: props.size + "px",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -139,7 +139,7 @@
     "solid-forms": "^0.5.2",
     "solid-hcaptcha": "^0.4.0",
     "solid-icons": "^1.1.0",
-    "solid-js": "^1.9.6",
+    "solid-js": "^1.9.14",
     "solid-livekit-components": "workspace:^",
     "solid-motionone": "^1.0.4",
     "solid-qr-code": "^0.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 6.38.6
       '@dschz/solid-auto-sizer':
         specifier: ^0.1.3
-        version: 0.1.3(solid-js@1.9.6)
+        version: 0.1.3(solid-js@1.9.14)
       '@floating-ui/dom':
         specifier: ^1.7.0
         version: 1.7.0
@@ -139,7 +139,7 @@ importers:
         version: 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(babel-plugin-macros@3.1.0)
       '@lingui/solid':
         specifier: ^6.6.0
-        version: 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(babel-plugin-macros@3.1.0)(solid-js@1.9.6)
+        version: 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(babel-plugin-macros@3.1.0)(solid-js@1.9.14)
       '@livekit/components-core':
         specifier: ^0.12.14
         version: 0.12.14(livekit-client@2.20.2(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
@@ -157,7 +157,7 @@ importers:
         version: 2.3.0
       '@minht11/solid-virtual-container':
         specifier: ^0.2.1
-        version: 0.2.1(solid-js@1.9.6)
+        version: 0.2.1(solid-js@1.9.14)
       '@panzoom/panzoom':
         specifier: ^4.6.0
         version: 4.6.0
@@ -166,46 +166,46 @@ importers:
         version: 8.55.0
       '@solid-aria/button':
         specifier: ^0.1.3
-        version: 0.1.3(solid-js@1.9.6)
+        version: 0.1.3(solid-js@1.9.14)
       '@solid-devtools/debugger':
         specifier: ^0.23.4
-        version: 0.23.4(solid-js@1.9.6)
+        version: 0.23.4(solid-js@1.9.14)
       '@solid-devtools/overlay':
         specifier: ^0.30.1
-        version: 0.30.1(solid-js@1.9.6)
+        version: 0.30.1(solid-js@1.9.14)
       '@solid-primitives/date':
         specifier: ^2.1.6
-        version: 2.1.6(solid-js@1.9.6)
+        version: 2.1.6(solid-js@1.9.14)
       '@solid-primitives/i18n':
         specifier: ^2.2.1
-        version: 2.2.1(solid-js@1.9.6)
+        version: 2.2.1(solid-js@1.9.14)
       '@solid-primitives/keyed':
         specifier: ^1.5.1
-        version: 1.5.2(solid-js@1.9.6)
+        version: 1.5.2(solid-js@1.9.14)
       '@solid-primitives/map':
         specifier: ^0.7.1
-        version: 0.7.1(solid-js@1.9.6)
+        version: 0.7.1(solid-js@1.9.14)
       '@solid-primitives/resize-observer':
         specifier: 2.1.1
-        version: 2.1.1(solid-js@1.9.6)
+        version: 2.1.1(solid-js@1.9.14)
       '@solid-primitives/set':
         specifier: ^0.7.1
-        version: 0.7.1(solid-js@1.9.6)
+        version: 0.7.1(solid-js@1.9.14)
       '@solidjs/router':
         specifier: ^0.15.3
-        version: 0.15.3(solid-js@1.9.6)
+        version: 0.15.3(solid-js@1.9.14)
       '@stripe/stripe-js':
         specifier: ^7.3.1
         version: 7.3.1
       '@tanstack/solid-query':
         specifier: ^5.76.0
-        version: 5.76.0(solid-js@1.9.6)
+        version: 5.76.0(solid-js@1.9.14)
       '@tauri-apps/api':
         specifier: ^2.5.0
         version: 2.5.0
       '@thisbeyond/solid-dnd':
         specifier: ^0.7.5
-        version: 0.7.5(solid-js@1.9.6)
+        version: 0.7.5(solid-js@1.9.14)
       color-rgba:
         specifier: ^3.0.0
         version: 3.0.0
@@ -331,34 +331,34 @@ importers:
         version: 1.29.2
       solid-dnd-directive:
         specifier: ^0.2.0
-        version: 0.2.0(solid-js@1.9.6)
+        version: 0.2.0(solid-js@1.9.14)
       solid-floating-ui:
         specifier: ^0.3.1
-        version: 0.3.1(@floating-ui/dom@1.7.0)(solid-js@1.9.6)
+        version: 0.3.1(@floating-ui/dom@1.7.0)(solid-js@1.9.14)
       solid-forms:
         specifier: ^0.5.2
-        version: 0.5.2(solid-js@1.9.6)
+        version: 0.5.2(solid-js@1.9.14)
       solid-hcaptcha:
         specifier: ^0.4.0
-        version: 0.4.0(solid-js@1.9.6)
+        version: 0.4.0(solid-js@1.9.14)
       solid-icons:
         specifier: ^1.1.0
-        version: 1.1.0(solid-js@1.9.6)
+        version: 1.1.0(solid-js@1.9.14)
       solid-js:
-        specifier: ^1.9.6
-        version: 1.9.6
+        specifier: ^1.9.14
+        version: 1.9.14
       solid-livekit-components:
         specifier: workspace:^
         version: link:../solid-livekit-components
       solid-motionone:
         specifier: ^1.0.4
-        version: 1.0.4(solid-js@1.9.6)
+        version: 1.0.4(solid-js@1.9.14)
       solid-qr-code:
         specifier: ^0.1.11
-        version: 0.1.11(solid-js@1.9.6)
+        version: 0.1.11(solid-js@1.9.14)
       solid-stripe:
         specifier: ^0.7.5
-        version: 0.7.5(@stripe/stripe-js@7.3.1)(solid-js@1.9.6)
+        version: 0.7.5(@stripe/stripe-js@7.3.1)(solid-js@1.9.14)
       space-separated-tokens:
         specifier: ^2.0.2
         version: 2.0.2
@@ -419,7 +419,7 @@ importers:
         version: 1.60.0
       '@solid-devtools/transform':
         specifier: ^0.10.4
-        version: 0.10.4(solid-js@1.9.6)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))
+        version: 0.10.4(solid-js@1.9.14)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -470,10 +470,10 @@ importers:
         version: 1.3.0(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.3.0)
       vite-plugin-solid:
         specifier: ^2.11.14
-        version: 2.11.14(solid-js@1.9.6)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))
+        version: 2.11.14(solid-js@1.9.14)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))
       vite-plugin-solid-svg:
         specifier: ^0.8.1
-        version: 0.8.1(solid-js@1.9.6)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))
+        version: 0.8.1(solid-js@1.9.14)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))
 
   packages/solid-livekit-components:
     dependencies:
@@ -8068,9 +8068,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
-  '@dschz/solid-auto-sizer@0.1.3(solid-js@1.9.6)':
+  '@dschz/solid-auto-sizer@0.1.3(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
@@ -8803,12 +8803,12 @@ snapshots:
       '@messageformat/parser': 5.1.1
       js-sha256: 0.10.1
 
-  '@lingui/solid@6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(babel-plugin-macros@3.1.0)(solid-js@1.9.6)':
+  '@lingui/solid@6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(babel-plugin-macros@3.1.0)(solid-js@1.9.14)':
     dependencies:
       '@lingui/babel-plugin-lingui-macro': 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)
       '@lingui/conf': 6.6.0
       '@lingui/core': 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(babel-plugin-macros@3.1.0)
-      solid-js: 1.9.6
+      solid-js: 1.9.14
     optionalDependencies:
       babel-plugin-macros: 3.1.0
     transitivePeerDependencies:
@@ -8884,9 +8884,9 @@ snapshots:
     dependencies:
       moo: 0.5.2
 
-  '@minht11/solid-virtual-container@0.2.1(solid-js@1.9.6)':
+  '@minht11/solid-virtual-container@0.2.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   '@modelcontextprotocol/sdk@1.11.2':
     dependencies:
@@ -9332,434 +9332,446 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@solid-aria/button@0.1.3(solid-js@1.9.6)':
+  '@solid-aria/button@0.1.3(solid-js@1.9.14)':
     dependencies:
-      '@solid-aria/focus': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/interactions': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/toggle': 0.1.3(solid-js@1.9.6)
-      '@solid-aria/types': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/utils': 0.2.1(solid-js@1.9.6)
-      '@solid-primitives/props': 2.2.2(solid-js@1.9.6)
-      '@solid-primitives/utils': 2.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-aria/focus': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/interactions': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/toggle': 0.1.3(solid-js@1.9.14)
+      '@solid-aria/types': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/utils': 0.2.1(solid-js@1.9.14)
+      '@solid-primitives/props': 2.2.2(solid-js@1.9.14)
+      '@solid-primitives/utils': 2.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-aria/focus@0.1.4(solid-js@1.9.6)':
+  '@solid-aria/focus@0.1.4(solid-js@1.9.14)':
     dependencies:
-      '@solid-aria/interactions': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/types': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/utils': 0.2.1(solid-js@1.9.6)
-      '@solid-primitives/props': 2.2.2(solid-js@1.9.6)
-      '@solid-primitives/utils': 2.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-aria/interactions': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/types': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/utils': 0.2.1(solid-js@1.9.14)
+      '@solid-primitives/props': 2.2.2(solid-js@1.9.14)
+      '@solid-primitives/utils': 2.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-aria/interactions@0.1.4(solid-js@1.9.6)':
+  '@solid-aria/interactions@0.1.4(solid-js@1.9.14)':
     dependencies:
-      '@solid-aria/types': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/utils': 0.2.1(solid-js@1.9.6)
-      '@solid-primitives/platform': 0.0.100(solid-js@1.9.6)
-      '@solid-primitives/props': 2.2.2(solid-js@1.9.6)
-      '@solid-primitives/utils': 2.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-aria/types': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/utils': 0.2.1(solid-js@1.9.14)
+      '@solid-primitives/platform': 0.0.100(solid-js@1.9.14)
+      '@solid-primitives/props': 2.2.2(solid-js@1.9.14)
+      '@solid-primitives/utils': 2.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-aria/toggle@0.1.3(solid-js@1.9.6)':
+  '@solid-aria/toggle@0.1.3(solid-js@1.9.14)':
     dependencies:
-      '@solid-aria/focus': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/interactions': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/types': 0.1.4(solid-js@1.9.6)
-      '@solid-aria/utils': 0.2.1(solid-js@1.9.6)
-      '@solid-primitives/props': 2.2.2(solid-js@1.9.6)
-      '@solid-primitives/utils': 2.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-aria/focus': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/interactions': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/types': 0.1.4(solid-js@1.9.14)
+      '@solid-aria/utils': 0.2.1(solid-js@1.9.14)
+      '@solid-primitives/props': 2.2.2(solid-js@1.9.14)
+      '@solid-primitives/utils': 2.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-aria/types@0.1.4(solid-js@1.9.6)':
+  '@solid-aria/types@0.1.4(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 2.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 2.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-aria/utils@0.2.1(solid-js@1.9.6)':
+  '@solid-aria/utils@0.2.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-aria/types': 0.1.4(solid-js@1.9.6)
-      '@solid-primitives/utils': 2.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-aria/types': 0.1.4(solid-js@1.9.14)
+      '@solid-primitives/utils': 2.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-devtools/debugger@0.18.1(solid-js@1.9.6)':
+  '@solid-devtools/debugger@0.18.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-devtools/shared': 0.10.6(solid-js@1.9.6)
-      '@solid-primitives/bounds': 0.0.105(solid-js@1.9.6)
-      '@solid-primitives/cursor': 0.0.103(solid-js@1.9.6)
-      '@solid-primitives/event-bus': 0.1.6(solid-js@1.9.6)
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/keyboard': 1.3.1(solid-js@1.9.6)
-      '@solid-primitives/platform': 0.0.102(solid-js@1.9.6)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.6)
-      '@solid-primitives/utils': 4.0.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-devtools/shared': 0.10.6(solid-js@1.9.14)
+      '@solid-primitives/bounds': 0.0.105(solid-js@1.9.14)
+      '@solid-primitives/cursor': 0.0.103(solid-js@1.9.14)
+      '@solid-primitives/event-bus': 0.1.6(solid-js@1.9.14)
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/keyboard': 1.3.1(solid-js@1.9.14)
+      '@solid-primitives/platform': 0.0.102(solid-js@1.9.14)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.14)
+      '@solid-primitives/utils': 4.0.1(solid-js@1.9.14)
+      solid-js: 1.9.14
       type-fest: 3.13.1
 
-  '@solid-devtools/debugger@0.23.4(solid-js@1.9.6)':
+  '@solid-devtools/debugger@0.23.4(solid-js@1.9.14)':
     dependencies:
       '@nothing-but/utils': 0.12.1
-      '@solid-devtools/shared': 0.13.2(solid-js@1.9.6)
-      '@solid-primitives/bounds': 0.0.118(solid-js@1.9.6)
-      '@solid-primitives/cursor': 0.0.112(solid-js@1.9.6)
-      '@solid-primitives/event-bus': 1.1.1(solid-js@1.9.6)
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/keyboard': 1.3.1(solid-js@1.9.6)
-      '@solid-primitives/platform': 0.1.2(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/scheduled': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-devtools/shared': 0.13.2(solid-js@1.9.14)
+      '@solid-primitives/bounds': 0.0.118(solid-js@1.9.14)
+      '@solid-primitives/cursor': 0.0.112(solid-js@1.9.14)
+      '@solid-primitives/event-bus': 1.1.1(solid-js@1.9.14)
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/keyboard': 1.3.1(solid-js@1.9.14)
+      '@solid-primitives/platform': 0.1.2(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/scheduled': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-devtools/frontend@0.11.5(solid-js@1.9.6)':
+  '@solid-devtools/frontend@0.11.5(solid-js@1.9.14)':
     dependencies:
       '@nothing-but/utils': 0.12.1
-      '@solid-devtools/debugger': 0.23.4(solid-js@1.9.6)
-      '@solid-devtools/shared': 0.13.2(solid-js@1.9.6)
+      '@solid-devtools/debugger': 0.23.4(solid-js@1.9.14)
+      '@solid-devtools/shared': 0.13.2(solid-js@1.9.14)
       '@solid-devtools/theme': 0.0.1
-      '@solid-primitives/context': 0.2.3(solid-js@1.9.6)
-      '@solid-primitives/cursor': 0.0.112(solid-js@1.9.6)
-      '@solid-primitives/date': 2.1.6(solid-js@1.9.6)
-      '@solid-primitives/event-bus': 1.1.1(solid-js@1.9.6)
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/jsx-tokenizer': 1.1.1(solid-js@1.9.6)
-      '@solid-primitives/keyboard': 1.3.1(solid-js@1.9.6)
-      '@solid-primitives/keyed': 1.5.2(solid-js@1.9.6)
-      '@solid-primitives/media': 2.3.1(solid-js@1.9.6)
-      '@solid-primitives/mouse': 2.1.2(solid-js@1.9.6)
-      '@solid-primitives/props': 3.2.1(solid-js@1.9.6)
-      '@solid-primitives/range': 0.1.18(solid-js@1.9.6)
-      '@solid-primitives/resize-observer': 2.1.1(solid-js@1.9.6)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.6)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.6)
-      '@solid-primitives/styles': 0.0.111(solid-js@1.9.6)
-      '@solid-primitives/timer': 1.4.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
+      '@solid-primitives/context': 0.2.3(solid-js@1.9.14)
+      '@solid-primitives/cursor': 0.0.112(solid-js@1.9.14)
+      '@solid-primitives/date': 2.1.6(solid-js@1.9.14)
+      '@solid-primitives/event-bus': 1.1.1(solid-js@1.9.14)
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/jsx-tokenizer': 1.1.1(solid-js@1.9.14)
+      '@solid-primitives/keyboard': 1.3.1(solid-js@1.9.14)
+      '@solid-primitives/keyed': 1.5.2(solid-js@1.9.14)
+      '@solid-primitives/media': 2.3.1(solid-js@1.9.14)
+      '@solid-primitives/mouse': 2.1.2(solid-js@1.9.14)
+      '@solid-primitives/props': 3.2.1(solid-js@1.9.14)
+      '@solid-primitives/range': 0.1.18(solid-js@1.9.14)
+      '@solid-primitives/resize-observer': 2.1.1(solid-js@1.9.14)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.14)
+      '@solid-primitives/styles': 0.0.111(solid-js@1.9.14)
+      '@solid-primitives/timer': 1.4.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
       clsx: 2.1.1
-      solid-headless: 0.13.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      solid-headless: 0.13.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-devtools/overlay@0.30.1(solid-js@1.9.6)':
+  '@solid-devtools/overlay@0.30.1(solid-js@1.9.14)':
     dependencies:
       '@nothing-but/utils': 0.12.1
-      '@solid-devtools/debugger': 0.23.4(solid-js@1.9.6)
-      '@solid-devtools/frontend': 0.11.5(solid-js@1.9.6)
-      '@solid-devtools/shared': 0.13.2(solid-js@1.9.6)
-      '@solid-primitives/cursor': 0.0.112(solid-js@1.9.6)
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/media': 2.3.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-devtools/debugger': 0.23.4(solid-js@1.9.14)
+      '@solid-devtools/frontend': 0.11.5(solid-js@1.9.14)
+      '@solid-devtools/shared': 0.13.2(solid-js@1.9.14)
+      '@solid-primitives/cursor': 0.0.112(solid-js@1.9.14)
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/media': 2.3.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-devtools/shared@0.10.6(solid-js@1.9.6)':
+  '@solid-devtools/shared@0.10.6(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-bus': 0.1.6(solid-js@1.9.6)
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/media': 2.3.1(solid-js@1.9.6)
-      '@solid-primitives/refs': 0.3.7(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.6)
-      '@solid-primitives/styles': 0.0.101(solid-js@1.9.6)
-      '@solid-primitives/utils': 4.0.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-bus': 0.1.6(solid-js@1.9.14)
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/media': 2.3.1(solid-js@1.9.14)
+      '@solid-primitives/refs': 0.3.7(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.14)
+      '@solid-primitives/styles': 0.0.101(solid-js@1.9.14)
+      '@solid-primitives/utils': 4.0.1(solid-js@1.9.14)
+      solid-js: 1.9.14
       type-fest: 3.13.1
 
-  '@solid-devtools/shared@0.13.2(solid-js@1.9.6)':
+  '@solid-devtools/shared@0.13.2(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-bus': 1.1.1(solid-js@1.9.6)
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/media': 2.3.1(solid-js@1.9.6)
-      '@solid-primitives/refs': 1.1.1(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.6)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.6)
-      '@solid-primitives/styles': 0.0.111(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-bus': 1.1.1(solid-js@1.9.14)
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/media': 2.3.1(solid-js@1.9.14)
+      '@solid-primitives/refs': 1.1.1(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.14)
+      '@solid-primitives/styles': 0.0.111(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
   '@solid-devtools/theme@0.0.1':
     dependencies:
       '@nothing-but/utils': 0.12.1
 
-  '@solid-devtools/transform@0.10.4(solid-js@1.9.6)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))':
+  '@solid-devtools/transform@0.10.4(solid-js@1.9.14)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.1)
       '@babel/types': 7.27.1
-      '@solid-devtools/debugger': 0.18.1(solid-js@1.9.6)
-      '@solid-devtools/shared': 0.10.6(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-devtools/debugger': 0.18.1(solid-js@1.9.14)
+      '@solid-devtools/shared': 0.10.6(solid-js@1.9.14)
+      solid-js: 1.9.14
       vite: 6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@solid-primitives/bounds@0.0.105(solid-js@1.9.6)':
+  '@solid-primitives/bounds@0.0.105(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/resize-observer': 2.1.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 4.0.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/resize-observer': 2.1.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 4.0.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/bounds@0.0.118(solid-js@1.9.6)':
+  '@solid-primitives/bounds@0.0.118(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/resize-observer': 2.1.1(solid-js@1.9.6)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/resize-observer': 2.1.1(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/context@0.2.3(solid-js@1.9.6)':
+  '@solid-primitives/context@0.2.3(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/cursor@0.0.103(solid-js@1.9.6)':
+  '@solid-primitives/cursor@0.0.103(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 4.0.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 4.0.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/cursor@0.0.112(solid-js@1.9.6)':
+  '@solid-primitives/cursor@0.0.112(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/date@2.1.6(solid-js@1.9.6)':
+  '@solid-primitives/date@2.1.6(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/memo': 1.4.5(solid-js@1.9.6)
-      '@solid-primitives/timer': 1.4.4(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/memo': 1.4.5(solid-js@1.9.14)
+      '@solid-primitives/timer': 1.4.4(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/event-bus@0.1.6(solid-js@1.9.6)':
+  '@solid-primitives/event-bus@0.1.6(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/immutable': 0.1.10(solid-js@1.9.6)
-      '@solid-primitives/utils': 5.5.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/immutable': 0.1.10(solid-js@1.9.14)
+      '@solid-primitives/utils': 5.5.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/event-bus@1.1.1(solid-js@1.9.6)':
+  '@solid-primitives/event-bus@1.1.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/event-listener@2.4.1(solid-js@1.9.6)':
+  '@solid-primitives/event-listener@2.4.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/i18n@2.2.1(solid-js@1.9.6)':
+  '@solid-primitives/i18n@2.2.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/immutable@0.1.10(solid-js@1.9.6)':
+  '@solid-primitives/immutable@0.1.10(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
   '@solid-primitives/intersection-observer@2.2.2(solid-js@1.9.6)':
     dependencies:
       '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
       solid-js: 1.9.6
 
-  '@solid-primitives/jsx-tokenizer@1.1.1(solid-js@1.9.6)':
+  '@solid-primitives/jsx-tokenizer@1.1.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/keyboard@1.3.1(solid-js@1.9.6)':
+  '@solid-primitives/keyboard@1.3.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
+
+  '@solid-primitives/keyed@1.5.2(solid-js@1.9.14)':
+    dependencies:
+      solid-js: 1.9.14
 
   '@solid-primitives/keyed@1.5.2(solid-js@1.9.6)':
     dependencies:
       solid-js: 1.9.6
 
-  '@solid-primitives/map@0.7.1(solid-js@1.9.6)':
+  '@solid-primitives/map@0.7.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/trigger': 1.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/trigger': 1.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
   '@solid-primitives/map@0.7.4(solid-js@1.9.14)':
     dependencies:
       '@solid-primitives/trigger': 1.2.4(solid-js@1.9.14)
       solid-js: 1.9.14
 
-  '@solid-primitives/media@2.3.1(solid-js@1.9.6)':
+  '@solid-primitives/media@2.3.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/static-store': 0.1.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.1.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/memo@1.4.5(solid-js@1.9.6)':
+  '@solid-primitives/memo@1.4.5(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/mouse@2.1.2(solid-js@1.9.6)':
+  '@solid-primitives/mouse@2.1.2(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/static-store': 0.1.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.1.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/platform@0.0.100(solid-js@1.9.6)':
+  '@solid-primitives/platform@0.0.100(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/platform@0.0.102(solid-js@1.9.6)':
+  '@solid-primitives/platform@0.0.102(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/platform@0.1.2(solid-js@1.9.6)':
+  '@solid-primitives/platform@0.1.2(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/props@2.2.2(solid-js@1.9.6)':
+  '@solid-primitives/props@2.2.2(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 3.1.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 3.1.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/props@3.2.1(solid-js@1.9.6)':
+  '@solid-primitives/props@3.2.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/range@0.1.18(solid-js@1.9.6)':
+  '@solid-primitives/range@0.1.18(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/refs@0.3.7(solid-js@1.9.6)':
+  '@solid-primitives/refs@0.3.7(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/immutable': 0.1.10(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 5.5.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/immutable': 0.1.10(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 5.5.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/refs@1.1.1(solid-js@1.9.6)':
+  '@solid-primitives/refs@1.1.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/resize-observer@2.1.1(solid-js@1.9.6)':
+  '@solid-primitives/resize-observer@2.1.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.6)
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/static-store': 0.1.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/event-listener': 2.4.1(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.1.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/rootless@1.5.1(solid-js@1.9.6)':
+  '@solid-primitives/rootless@1.5.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/scheduled@1.5.1(solid-js@1.9.6)':
+  '@solid-primitives/scheduled@1.5.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
+
+  '@solid-primitives/scheduled@1.5.3(solid-js@1.9.14)':
+    dependencies:
+      solid-js: 1.9.14
 
   '@solid-primitives/scheduled@1.5.3(solid-js@1.9.6)':
     dependencies:
       solid-js: 1.9.6
 
-  '@solid-primitives/script-loader@2.3.1(solid-js@1.9.6)':
+  '@solid-primitives/script-loader@2.3.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/set@0.7.1(solid-js@1.9.6)':
+  '@solid-primitives/set@0.7.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/trigger': 1.2.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/trigger': 1.2.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
   '@solid-primitives/set@0.7.4(solid-js@1.9.14)':
     dependencies:
       '@solid-primitives/trigger': 1.2.4(solid-js@1.9.14)
       solid-js: 1.9.14
 
-  '@solid-primitives/static-store@0.0.5(solid-js@1.9.6)':
+  '@solid-primitives/static-store@0.0.5(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/static-store@0.1.1(solid-js@1.9.6)':
+  '@solid-primitives/static-store@0.1.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/styles@0.0.101(solid-js@1.9.6)':
+  '@solid-primitives/styles@0.0.101(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/styles@0.0.111(solid-js@1.9.6)':
+  '@solid-primitives/styles@0.0.111(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.6)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/rootless': 1.5.1(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/timer@1.4.1(solid-js@1.9.6)':
+  '@solid-primitives/timer@1.4.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/timer@1.4.4(solid-js@1.9.6)':
+  '@solid-primitives/timer@1.4.4(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/transition-group@1.1.1(solid-js@1.9.6)':
+  '@solid-primitives/transition-group@1.1.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/trigger@1.2.1(solid-js@1.9.6)':
+  '@solid-primitives/trigger@1.2.1(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
   '@solid-primitives/trigger@1.2.4(solid-js@1.9.14)':
     dependencies:
       '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
       solid-js: 1.9.14
 
-  '@solid-primitives/utils@2.2.1(solid-js@1.9.6)':
+  '@solid-primitives/utils@2.2.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/utils@3.1.0(solid-js@1.9.6)':
+  '@solid-primitives/utils@3.1.0(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/utils@4.0.1(solid-js@1.9.6)':
+  '@solid-primitives/utils@4.0.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/utils@5.5.2(solid-js@1.9.6)':
+  '@solid-primitives/utils@5.5.2(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  '@solid-primitives/utils@6.3.1(solid-js@1.9.6)':
+  '@solid-primitives/utils@6.3.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
+
+  '@solid-primitives/utils@6.3.2(solid-js@1.9.14)':
+    dependencies:
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@6.3.2(solid-js@1.9.6)':
     dependencies:
       solid-js: 1.9.6
 
-  '@solid-primitives/utils@6.4.0(solid-js@1.9.6)':
+  '@solid-primitives/utils@6.4.0(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@6.4.1(solid-js@1.9.14)':
     dependencies:
       solid-js: 1.9.14
 
-  '@solidjs/router@0.15.3(solid-js@1.9.6)':
+  '@solidjs/router@0.15.3(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   '@stripe/stripe-js@7.3.1': {}
 
@@ -9772,16 +9784,16 @@ snapshots:
 
   '@tanstack/query-core@5.76.0': {}
 
-  '@tanstack/solid-query@5.76.0(solid-js@1.9.6)':
+  '@tanstack/solid-query@5.76.0(solid-js@1.9.14)':
     dependencies:
       '@tanstack/query-core': 5.76.0
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   '@tauri-apps/api@2.5.0': {}
 
-  '@thisbeyond/solid-dnd@0.7.5(solid-js@1.9.6)':
+  '@thisbeyond/solid-dnd@0.7.5(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   '@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.25)(prettier@3.8.1)':
     dependencies:
@@ -13530,35 +13542,35 @@ snapshots:
 
   smob@1.6.2: {}
 
-  solid-dnd-directive@0.2.0(solid-js@1.9.6):
+  solid-dnd-directive@0.2.0(solid-js@1.9.14):
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
       svelte-dnd-action: 0.9.11
 
-  solid-floating-ui@0.3.1(@floating-ui/dom@1.7.0)(solid-js@1.9.6):
+  solid-floating-ui@0.3.1(@floating-ui/dom@1.7.0)(solid-js@1.9.14):
     dependencies:
       '@floating-ui/dom': 1.7.0
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  solid-forms@0.5.2(solid-js@1.9.6):
+  solid-forms@0.5.2(solid-js@1.9.14):
     dependencies:
       fast-deep-equal: 3.1.3
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  solid-hcaptcha@0.4.0(solid-js@1.9.6):
+  solid-hcaptcha@0.4.0(solid-js@1.9.14):
     dependencies:
       '@hcaptcha/types': 1.0.4
-      '@solid-primitives/script-loader': 2.3.1(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/script-loader': 2.3.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  solid-headless@0.13.1(solid-js@1.9.6):
+  solid-headless@0.13.1(solid-js@1.9.14):
     dependencies:
-      solid-js: 1.9.6
-      solid-use: 0.6.2(solid-js@1.9.6)
+      solid-js: 1.9.14
+      solid-use: 0.6.2(solid-js@1.9.14)
 
-  solid-icons@1.1.0(solid-js@1.9.6):
+  solid-icons@1.1.0(solid-js@1.9.14):
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   solid-js@1.9.14:
     dependencies:
@@ -13572,19 +13584,28 @@ snapshots:
       seroval: 1.3.1
       seroval-plugins: 1.3.1(seroval@1.3.1)
 
-  solid-motionone@1.0.4(solid-js@1.9.6):
+  solid-motionone@1.0.4(solid-js@1.9.14):
     dependencies:
       '@motionone/dom': 10.18.0
       '@motionone/utils': 10.18.0
-      '@solid-primitives/props': 3.2.1(solid-js@1.9.6)
-      '@solid-primitives/refs': 1.1.1(solid-js@1.9.6)
-      '@solid-primitives/transition-group': 1.1.1(solid-js@1.9.6)
+      '@solid-primitives/props': 3.2.1(solid-js@1.9.14)
+      '@solid-primitives/refs': 1.1.1(solid-js@1.9.14)
+      '@solid-primitives/transition-group': 1.1.1(solid-js@1.9.14)
       csstype: 3.1.3
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  solid-qr-code@0.1.11(solid-js@1.9.6):
+  solid-qr-code@0.1.11(solid-js@1.9.14):
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
+
+  solid-refresh@0.6.3(solid-js@1.9.14):
+    dependencies:
+      '@babel/generator': 7.29.8
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/types': 7.29.8
+      solid-js: 1.9.14
+    transitivePeerDependencies:
+      - supports-color
 
   solid-refresh@0.6.3(solid-js@1.9.6):
     dependencies:
@@ -13595,14 +13616,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-stripe@0.7.5(@stripe/stripe-js@7.3.1)(solid-js@1.9.6):
+  solid-stripe@0.7.5(@stripe/stripe-js@7.3.1)(solid-js@1.9.14):
     dependencies:
       '@stripe/stripe-js': 7.3.1
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
-  solid-use@0.6.2(solid-js@1.9.6):
+  solid-use@0.6.2(solid-js@1.9.14):
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
 
   source-map-js@1.2.1: {}
 
@@ -14171,20 +14192,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid-svg@0.8.1(solid-js@1.9.6)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1)):
+  vite-plugin-solid-svg@0.8.1(solid-js@1.9.14)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1)):
     dependencies:
-      solid-js: 1.9.6
+      solid-js: 1.9.14
       svgo: 3.3.2
       vite: 6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1)
 
-  vite-plugin-solid@2.11.14(solid-js@1.9.6)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1)):
+  vite-plugin-solid@2.11.14(solid-js@1.9.14)(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1)):
     dependencies:
       '@babel/core': 7.29.7
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.6(@babel/core@7.29.7)
       merge-anything: 5.1.7
-      solid-js: 1.9.6
-      solid-refresh: 0.6.3(solid-js@1.9.6)
+      solid-js: 1.9.14
+      solid-refresh: 0.6.3(solid-js@1.9.14)
       vite: 6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1)
       vitefu: 1.0.6(vite@6.4.3(@types/node@24.7.1)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.49.2)(yaml@2.7.1))
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   prettier: ^3.8.1
+  solid-js: 1.9.14
 
 importers:
 
@@ -345,7 +346,7 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(solid-js@1.9.14)
       solid-js:
-        specifier: ^1.9.14
+        specifier: 1.9.14
         version: 1.9.14
       solid-livekit-components:
         specifier: workspace:^
@@ -482,13 +483,13 @@ importers:
         version: 0.12.14(livekit-client@2.20.2(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
       '@solid-primitives/intersection-observer':
         specifier: ^2.2.2
-        version: 2.2.2(solid-js@1.9.6)
+        version: 2.2.2(solid-js@1.9.14)
       '@solid-primitives/keyed':
         specifier: ^1.5.2
-        version: 1.5.2(solid-js@1.9.6)
+        version: 1.5.2(solid-js@1.9.14)
       '@solid-primitives/scheduled':
         specifier: ^1.5.2
-        version: 1.5.3(solid-js@1.9.6)
+        version: 1.5.3(solid-js@1.9.14)
       livekit-client:
         specifier: ^2.20.2
         version: 2.20.2(@types/dom-mediacapture-record@1.0.22)
@@ -510,7 +511,7 @@ importers:
         version: 0.18.20
       esbuild-plugin-solid:
         specifier: ^0.5.0
-        version: 0.5.0(esbuild@0.18.20)(solid-js@1.9.6)
+        version: 0.5.0(esbuild@0.18.20)(solid-js@1.9.14)
       eslint:
         specifier: ^8.45.0
         version: 8.57.1
@@ -521,14 +522,14 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       solid-js:
-        specifier: ^1.7.8
-        version: 1.9.6
+        specifier: 1.9.14
+        version: 1.9.14
       tsup:
         specifier: ^7.1.0
         version: 7.3.0(postcss@8.5.14)(typescript@5.8.3)
       tsup-preset-solid:
         specifier: ^2.0.1
-        version: 2.2.0(esbuild@0.18.20)(solid-js@1.9.6)(tsup@7.3.0(postcss@8.5.14)(typescript@5.8.3))
+        version: 2.2.0(esbuild@0.18.20)(solid-js@1.9.14)(tsup@7.3.0(postcss@8.5.14)(typescript@5.8.3))
       typescript:
         specifier: ^5.1.6
         version: 5.8.3
@@ -537,7 +538,7 @@ importers:
         version: 4.5.14(@types/node@20.17.46)(lightningcss@1.31.1)(terser@5.49.2)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.11.6(solid-js@1.9.6)(vite@4.5.14(@types/node@20.17.46)(lightningcss@1.31.1)(terser@5.49.2))
+        version: 2.11.6(solid-js@1.9.14)(vite@4.5.14(@types/node@20.17.46)(lightningcss@1.31.1)(terser@5.49.2))
 
   packages/stoat.js:
     dependencies:
@@ -554,7 +555,7 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4
       solid-js:
-        specifier: ^1.9.14
+        specifier: 1.9.14
         version: 1.9.14
       stoat-api:
         specifier: 0.14.3
@@ -1393,7 +1394,7 @@ packages:
   '@dschz/solid-auto-sizer@0.1.3':
     resolution: {integrity: sha512-KvgvrZRiqe0qU1e1K91MqMVuzr1McptHX+LEkmaek8bwETSNXvLbPDgQQSkvPtVq26/pv4pdIIDJ/JpHVMS0ag==}
     peerDependencies:
-      solid-js: '>=1.6.0'
+      solid-js: 1.9.14
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -2332,7 +2333,7 @@ packages:
     engines: {node: '>=22.19.0'}
     peerDependencies:
       babel-plugin-macros: 2 || 3
-      solid-js: ^1.8.0 || ^1.9.0
+      solid-js: 1.9.14
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
@@ -2408,7 +2409,7 @@ packages:
   '@minht11/solid-virtual-container@0.2.1':
     resolution: {integrity: sha512-HvQWx1uE5NWwx9WsN4waFtmyOjhZKMA/3vBf+j3zGsRfi556LCUk4oOmqZcOvIB5nEpHezvuZ8oUlwxigdO3Xg==}
     peerDependencies:
-      solid-js: '>= 1.0.0'
+      solid-js: 1.9.14
 
   '@modelcontextprotocol/sdk@1.11.2':
     resolution: {integrity: sha512-H9vwztj5OAqHg9GockCQC06k1natgcxWQSRpQcPJf6i5+MWBzfKkRtxGbjQf0X2ihii0ffLZCRGbYV2f2bjNCQ==}
@@ -2760,62 +2761,62 @@ packages:
   '@solid-aria/button@0.1.3':
     resolution: {integrity: sha512-gN7/d5YkHAbQPhzBVbNNp9grf9w+mxFRulbmeXjp61hFNLOJRDcdMPCri5MmfUJ8D2BwefcyHvCGTCc62Ua23A==}
     peerDependencies:
-      solid-js: ^1.4.4
+      solid-js: 1.9.14
 
   '@solid-aria/focus@0.1.4':
     resolution: {integrity: sha512-yX/BbN97s7ascNJu0yB+p1bx48U0NOOWw7+TYlGcAfFGc2HMNpIxG5OdhWGUoz8D9Tp5ELEgWgN3d4dAf7Hk9Q==}
     peerDependencies:
-      solid-js: ^1.4.4
+      solid-js: 1.9.14
 
   '@solid-aria/interactions@0.1.4':
     resolution: {integrity: sha512-gVJWJTX51mZfURoak39mxCo/vUQl8UInctJBlT2nIc3VQrTPL4ekOV6czrvTffpduoWgXeuf61+Dabc7b920lQ==}
     peerDependencies:
-      solid-js: ^1.4.4
+      solid-js: 1.9.14
 
   '@solid-aria/toggle@0.1.3':
     resolution: {integrity: sha512-ZVRhY+Te8XBFFcumuu2J92LBntlmV6ss/6fNkDfhvr4LV42VB1goRZvPJk8rqakyR3JkQBTnQuxt7idrqqaxgA==}
     peerDependencies:
-      solid-js: ^1.4.4
+      solid-js: 1.9.14
 
   '@solid-aria/types@0.1.4':
     resolution: {integrity: sha512-CxVXiZPE+nfD7wr7+6xtY3IrCTyAfL3zW4tH4NtsxlqBoz10tLFRCsTqeyl6OWMDhwABIaSdeHPKXVnKsKErcQ==}
     peerDependencies:
-      solid-js: ^1.4.4
+      solid-js: 1.9.14
 
   '@solid-aria/utils@0.2.1':
     resolution: {integrity: sha512-zZgPpdg7azQUKE2jDUnCmzopN8CFdeKKcFTIv9ICrc0afS1qUR8ScywWBF/AwNBgGYhneBr7xEOwAHxe+zUcHQ==}
     peerDependencies:
-      solid-js: ^1.4.4
+      solid-js: 1.9.14
 
   '@solid-devtools/debugger@0.18.1':
     resolution: {integrity: sha512-PFbf3+t5ua/v9HpnYOo24NIIM/pf/ZUFYF26YWy8qq2ddRbkKL87nmG5gDGvtgK7lVV3GM3O01fdq4YnSG1SYg==}
     peerDependencies:
-      solid-js: ^1.6.2
+      solid-js: 1.9.14
 
   '@solid-devtools/debugger@0.23.4':
     resolution: {integrity: sha512-EfTB1Eo313wztQYGJ4Ec/wE70Ay2d603VCXfT3RlyqO5QfLrQGRHX5NXC07hJpQTJJJ3tbNgzO7+ZKo76MM5uA==}
     peerDependencies:
-      solid-js: ^1.8.0
+      solid-js: 1.9.14
 
   '@solid-devtools/frontend@0.11.5':
     resolution: {integrity: sha512-nEx6BkDWvTEkrZTswpwJfitrKEuYmisA2GiIfAtRUgIeUUK3Zdz8jllEuAAl75Kt/ZsbR1aHFnpwjf8BvKLXCQ==}
     peerDependencies:
-      solid-js: ^1.8.0
+      solid-js: 1.9.14
 
   '@solid-devtools/overlay@0.30.1':
     resolution: {integrity: sha512-zy4FkE29QN8B7f5y1SFfA9k2baEMfdn8H6LQsNLGvwIeFs6N45NxWKTq7VoHmL0FW7ZDvOU9zp1PYMCLsJblvQ==}
     peerDependencies:
-      solid-js: ^1.8.0
+      solid-js: 1.9.14
 
   '@solid-devtools/shared@0.10.6':
     resolution: {integrity: sha512-UfLERQMxULRl2GoNc/Y1fMkRp71uTk/56dksowRLMdsyFpH3vqKr3+AHfm/2tXI/XeRAvXsXhC90zpVff5y+Hg==}
     peerDependencies:
-      solid-js: ^1.6.2
+      solid-js: 1.9.14
 
   '@solid-devtools/shared@0.13.2':
     resolution: {integrity: sha512-Y4uaC4EfTVwBR537MZwfaY/eiWAh+hW4mbtnwNuUw/LFmitHSkQhNQTUlLQv/S0chtwrYWQBxvXos1dC7e8R9g==}
     peerDependencies:
-      solid-js: ^1.8.0
+      solid-js: 1.9.14
 
   '@solid-devtools/theme@0.0.1':
     resolution: {integrity: sha512-10Kky0Ed4S89PFpJfcFsU6cc3ckNPTAjiEGYYoBdfaekvvAibdWllkbKhiDngPkwFUY8BpSi5ZLMlBPBxrxgLg==}
@@ -2824,273 +2825,273 @@ packages:
     resolution: {integrity: sha512-r8JzHMmBFgaFy+FQVQdvNpTX8L3zwuiW1/puV3VHyaw1FpODmdmkbOnQgUQgHqN/X1LLPzTMtVGKLcDmJJOQbQ==}
     deprecated: vite plugin has been moved entirely to 'solid-devtools' pacakge.
     peerDependencies:
-      solid-js: ^1.6.2
+      solid-js: 1.9.14
       vite: ^2.2.3 || ^3.0.0 || ^4.0.0
 
   '@solid-primitives/bounds@0.0.105':
     resolution: {integrity: sha512-a2ZRuZayXV1/kSKx8cEOR5pIs2zKAF9lS3Gj/r7uHmBQBmn25GYCYOwj4LbLQbqqbumZr2eJO+/wDyi4UOX5pw==}
     peerDependencies:
-      solid-js: ^1.6.0
+      solid-js: 1.9.14
 
   '@solid-primitives/bounds@0.0.118':
     resolution: {integrity: sha512-Qj42w8LlnhJ3r/t+t0c0vrdwIvvQMPgjEFGmLiwREaA85ojLbgL9lSBq2tKvljeLCvRVkgj10KEUf+vc99VCIg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/context@0.2.3':
     resolution: {integrity: sha512-6/e8qu9qJf48FJ+sxc/B782NdgFw5TvI8+r6U0gHizumfZcWZg8FAJqvRZAiwlygkUNiTQOGTeO10LVbMm0kvg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/cursor@0.0.103':
     resolution: {integrity: sha512-bb5x5lCimBf7R2VqrrMVcP2y/aGTMjNj7fjvY+RvTAC3/WtG/odqeYwka4lCBV27pX9TiJCKtNS6mVTigdfLMA==}
     peerDependencies:
-      solid-js: ^1.6.0
+      solid-js: 1.9.14
 
   '@solid-primitives/cursor@0.0.112':
     resolution: {integrity: sha512-TAtU7qD7ipSLSXHnq8FhhosAPVX+dnOCb/ITcGcLlj8e/C9YKcxDhgBHJ3R/d1xDRb5/vO/szJtEz6fnQD311Q==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/date@2.1.6':
     resolution: {integrity: sha512-lKNdQHr4B6q1a1iw3F1o3Sx2eyj6TAZ2S8fp+LQ/Lt/tSg7QQiLCM9WO32X9AxEZ6ZWmGjlGnWDq1AVKfbsJPA==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/event-bus@0.1.6':
     resolution: {integrity: sha512-UGtBU5zDyjSYnX0BjaYFcs1XfRD6BDN6VEJi4ydxePaUEKlloOG53BsLZjFgTux8cMEmJAaHjoJQH3/SBt3zcw==}
     peerDependencies:
-      solid-js: ^1.6.0
+      solid-js: 1.9.14
 
   '@solid-primitives/event-bus@1.1.1':
     resolution: {integrity: sha512-UV164rO0k6wFyRoN1WukQ7OFxsll167TtBWZPdBtuFfNIbgb71Gj5obSc5eGEq/M1y3pq9VeHHuGDG/Uu1b2XA==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/event-listener@2.4.1':
     resolution: {integrity: sha512-Xc/lBCeuh9LwzR4lYbMDtopwWK7N9b4o+FmI4uoI8DOtVGYi0Ip20DG8PtwHk+g31lHgvwtFFVKfnUx2UaqZJg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/i18n@2.2.1':
     resolution: {integrity: sha512-TnTnE2Ku11MGYZ1JzhJ8pYscwg1fr9MteoYxPwsfxWfh9Jp5K7RRJncJn9BhOHvNLwROjqOHZ46PT7sPHqbcXw==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/immutable@0.1.10':
     resolution: {integrity: sha512-5XkiiBGSuUaoG2HFei1bG2eDyUwsj/b6IBP7ggm4UMU5mM/APz1u7e3rzMyPn5zVqnHT3oRSbj3UDPNYb5Y9Qg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/intersection-observer@2.2.2':
     resolution: {integrity: sha512-5Vak/eRuCKAQis+YaPsP4KysPc+sQGL2ew8kvTOMxKVOTJcICkxznRrlFEBbBk0UsiUQlm9CcVQtJwocKWNXcw==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/jsx-tokenizer@1.1.1':
     resolution: {integrity: sha512-IA9dxb+C7f19Vj+QnD3PyrhnkT1GSr60j169Fu3fre/pYjcZnrtaY8te4fOTg7Mxc2iWWgpgFSLPotqtrkZdYg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/keyboard@1.3.1':
     resolution: {integrity: sha512-ib4xPC5ioOGj2A/5PqFTJvWbgGVx/5okFEoU0qXhCrehVB84gPBhKFNRqTlpiYzCbVHPIUZCTO2ZMkqzJdIA2w==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/keyed@1.5.2':
     resolution: {integrity: sha512-BgoEdqPw48URnI+L5sZIHdF4ua4Las1eWEBBPaoSFs42kkhnHue+rwCBPL2Z9ebOyQ75sUhUfOETdJfmv0D6Kg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/map@0.7.1':
     resolution: {integrity: sha512-0Fo5gToY+XPZVQLwzm8dc/3vVLdYLboUJD+kyoW+V64YPHs0qPDEekJuRUV7Mp9uiyHnD1DArfy1CrHAezTDZQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/map@0.7.4':
     resolution: {integrity: sha512-zHWjQpcqxiXCuHb08GXJm3KnCTXOQNGMQu07CBOwtj9qCgjNUmwm5/UG+M2txQIPCbpY9rleAoOmEaQW4iaXMQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/media@2.3.1':
     resolution: {integrity: sha512-UTX8LAaQS7k3rvekme8y5ihOrt5SJpgkw7xyUySlPhIapD7JxlhYncQoSFsys5D1XPCgI/3snobpvbanRcrTAw==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/memo@1.4.5':
     resolution: {integrity: sha512-dMfFShNsyX5virETyDv/Uoy2HP+PL4k8cUTTLb2r4TfoqJb010KIaOuURqp/Qbdznp4ZkDuP57b28d45kaOueQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/mouse@2.1.2':
     resolution: {integrity: sha512-ov4K3eQCybN0bN4ZzBA3mFGuj2AJmgP9kOJaGZtTtjJ6uvI6LYd8pfv+Tm6gb3BlaIlVurLMuOU30mapSaJjhA==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/platform@0.0.100':
     resolution: {integrity: sha512-TMGeDtjA8b7xlUQGq3QhdR8SSa49bvqhFJ0iD+iy4fsnEHr9xA5hIDyBX/ntmz70SbOVyz+z9IdXwBnqurr4bQ==}
     peerDependencies:
-      solid-js: ^1.4.0
+      solid-js: 1.9.14
 
   '@solid-primitives/platform@0.0.102':
     resolution: {integrity: sha512-1eZA1/HYOhmlZ9LrrGot+LUi/ypO2NXqfB+9F1WY98dGNDMz9pG9k+X7kg2YDJTUHDGbzY7WrsBRyAE8LurE7Q==}
     peerDependencies:
-      solid-js: ^1.5.0
+      solid-js: 1.9.14
 
   '@solid-primitives/platform@0.1.2':
     resolution: {integrity: sha512-sSxcZfuUrtxcwV0vdjmGnZQcflACzMfLriVeIIWXKp8hzaS3Or3tO6EFQkTd3L8T5dTq+kTtLvPscXIpL0Wzdg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/props@2.2.2':
     resolution: {integrity: sha512-vjRRoi/z3S2ylIJKCs+mN07oxDmt2S9gPCbTqkEx8jYHnvzocpt34UQdglLoSklTE6jI37JhW3g/Cs8Qr/peHg==}
     peerDependencies:
-      solid-js: ^1.3.0
+      solid-js: 1.9.14
 
   '@solid-primitives/props@3.2.1':
     resolution: {integrity: sha512-SuTuCctLLZbUL1QyWamQGWSWPIgoc/gXt5kL8P2yLhb51f9Dj+WHxU0shXBjzx7z+hDc5KtheQgM4NnJqQJi2A==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/range@0.1.18':
     resolution: {integrity: sha512-F5OTdpRFdeLOPEHs92S714GKUk1ZUUmEJ45Z/Z5h6i43DHi7fUFgUL7LeHFxVgIjtGv+Tg5Op7aM9PdSo5iqeQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/refs@0.3.7':
     resolution: {integrity: sha512-aqidj/Sw5b2FvXgvNP8zH5HC2jEzDbFju+xRUCxZguaBmDJJyzec12fpZ9JV6SiWCyk08nZ/N4rfPNQnt1af1Q==}
     peerDependencies:
-      solid-js: ^1.6.0
+      solid-js: 1.9.14
 
   '@solid-primitives/refs@1.1.1':
     resolution: {integrity: sha512-MIQ7Bh59IiT9NDQPf6iWRnPe0RgKggEjF0H+iMoIi1KBCcp4Mfss2IkUWYPr9wqQg963ZQFbcg5D6oN9Up6Mww==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/resize-observer@2.1.1':
     resolution: {integrity: sha512-vb/VS9+YdUdVZ2V92JimFmFuaJ2MSyKOGnUay/mQvoQ0R+mtdT7FSylfQlVslCzm0ecx8Jkvsm1Sk2lopvMAdg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/rootless@1.5.1':
     resolution: {integrity: sha512-G4eNC6F3ufRT2Mjbodl7rSOH7uq/Emqs3S7/BIBWgh+V/IFUtvu6WELeqSrk4FJX3T/kKKvC+T8gXhepExSWyg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/scheduled@1.5.1':
     resolution: {integrity: sha512-WKg/zvAyDIgQ/Xo48YaUY7ISaPyWTZNDzIVWP2R84CuLH+nZN/2O0aFn/gQlWY6y/Bfi/LdDt6Og2/PRzPY7mA==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/scheduled@1.5.3':
     resolution: {integrity: sha512-oNwLE6E6lxJAWrc8QXuwM0k2oU1BnANnkChwMw82aK1j3+mWGJkG1IFe5gCwbV+afYmjI76t9JJV3md/8tLw+g==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/script-loader@2.3.1':
     resolution: {integrity: sha512-NRvrFwDcgsAQlsFPdKQzRN5LuIh3dYFTzcctaxaqEF2cjEz1zbYekAa6dVdSeX5G0vdBsj9PLwVZ2Ps5SlJIpQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/set@0.7.1':
     resolution: {integrity: sha512-mB5SfKHnyTlVZGLhh5BDivDemKWtMePNyUX3FIiBisTf7mkJZVFdgiKLO0l+QaOlRKM5+VsRT1pThL5grl2sig==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/set@0.7.4':
     resolution: {integrity: sha512-/QlGdStYqUTGfuiEFF0MdURS+25k1ayxWAEqJyt9MRrNimZP7VFs6WgkKaPBWW5t0yCrncAa/B9z24Coz9eE/w==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/static-store@0.0.5':
     resolution: {integrity: sha512-ssQ+s/wrlFAEE4Zw8GV499yBfvWx7SMm+ZVc11wvao4T5xg9VfXCL9Oa+x4h+vPMvSV/Knv5LrsLiUa+wlJUXQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/static-store@0.1.1':
     resolution: {integrity: sha512-daXWvpLjd+4hbYdGaaEJ2kKFuFhshvfIBFLveW7mfk2BWHl9lGQVwUuExp3qllkK9ONA9p+5D2cpwBQosv8odQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/styles@0.0.101':
     resolution: {integrity: sha512-tHkeUMntlS/w+/zDzXJv82hhMy3J3q7tVV3ZTbahRo0hZienAM8ZJrCYZNK/fu2px8NHVSZFRufxv9qhIclPTw==}
     peerDependencies:
-      solid-js: ^1.5.0
+      solid-js: 1.9.14
 
   '@solid-primitives/styles@0.0.111':
     resolution: {integrity: sha512-1mBxOGAPXmfD5oYCvqjKBDN7SuNjz2qz7RdH7KtsuNLQh6lpuSKadtHnLvru0Y8Vz1InqTJisBIy/6P5kyDmPw==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/timer@1.4.1':
     resolution: {integrity: sha512-M7xrZ/rIq2qEas3fZHLoKQjvseRgNH5IGOl7ZkDxlSJDa5RxAcnzdNPmJiMZH/9+PWrViCrnO0RxLs8w/YIOpg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/timer@1.4.4':
     resolution: {integrity: sha512-Ayjyb3+v1hyU92vuLUN0tVHq2mmTCPGxSDLGJMsDydRqx9ZfJIc9xj6cxK4XvdY3pif3ps2mIv52pjgToybEpQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/transition-group@1.1.1':
     resolution: {integrity: sha512-yf8mheMunnAkPSH2WNlemdSR2mrBar0Hw2FenZCqr10iKrI4sUiERIOR4nnFNnUK73BVwAA/xeYbiOk6s36fvw==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/trigger@1.2.1':
     resolution: {integrity: sha512-pvNmddYs5AYUpiH373F7wbQOlcc10SSNHY8kUiu4UHoDlv4jhSnlNXzbFkmt33hq4ODKdN5gVm00jCnAJ+wm8Q==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/trigger@1.2.4':
     resolution: {integrity: sha512-Ju0e+ZOD7hpOp7nptJimvDSZHWFvIvF9iBWMvuwt30smX7c5wmB8Kmc0AdDuv0wOTi06PQ1J5IrP1WJbH2yUBQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@2.2.1':
     resolution: {integrity: sha512-vaBO3MGOpjzitbSAVuJkYZnzNPRl6sRrw2do390DEBbfeqMfPpW4fAEb5/tI4b5T13V1xAY+giHoxqvVg2SRhQ==}
     peerDependencies:
-      solid-js: ^1.4.1
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@3.1.0':
     resolution: {integrity: sha512-/rerChcwgFtHEgVCCBY7BXGHh7a83HcIAzR8QhXJ789geIVbBs2YxHF4UUZlG7ec00NKSfvO3+sQquN/xKQLMw==}
     peerDependencies:
-      solid-js: ^1.5.0
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@4.0.1':
     resolution: {integrity: sha512-06fSyBair7ZxCquMjIqJes29aNg65X776TVw4EUN7PBtdWsGUeIZ9F/H4ek7yrDSxaSDaPHeye5knEYsYAq2gA==}
     peerDependencies:
-      solid-js: ^1.6.0
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@5.5.2':
     resolution: {integrity: sha512-L52ig3eHKU6CqbPCKJIb4lweBuINHBOERcE1duApyKozEN8+zCqEKwD1Qo9ljKeEzJTBGWClxNpwEiNTUWTGvg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@6.3.1':
     resolution: {integrity: sha512-4/Z59nnwu4MPR//zWZmZm2yftx24jMqQ8CSd/JobL26TPfbn4Ph8GKNVJfGJWShg1QB98qObJSskqizbTvcLLA==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@6.3.2':
     resolution: {integrity: sha512-hZ/M/qr25QOCcwDPOHtGjxTD8w2mNyVAYvcfgwzBHq2RwNqHNdDNsMZYap20+ruRwW4A3Cdkczyoz0TSxLCAPQ==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@6.4.0':
     resolution: {integrity: sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@6.4.1':
     resolution: {integrity: sha512-ISSB5QX1qP2ynrheIpYwc4oKR5Ny4siNuUyf1qZniy+Il+p/PtDB0QK1Dnle8noiHpwRD3gpPdubOC3qI/Zamg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solidjs/router@0.15.3':
     resolution: {integrity: sha512-iEbW8UKok2Oio7o6Y4VTzLj+KFCmQPGEpm1fS3xixwFBdclFVBvaQVeibl1jys4cujfAK5Kn6+uG2uBm3lxOMw==}
     peerDependencies:
-      solid-js: ^1.8.6
+      solid-js: 1.9.14
 
   '@stripe/stripe-js@7.3.1':
     resolution: {integrity: sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==}
@@ -3105,7 +3106,7 @@ packages:
   '@tanstack/solid-query@5.76.0':
     resolution: {integrity: sha512-zbNtAnFnneJvZgwhygtLvLCmeRzeBz7IwneOZC7UpCG1teZS5H2ohPXAkKegVGgRp8hgZrRKyU1nDJLUOOFd2w==}
     peerDependencies:
-      solid-js: ^1.6.0
+      solid-js: 1.9.14
 
   '@tauri-apps/api@2.5.0':
     resolution: {integrity: sha512-Ldux4ip+HGAcPUmuLT8EIkk6yafl5vK0P0c0byzAKzxJh7vxelVtdPONjfgTm96PbN24yjZNESY8CKo8qniluA==}
@@ -3114,7 +3115,7 @@ packages:
     resolution: {integrity: sha512-DfI5ff+yYGpK9M21LhYwIPlbP2msKxN2ARwuu6GF8tT1GgNVDTI8VCQvH4TJFoVApP9d44izmAcTh/iTCH2UUw==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     peerDependencies:
-      solid-js: ^1.5
+      solid-js: 1.9.14
 
   '@trivago/prettier-plugin-sort-imports@5.2.2':
     resolution: {integrity: sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==}
@@ -4056,7 +4057,7 @@ packages:
     resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
     peerDependencies:
       esbuild: '>=0.12'
-      solid-js: '>= 1.0'
+      solid-js: 1.9.14
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -5988,21 +5989,11 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
-  seroval-plugins@1.3.1:
-    resolution: {integrity: sha512-dOlUoiI3fgZbQIcj6By+l865pzeWdP3XCSLdI3xlKnjCk5983yLWPsXytFOUI0BUZKG9qwqbj78n9yVcVwUqaQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
   seroval-plugins@1.5.6:
     resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
-
-  seroval@1.3.1:
-    resolution: {integrity: sha512-F+T9EQPdLzgdewgxnBh4mSc+vde+EOkU6dC9BDuu/bfGb+UyUlqM6t8znFCTPQSuai/ZcfFg0gu79h+bVW2O0w==}
-    engines: {node: '>=10'}
 
   seroval@1.5.6:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
@@ -6092,70 +6083,67 @@ packages:
     resolution: {integrity: sha512-4aPKidTrwSVBHqeiUPPe218t+HyRp0S4iYNJw7nDsWqP33HHYhAwvAyWVfqlqHBlnA/+A5jdevRvbCOiLV5Qew==}
     engines: {node: '>=14.16.0', npm: '>=6.14.8'}
     peerDependencies:
-      solid-js: ^1.0.0
+      solid-js: 1.9.14
 
   solid-floating-ui@0.3.1:
     resolution: {integrity: sha512-o/QmGsWPS2Z3KidAxP0nDvN7alI7Kqy0kU+wd85Fz+au5SYcnYm7I6Fk3M60Za35azsPX0U+5fEtqfOuk6Ao0Q==}
     engines: {node: '>=10'}
     peerDependencies:
       '@floating-ui/dom': ^1.5
-      solid-js: ^1.8
+      solid-js: 1.9.14
 
   solid-forms@0.5.2:
     resolution: {integrity: sha512-X5jbm0AeWrUAfZTxXbB8vJbuHQYs4pPIg15R/AwR/rwExcU2hcpfQP77Y7uOjA5uKhAfcP43w5hEGzuQEpNduw==}
     peerDependencies:
-      solid-js: ^1.4.0
+      solid-js: 1.9.14
 
   solid-hcaptcha@0.4.0:
     resolution: {integrity: sha512-ermYlhU09wPxqNZujVJr6NQI0T/25Ru8rN9a3gGjB83vqpQTapzP3HujmRBDGTF0Ghuy6r0xexhDnOYVTPrxhw==}
     peerDependencies:
-      solid-js: ^1.6.15 || ^1.7.12
+      solid-js: 1.9.14
 
   solid-headless@0.13.1:
     resolution: {integrity: sha512-FZJai49YmdBu6oEo8aJGPMQ1Qn8xiW0cnD6vNFDIQWMKJdXEUtDEwz0hTR9aZ7Epq3IkrZs+98E0vNiv1+pZpA==}
     engines: {node: '>=10'}
     peerDependencies:
-      solid-js: ^1.2
+      solid-js: 1.9.14
 
   solid-icons@1.1.0:
     resolution: {integrity: sha512-IesTfr/F1ElVwH2E1110s2RPXH4pujKfSs+koT8rwuTAdleO5s26lNSpqJV7D1+QHooJj18mcOiz2PIKs0ic+A==}
     peerDependencies:
-      solid-js: '*'
+      solid-js: 1.9.14
 
   solid-js@1.9.14:
     resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
 
-  solid-js@1.9.6:
-    resolution: {integrity: sha512-PoasAJvLk60hRtOTe9ulvALOdLjjqxuxcGZRolBQqxOnXrBXHGzqMT4ijNhGsDAYdOgEa8ZYaAE94PSldrFSkA==}
-
   solid-motionone@1.0.4:
     resolution: {integrity: sha512-aqEjgecoO9raDFznu/dEci7ORSmA26Kjj9J4Cn1Gyr0GZuOVdvsNxdxClTL9J40Aq/uYFx4GLwC8n70fMLHiuA==}
     peerDependencies:
-      solid-js: ^1.8.0
+      solid-js: 1.9.14
 
   solid-qr-code@0.1.11:
     resolution: {integrity: sha512-8TpELeuK6OoPz5TfJaycsna63IivaSr6Y34qU79eYDF+SRTowO9os8gpElNvNe2FFROZuMZpf28jgmn9gV20Eg==}
     engines: {node: '>=18'}
     peerDependencies:
-      solid-js: ^1.8.0
+      solid-js: 1.9.14
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
     peerDependencies:
-      solid-js: ^1.3
+      solid-js: 1.9.14
 
   solid-stripe@0.7.5:
     resolution: {integrity: sha512-NlbOhe/GuStzrqy6R5PlEyKYmyn1CYVlQxLGw1tW89czZKpx747mlBtYr+VhYdBIiK2QubpbFwJOM7ziFjn9UQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@stripe/stripe-js': ^1.44.1 || ^2.0.0 || ^3.0.0 || ^4.0.0
-      solid-js: ^1.6.0
+      solid-js: 1.9.14
 
   solid-use@0.6.2:
     resolution: {integrity: sha512-0ShJ5s+4PIN0pJB/BtsQucsZB+xnUeeTGaxErQDu6USn5jygZWXicAtOEvFbI8gv40xE751uY1Tz7Aib9lxL/Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      solid-js: ^1.5
+      solid-js: 1.9.14
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6647,14 +6635,14 @@ packages:
   vite-plugin-solid-svg@0.8.1:
     resolution: {integrity: sha512-ROGC2ae1eYUCMd+zfJtsbUtuZwsb6DZS0+Sy5/ZXDokOunGi0Ez/cL7OPdsixN3I0/rNYd/3hilo3kpRMAS+IA==}
     peerDependencies:
-      solid-js: ^1
+      solid-js: 1.9.14
       vite: '>=4'
 
   vite-plugin-solid@2.11.14:
     resolution: {integrity: sha512-7ZVBt8rpoyqmlwin2kRIUveaHoF6/kulY7gsnD+qFh4nS29V4OPAnw+ojoAspXIjObiL9o1xh9a/nTuYHm02Rw==}
     peerDependencies:
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0
-      solid-js: ^1.7.2
+      solid-js: 1.9.14
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
@@ -6664,7 +6652,7 @@ packages:
     resolution: {integrity: sha512-Sl5CTqJTGyEeOsmdH6BOgalIZlwH3t4/y0RQuFLMGnvWMBvxb4+lq7x3BSiAw6etf0QexfNJW7HSOO/Qf7pigg==}
     peerDependencies:
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: ^1.7.2
+      solid-js: 1.9.14
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
@@ -9555,10 +9543,10 @@ snapshots:
       '@solid-primitives/utils': 6.4.0(solid-js@1.9.14)
       solid-js: 1.9.14
 
-  '@solid-primitives/intersection-observer@2.2.2(solid-js@1.9.6)':
+  '@solid-primitives/intersection-observer@2.2.2(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.6)
-      solid-js: 1.9.6
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.14)
+      solid-js: 1.9.14
 
   '@solid-primitives/jsx-tokenizer@1.1.1(solid-js@1.9.14)':
     dependencies:
@@ -9575,10 +9563,6 @@ snapshots:
   '@solid-primitives/keyed@1.5.2(solid-js@1.9.14)':
     dependencies:
       solid-js: 1.9.14
-
-  '@solid-primitives/keyed@1.5.2(solid-js@1.9.6)':
-    dependencies:
-      solid-js: 1.9.6
 
   '@solid-primitives/map@0.7.1(solid-js@1.9.14)':
     dependencies:
@@ -9672,10 +9656,6 @@ snapshots:
     dependencies:
       solid-js: 1.9.14
 
-  '@solid-primitives/scheduled@1.5.3(solid-js@1.9.6)':
-    dependencies:
-      solid-js: 1.9.6
-
   '@solid-primitives/script-loader@2.3.1(solid-js@1.9.14)':
     dependencies:
       solid-js: 1.9.14
@@ -9756,10 +9736,6 @@ snapshots:
   '@solid-primitives/utils@6.3.2(solid-js@1.9.14)':
     dependencies:
       solid-js: 1.9.14
-
-  '@solid-primitives/utils@6.3.2(solid-js@1.9.6)':
-    dependencies:
-      solid-js: 1.9.6
 
   '@solid-primitives/utils@6.4.0(solid-js@1.9.14)':
     dependencies:
@@ -10954,13 +10930,13 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  esbuild-plugin-solid@0.5.0(esbuild@0.18.20)(solid-js@1.9.6):
+  esbuild-plugin-solid@0.5.0(esbuild@0.18.20)(solid-js@1.9.14):
     dependencies:
       '@babel/core': 7.27.1
       '@babel/preset-typescript': 7.27.1(@babel/core@7.27.1)
       babel-preset-solid: 1.9.6(@babel/core@7.27.1)
       esbuild: 0.18.20
-      solid-js: 1.9.6
+      solid-js: 1.9.14
     transitivePeerDependencies:
       - supports-color
 
@@ -13417,15 +13393,9 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  seroval-plugins@1.3.1(seroval@1.3.1):
-    dependencies:
-      seroval: 1.3.1
-
   seroval-plugins@1.5.6(seroval@1.5.6):
     dependencies:
       seroval: 1.5.6
-
-  seroval@1.3.1: {}
 
   seroval@1.5.6: {}
 
@@ -13578,12 +13548,6 @@ snapshots:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
 
-  solid-js@1.9.6:
-    dependencies:
-      csstype: 3.1.3
-      seroval: 1.3.1
-      seroval-plugins: 1.3.1(seroval@1.3.1)
-
   solid-motionone@1.0.4(solid-js@1.9.14):
     dependencies:
       '@motionone/dom': 10.18.0
@@ -13604,15 +13568,6 @@ snapshots:
       '@babel/helper-module-imports': 7.29.7
       '@babel/types': 7.29.8
       solid-js: 1.9.14
-    transitivePeerDependencies:
-      - supports-color
-
-  solid-refresh@0.6.3(solid-js@1.9.6):
-    dependencies:
-      '@babel/generator': 7.29.8
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/types': 7.29.8
-      solid-js: 1.9.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13898,9 +13853,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup-preset-solid@2.2.0(esbuild@0.18.20)(solid-js@1.9.6)(tsup@7.3.0(postcss@8.5.14)(typescript@5.8.3)):
+  tsup-preset-solid@2.2.0(esbuild@0.18.20)(solid-js@1.9.14)(tsup@7.3.0(postcss@8.5.14)(typescript@5.8.3)):
     dependencies:
-      esbuild-plugin-solid: 0.5.0(esbuild@0.18.20)(solid-js@1.9.6)
+      esbuild-plugin-solid: 0.5.0(esbuild@0.18.20)(solid-js@1.9.14)
       tsup: 7.3.0(postcss@8.5.14)(typescript@5.8.3)
     transitivePeerDependencies:
       - esbuild
@@ -14211,14 +14166,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@4.5.14(@types/node@20.17.46)(lightningcss@1.31.1)(terser@5.49.2)):
+  vite-plugin-solid@2.11.6(solid-js@1.9.14)(vite@4.5.14(@types/node@20.17.46)(lightningcss@1.31.1)(terser@5.49.2)):
     dependencies:
       '@babel/core': 7.27.1
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.6(@babel/core@7.27.1)
       merge-anything: 5.1.7
-      solid-js: 1.9.6
-      solid-refresh: 0.6.3(solid-js@1.9.6)
+      solid-js: 1.9.14
+      solid-refresh: 0.6.3(solid-js@1.9.14)
       vite: 4.5.14(@types/node@20.17.46)(lightningcss@1.31.1)(terser@5.49.2)
       vitefu: 1.0.6(vite@4.5.14(@types/node@20.17.46)(lightningcss@1.31.1)(terser@5.49.2))
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,9 @@ nodeLinker: isolated
 
 # Override prettier because some of the submodules have ancient prettiers required
 # Having multiple prettiers makes the vscode extension unpredictable
+# Override solid-js because somewhere from 1.9.6 -> 1.9.14 breaks reactivity
+# across dependencies.
 overrides:
   "prettier": "^3.8.1"
+  "solid-js": "1.9.14"
 strictPeerDependencies: false


### PR DESCRIPTION
i fixa duh webdite

A bit ago I updated solidjs to 1.9.14 in stoat.js but didn't update it in for-web. A consequence of that was a bunch of crap breaking and not being reactive. This update fixes that as far as I can tell.

~~This PR seems to have broken a few things and warrants more research.~~ Forcing solid to 1.9.14 appears to have fixed it.

- `main` <!-- branch-stack -->
  - \#1479 :point\_left:
