### PR TITLE
feat: add public bot toggle to bot editor

### DIFF
--- a/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
+++ b/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
@@ -7,6 +7,7 @@ import { useModals } from "@revolt/modal";
 import {
   CategoryButton,
   Column,
+  Form2,
   iconSize,
   Symbol,
   useSnackbar,
@@ -20,6 +21,7 @@ import MdPersonAdd from "@material-design-icons/svg/outlined/person_add.svg?comp
 import MdPublic from "@material-design-icons/svg/outlined/public.svg?component-solid";
 import MdToken from "@material-design-icons/svg/outlined/token.svg?component-solid";
 
+import { IFormControl } from "solid-forms";
 import { UserSummary } from "../account/index";
 import { UserProfileEditor } from "../profile/UserProfileEditor";
 
@@ -43,7 +45,34 @@ export function ViewBot(props: { bot: Bot }) {
         bannerUrl={profile.data?.animatedBannerURL}
       />
 
-      <UserProfileEditor user={props.bot.user!} profile={profile.data} />
+      <UserProfileEditor
+        user={props.bot.user!}
+        profile={profile.data}
+        attach={[
+          {
+            name: "public",
+            value: props.bot.public,
+          },
+        ]}
+        onSubmit={(g) => {
+          props.bot.edit({
+            public: (g.controls["public"] as IFormControl<boolean>).value,
+          });
+        }}
+        onReset={(g) => {
+          (g.controls["public"] as IFormControl<boolean>).setValue(
+            props.bot.public || false,
+          );
+        }}
+      >
+        {(g) => (
+          <Form2.Checkbox
+            control={g.controls["public"] as IFormControl<boolean>}
+          >
+            <Trans>Allow others to invite your bot</Trans>
+          </Form2.Checkbox>
+        )}
+      </UserProfileEditor>
       {/* <ErrorBoundary fallback={<>Failed to load profile</>}>
         <Suspense fallback={<>loading...</>}>{profile.data?.content}</Suspense>
       </ErrorBoundary> */}

--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -1,5 +1,5 @@
-import { createFormControl, createFormGroup } from "solid-forms";
-import { Show, createEffect, createSignal, on } from "solid-js";
+import { createFormControl, createFormGroup, IFormGroup } from "solid-forms";
+import { createEffect, createSignal, JSX, on, Show } from "solid-js";
 
 import { Trans, useLingui } from "@lingui/solid/macro";
 import { useQueryClient } from "@tanstack/solid-query";
@@ -20,9 +20,18 @@ import MdBadge from "@material-design-icons/svg/filled/badge.svg?component-solid
 
 import { useSettingsNavigation } from "../../Settings";
 
+type AttachedControl<T> = {
+  name: string;
+  value: T;
+};
+
 interface Props {
   user: User;
   profile?: UserProfile;
+  attach?: AttachedControl<unknown>[];
+  onSubmit?: (g: IFormGroup) => void;
+  onReset?: (g: IFormGroup) => void;
+  children?: (g: IFormGroup) => JSX.Element;
 }
 
 export function UserProfileEditor(props: Props) {
@@ -42,6 +51,15 @@ export function UserProfileEditor(props: Props) {
     pronouns: createFormControl<string>(props.user.pronouns),
     banner: createFormControl<string | File[] | null>(null),
     bio: createFormControl(""),
+    ...(props.attach
+      ? props.attach.reduce(
+          (attached, toAttach) => ({
+            [toAttach.name]: createFormControl(toAttach.value),
+            ...attached,
+          }),
+          {},
+        )
+      : {}),
   });
   /* eslint-enable solid/reactivity */
 
@@ -75,6 +93,10 @@ export function UserProfileEditor(props: Props) {
       );
       editGroup.controls.bio.setValue(props.profile.content || "");
       setInitialBio([props.profile.content || ""]);
+    }
+
+    if (props.onReset) {
+      props.onReset(editGroup);
     }
   }
 
@@ -152,6 +174,10 @@ export function UserProfileEditor(props: Props) {
         content: editGroup.controls.bio.value,
       });
     }
+
+    if (props.onSubmit) {
+      props.onSubmit(editGroup);
+    }
   }
 
   const submit = Form2.useSubmitHandler(editGroup, onSubmit, onReset);
@@ -191,7 +217,6 @@ export function UserProfileEditor(props: Props) {
           control={editGroup.controls.pronouns}
           label={t`Pronouns`}
         />
-
         <Show when={!props.user.bot}>
           <CategoryButton
             icon={<MdBadge />}
@@ -204,7 +229,6 @@ export function UserProfileEditor(props: Props) {
             <Trans>Want to change username?</Trans>
           </CategoryButton>
         </Show>
-
         <Text class="label">
           <Trans>Profile Bio</Trans>
         </Text>
@@ -213,6 +237,7 @@ export function UserProfileEditor(props: Props) {
           control={editGroup.controls.bio}
           placeholder={t`Something cool about me...`}
         />
+        {props.children?.(editGroup)}
 
         <Row>
           <Form2.Reset group={editGroup} onReset={onReset} />


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #1481

Adds a toggle below the profile editor to toggle whether a bot is public or not.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Bots can be made public and private 

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<img width="953" height="257" alt="image" src="https://github.com/user-attachments/assets/108729c2-6e49-467b-9d25-c6a0ef8312ce" />

<img width="953" height="257" alt="image" src="https://github.com/user-attachments/assets/82deb64c-1342-4d0a-95d6-c64186b908e5" />


<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No ai was used to author this PR.
