### PR TITLE
fix: wrong order of cards in UserCard

### DIFF
--- a/packages/client/components/ui/components/floating/UserCard.tsx
+++ b/packages/client/components/ui/components/floating/UserCard.tsx
@@ -65,7 +65,6 @@ export function UserCard(
             bannerUrl={query.data?.animatedBannerURL}
             onClick={openFull}
           />
-
           <Profile.Actions
             user={props.user}
             member={props.member}
@@ -75,11 +74,11 @@ export function UserCard(
           <Profile.Roles member={props.member} />
           <Profile.Badges user={props.user} />
           <Profile.Status user={props.user} />
-          <Profile.Joined user={props.user} member={props.member} />
-          <Profile.Bio content={query.data?.content} onClick={openFull} />
+          <Profile.Joined user={props.user} member={props.member} />{" "}
           <Show when={props.bot}>
             <Profile.Owner bot={props.bot!} />
           </Show>
+          <Profile.Bio content={query.data?.content} onClick={openFull} />
         </Grid>
       </div>
     </Show>


### PR DESCRIPTION
## How was this PR tested?

- [x] Bot Owner card appears next to Joined card

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
No ai was used to move three lines of code
