### PR TITLE
feat: show embed icon for user/bot embeds (if present)

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
@@ -30,7 +30,7 @@ const Base = styled("div", {
   },
 });
 
-const SiteInformation = styled("div", {
+const InformationRow = styled("div", {
   base: {
     display: "flex",
     flexDirection: "row",
@@ -94,7 +94,7 @@ export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
             (props.embed as WebsiteEmbed).siteName
           }
         >
-          <SiteInformation>
+          <InformationRow>
             <Show when={props.embed.iconUrl}>
               <Favicon
                 loading="lazy"
@@ -108,15 +108,25 @@ export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
                 {(props.embed as WebsiteEmbed).siteName}
               </Text>
             </OverflowingText>
-          </SiteInformation>
+          </InformationRow>
         </Show>
 
         <Show when={props.embed.title}>
-          <RenderAnchor href={props.embed.url}>
-            <Title>
-              <OverflowingText>{props.embed.title}</OverflowingText>
-            </Title>
-          </RenderAnchor>
+          <InformationRow>
+            <Show when={props.embed.iconUrl}>
+              <Favicon
+                loading="lazy"
+                draggable={false}
+                src={props.embed.proxiedIconURL}
+                onError={(e) => (e.currentTarget.style.display = "none")}
+              />
+            </Show>
+            <RenderAnchor href={props.embed.url}>
+              <Title>
+                <OverflowingText>{props.embed.title}</OverflowingText>
+              </Title>
+            </RenderAnchor>
+          </InformationRow>
         </Show>
 
         <Show when={props.embed.description}>


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #1325 (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Embeds that have a `icon_url` field are displayed with the provided (proxied) icon
- [x] Website embeds still work
- [x] Embeds without an icon omit it

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

### With `icon_url`

<img width="338" height="177" alt="image" src="https://github.com/user-attachments/assets/b5338b0d-41f4-447f-8b40-ddc1b337a9be" />

### Without `icon_url`

<img width="524" height="214" alt="image" src="https://github.com/user-attachments/assets/12654cba-393a-4da9-850d-daa1a30ab8ac" />


<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used to author this pull request.
