### PR TITLE
fix: keybind input queue not clearing when focus is dropped

### DIFF
--- a/packages/client/components/keybinds/keybindHandler.tsx
+++ b/packages/client/components/keybinds/keybindHandler.tsx
@@ -130,12 +130,18 @@ export function KeybindContext(props: { children: JSXElement }) {
     activeKeys.delete(event.key);
   }
 
+  function onFocusDropped(_: FocusEvent) {
+    activeKeys.clear();
+  }
+
   document.body.addEventListener("keydown", onKeyDown);
   document.body.addEventListener("keyup", onKeyUp);
+  window.addEventListener("blur", onFocusDropped);
 
   onCleanup(() => {
     document.body.removeEventListener("keydown", onKeyDown);
     document.body.removeEventListener("keyup", onKeyUp);
+    window.removeEventListener("blur", onFocusDropped);
   });
 
   return (


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #480

The keybind input queue wasn't being cleared when the window lost focus, which lead to issues such as accidentally pressing the up arrow and being sent to another channel, or pressing right and being sent to a random server. This should no longer happen because the queue now gets cleared on "blur" (focus lost). 


## How was this PR tested?


- [x] Keybind queue is cleared correctly on focus lost
- [x] Can't trigger any other keybinds by going in and out of the app while pressing a modifier key.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No ai was used to author this PR.
