### PR TITLE
fix: unable to remove display name from profile

### DIFF
--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -84,7 +84,11 @@ export function UserProfileEditor(props: Props) {
     };
 
     if (editGroup.controls.displayName.isDirty) {
-      changes.display_name = editGroup.controls.displayName.value.trim();
+      if (!editGroup.controls.displayName.value) {
+        changes.remove!.push("DisplayName");
+      } else {
+        changes.display_name = editGroup.controls.displayName.value.trim();
+      }
     }
 
     if (editGroup.controls.avatar.isDirty) {


### PR DESCRIPTION
Funny issue I found while testing one of my PRs. It follows the same pattern found on the other fields.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Emptied the display name field to remove the display name

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used to author this pull request.
