### PR TITLE
fix: prefer display name on replies

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/MessageReply.tsx
@@ -129,7 +129,12 @@ export function MessageReply(props: Props) {
             <NonBreakingText>
               <Username
                 colour={props.message!.roleColour!}
-                username={(props.mention ? "@" : "") + props.message!.username}
+                username={
+                  (props.mention ? "@" : "") +
+                  (props.message!.member?.nickname ??
+                    props.message!.author?.displayName ??
+                    props.message!.username)
+                }
               />
             </NonBreakingText>
           </div>


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #1379

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Reply uses Nickname if available
- [x] Reply falls back to Display Name if available and nickname is not available
- [x] Reply falls back to Username if none are available 

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

### Nickname

<img width="225" height="32" alt="image" src="https://github.com/user-attachments/assets/da8a436a-86d1-472d-8835-2385d7e1996f" />

### Display Name

<img width="225" height="32" alt="image" src="https://github.com/user-attachments/assets/9db84aed-2544-4be8-bcec-14189d0e3fdb" />

### Username (current)

<img width="276" height="86" alt="image" src="https://github.com/user-attachments/assets/e397e80b-cb5e-494a-8639-15657fc5f8b2" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used to author this pull request.
