### PR TITLE
fix: allow selecting channel description in ChannelInfoModal

### DIFF
--- a/packages/client/components/modal/modals/ChannelInfo.tsx
+++ b/packages/client/components/modal/modals/ChannelInfo.tsx
@@ -3,6 +3,7 @@ import { Trans } from "@lingui/solid/macro";
 import { Markdown } from "@revolt/markdown";
 import { Dialog, DialogProps } from "@revolt/ui";
 
+import { css } from "styled-system/css";
 import { Modals } from "../types";
 
 export function ChannelInfoModal(
@@ -15,7 +16,9 @@ export function ChannelInfoModal(
       title={`#${props.channel.name}`}
       actions={[{ text: <Trans>Close</Trans> }]}
     >
-      <Markdown content={props.channel.description!} />
+      <div class={css({ userSelect: "text" })}>
+        <Markdown content={props.channel.description!} />
+      </div>
     </Dialog>
   );
 }


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #1117

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Description in modal is able to be selected
- [x] Description in modal can be copied

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<img width="741" height="261" alt="image" src="https://github.com/user-attachments/assets/b4952511-b43e-4b5a-98b7-7c01d4f9263c" />


</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used to author this pull request.
