### PR TITLE
fix: Allow re-viewing existing invite codes

### DIFF
--- a/packages/client/components/app/interface/settings/server/invites/ListServerInvites.tsx
+++ b/packages/client/components/app/interface/settings/server/invites/ListServerInvites.tsx
@@ -3,9 +3,11 @@ import { For, Match, Switch } from "solid-js";
 import { Trans, useLingui } from "@lingui/solid/macro";
 import { useQuery, useQueryClient } from "@tanstack/solid-query";
 import { Channel, Server, ServerInvite } from "stoat.js";
-import { styled } from "styled-system/jsx";
+import { css } from "styled-system/css";
 
+import { useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
+import { getInviteLink } from "@revolt/modal/modals/CreateInvite";
 import {
   Avatar,
   Button,
@@ -23,6 +25,7 @@ import {
 export function ListServerInvites(props: { server: Server }) {
   const { t } = useLingui();
   const client = useQueryClient();
+  const instance = useInstance();
   const { showError, openModal } = useModals();
   const query = useQuery(() => ({
     queryKey: ["invites", props.server.id],
@@ -104,21 +107,25 @@ export function ListServerInvites(props: { server: Server }) {
                         </Column>
                       </Row>
                     </DataTable.Cell>
-                    <DataTable.Cell>
-                      <Link
-                        href="#"
-                        onClick={() => {
-                          const channel = item.channel || defaultChannel();
-                          if (channel)
-                            openModal({
-                              type: "create_invite",
-                              channel,
-                              id: item.id,
-                            });
+                    <DataTable.Cell class={itemIds}>
+                      {item.id}
+                      <Button
+                        size="icon"
+                        variant="text"
+                        use:floating={{
+                          tooltip: {
+                            placement: "bottom",
+                            content: t`Copy invite link`,
+                          },
                         }}
+                        onPress={() =>
+                          navigator.clipboard.writeText(
+                            getInviteLink(item.id, instance),
+                          )
+                        }
                       >
-                        {item.id}
-                      </Link>
+                        <Symbol size={20}>content_copy</Symbol>
+                      </Button>
                     </DataTable.Cell>
                     <DataTable.Cell width="40px">
                       <Button
@@ -146,10 +153,10 @@ export function ListServerInvites(props: { server: Server }) {
   );
 }
 
-const Link = styled("a", {
-  base: {
-    color: "var(--md-sys-color-primary)",
-    cursor: "pointer",
-    "&:hover": { textDecoration: "underline" },
+const itemIds = css({
+  "& button": {
+    display: "inline-block",
+    verticalAlign: "middle",
+    marginLeft: "var(--gap-sm)",
   },
 });

--- a/packages/client/components/app/interface/settings/server/invites/ListServerInvites.tsx
+++ b/packages/client/components/app/interface/settings/server/invites/ListServerInvites.tsx
@@ -2,7 +2,8 @@ import { For, Match, Switch } from "solid-js";
 
 import { Trans, useLingui } from "@lingui/solid/macro";
 import { useQuery, useQueryClient } from "@tanstack/solid-query";
-import { Server, ServerInvite } from "stoat.js";
+import { Channel, Server, ServerInvite } from "stoat.js";
+import { styled } from "styled-system/jsx";
 
 import { useModals } from "@revolt/modal";
 import {
@@ -12,10 +13,9 @@ import {
   Column,
   DataTable,
   Row,
+  Symbol,
   Text,
 } from "@revolt/ui";
-
-import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-solid";
 
 /**
  * List and invalidate server invites
@@ -29,8 +29,10 @@ export function ListServerInvites(props: { server: Server }) {
     queryFn: () => props.server.fetchInvites() as Promise<ServerInvite[]>,
   }));
 
-  const serverDoesntHaveChannels = () =>
-    !props.server.defaultChannel || props.server.channels.length == 0;
+  const defaultChannel = () =>
+    (props.server.defaultChannel || props.server.channels[0]) as
+      | Channel
+      | undefined;
 
   async function deleteInvite(invite: ServerInvite) {
     try {
@@ -45,14 +47,8 @@ export function ListServerInvites(props: { server: Server }) {
   }
 
   async function createInvite() {
-    const defaultChannel =
-      props.server.defaultChannel || props.server.channels[0] || null;
-    if (defaultChannel) {
-      openModal({
-        type: "create_invite",
-        channel: defaultChannel,
-      });
-    }
+    const channel = defaultChannel();
+    if (channel) openModal({ type: "create_invite", channel });
   }
 
   return (
@@ -60,9 +56,9 @@ export function ListServerInvites(props: { server: Server }) {
       <Button
         group="standard"
         onPress={createInvite}
-        isDisabled={serverDoesntHaveChannels()}
+        isDisabled={!defaultChannel()}
         use:floating={{
-          tooltip: serverDoesntHaveChannels()
+          tooltip: !defaultChannel()
             ? {
                 content: t`Create a channel before inviting others!`,
                 placement: "bottom",
@@ -108,11 +104,26 @@ export function ListServerInvites(props: { server: Server }) {
                         </Column>
                       </Row>
                     </DataTable.Cell>
-                    <DataTable.Cell>{item.id}</DataTable.Cell>
+                    <DataTable.Cell>
+                      <Link
+                        href="#"
+                        onClick={() => {
+                          const channel = item.channel || defaultChannel();
+                          if (channel)
+                            openModal({
+                              type: "create_invite",
+                              channel,
+                              id: item.id,
+                            });
+                        }}
+                      >
+                        {item.id}
+                      </Link>
+                    </DataTable.Cell>
                     <DataTable.Cell width="40px">
                       <Button
                         size="icon"
-                        variant="filled"
+                        variant="_error"
                         use:floating={{
                           tooltip: {
                             placement: "bottom",
@@ -121,7 +132,7 @@ export function ListServerInvites(props: { server: Server }) {
                         }}
                         onPress={() => deleteInvite(item)}
                       >
-                        <MdDelete />
+                        <Symbol>delete</Symbol>
                       </Button>
                     </DataTable.Cell>
                   </DataTable.Row>
@@ -134,3 +145,11 @@ export function ListServerInvites(props: { server: Server }) {
     </Column>
   );
 }
+
+const Link = styled("a", {
+  base: {
+    color: "var(--md-sys-color-primary)",
+    cursor: "pointer",
+    "&:hover": { textDecoration: "underline" },
+  },
+});

--- a/packages/client/components/modal/modals/CreateInvite.tsx
+++ b/packages/client/components/modal/modals/CreateInvite.tsx
@@ -5,6 +5,7 @@ import { useMutation } from "@tanstack/solid-query";
 import { styled } from "styled-system/jsx";
 
 import { useInstance } from "@revolt/instance";
+import Instance from "@revolt/instance/Instance";
 import { Dialog, DialogProps } from "@revolt/ui";
 
 import { useModals } from "..";
@@ -28,6 +29,10 @@ const Invite = styled("div", {
   },
 });
 
+/** Get absolute link from invite id */
+export const getInviteLink = (id: string, inst: Instance) =>
+  inst.isStoat ? `https://stt.gg/${id}` : inst.href(`/invite/${id}`);
+
 /**
  * Modal to create a new invite
  */
@@ -38,33 +43,21 @@ export function CreateInviteModal(
   const [link, setLink] = createSignal("...");
   const instance = useInstance();
 
-  const setId = (id: string) =>
-    setLink(
-      instance.isStoat
-        ? `https://stt.gg/${id}`
-        : instance.href(`/invite/${id}`),
-    );
-
   const fetchInvite = useMutation(() => ({
     mutationFn: () =>
-      props.channel.createInvite().then(({ _id }) => setId(_id)),
+      props.channel
+        .createInvite()
+        .then(({ _id }) => setLink(getInviteLink(_id, instance))),
     onError: showError,
   }));
 
-  onMount(() => {
-    if (props.id) setId(props.id);
-    else fetchInvite.mutate();
-  });
+  onMount(() => fetchInvite.mutate());
 
   return (
     <Dialog
       show={props.show}
       onClose={props.onClose}
-      title={
-        <Show when={props.id} fallback={<Trans>Create Invite</Trans>}>
-          <Trans>View Invite</Trans>
-        </Show>
-      }
+      title={<Trans>Create Invite</Trans>}
       actions={[
         { text: <Trans>OK</Trans> },
         {
@@ -81,8 +74,9 @@ export function CreateInviteModal(
         fallback={<Trans>Generating invite…</Trans>}
       >
         <Invite>
-          <Trans>Here is your invite code:</Trans>
-          <code>{link()}</code>
+          <Trans>
+            Here is your new invite code: <code>{link()}</code>
+          </Trans>
         </Invite>
       </Show>
     </Dialog>

--- a/packages/client/components/modal/modals/CreateInvite.tsx
+++ b/packages/client/components/modal/modals/CreateInvite.tsx
@@ -38,27 +38,33 @@ export function CreateInviteModal(
   const [link, setLink] = createSignal("...");
   const instance = useInstance();
 
+  const setId = (id: string) =>
+    setLink(
+      instance.isStoat
+        ? `https://stt.gg/${id}`
+        : instance.href(`/invite/${id}`),
+    );
+
   const fetchInvite = useMutation(() => ({
     mutationFn: () =>
-      props.channel
-        .createInvite()
-        .then(({ _id }) =>
-          setLink(
-            instance.isStoat
-              ? `https://stt.gg/${_id}`
-              : instance.href(`/invite/${_id}`),
-          ),
-        ),
+      props.channel.createInvite().then(({ _id }) => setId(_id)),
     onError: showError,
   }));
 
-  onMount(() => fetchInvite.mutate());
+  onMount(() => {
+    if (props.id) setId(props.id);
+    else fetchInvite.mutate();
+  });
 
   return (
     <Dialog
       show={props.show}
       onClose={props.onClose}
-      title={<Trans>Create Invite</Trans>}
+      title={
+        <Show when={props.id} fallback={<Trans>Create Invite</Trans>}>
+          <Trans>View Invite</Trans>
+        </Show>
+      }
       actions={[
         { text: <Trans>OK</Trans> },
         {
@@ -75,9 +81,8 @@ export function CreateInviteModal(
         fallback={<Trans>Generating invite…</Trans>}
       >
         <Invite>
-          <Trans>
-            Here is your new invite code: <code>{link()}</code>
-          </Trans>
+          <Trans>Here is your invite code:</Trans>
+          <code>{link()}</code>
         </Invite>
       </Show>
     </Dialog>

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -97,6 +97,7 @@ export type Modals =
   | {
       type: "create_invite";
       channel: Channel;
+      id?: string;
     }
   | {
       type: "create_server";

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -97,7 +97,6 @@ export type Modals =
   | {
       type: "create_invite";
       channel: Channel;
-      id?: string;
     }
   | {
       type: "create_server";


### PR DESCRIPTION
Also refactors to use Symbols (like infi said we may as well do that whenever updating the UI)

~~Rather than make a whole new modal for viewing the code, I just edited the new invite modal slightly to show existing invites too.~~ Update, using copy button instead based on Dadadah's suggestion.

## How was this PR tested?

By making/viewing some invites and then deleting them.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

First attempt:\
<img width=400 src="https://github.com/user-attachments/assets/021c5099-bf34-4fc4-bf38-936d40885e86" /> <img width=300 src="https://github.com/user-attachments/assets/6a5097da-703f-4efd-8c5d-50e52809c6f2" />

Update, new UI:\
<img width=400 src="https://github.com/user-attachments/assets/4210e707-35e6-4050-aca4-9833b3eb2f08" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None, because I'm Artificially Indifferent.

- `main` <!-- branch-stack -->
  - \#1488 :point\_left:
