### PR TITLE
fix: Always ensure the stream starts as below 720p

### DIFF
--- a/packages/client/components/rtc/index.ts
+++ b/packages/client/components/rtc/index.ts
@@ -1,4 +1,4 @@
-import { setupVirtualMic } from "./virtualMic";
+import { getVirtmic } from "./virtualMic";
 
 export { useVoice, VoiceContext } from "./state";
 
@@ -6,4 +6,47 @@ export { InRoom } from "./components/InRoom";
 export { RoomAudioManager } from "./components/RoomAudioManager";
 export { stoatSinkName } from "./virtualMic";
 
-setupVirtualMic();
+const originalMediaCall = navigator.mediaDevices.getDisplayMedia;
+
+navigator.mediaDevices.getDisplayMedia = async function (opts) {
+  // Hard overwrite the track constraints so that we -never ever- get a track
+  // that is over 720p when requesting a new video track
+  if (opts && opts.video && typeof opts.video === "object") {
+    console.log(opts);
+    opts.video = {
+      ...opts.video,
+      frameRate: { ideal: 5, max: 5 },
+      width: { ideal: 640, max: 640 },
+      height: { ideal: 480, max: 480 },
+    };
+  }
+
+  const stream: MediaStream = await originalMediaCall.call(this, opts);
+
+  if (opts && opts.audio && window.native?.isWayland?.()) {
+    const id = await getVirtmic();
+
+    console.debug("Virt mic acquired:", id);
+
+    if (id) {
+      const audio = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          deviceId: {
+            exact: id,
+          },
+          autoGainControl: false,
+          echoCancellation: false,
+          noiseSuppression: false,
+          channelCount: 2,
+          sampleRate: 48000,
+          sampleSize: 16,
+        },
+      });
+
+      stream.getAudioTracks().forEach((t) => stream.removeTrack(t));
+      stream.addTrack(audio.getAudioTracks()[0]);
+    }
+  }
+
+  return stream;
+};

--- a/packages/client/components/rtc/index.ts
+++ b/packages/client/components/rtc/index.ts
@@ -12,7 +12,6 @@ navigator.mediaDevices.getDisplayMedia = async function (opts) {
   // Hard overwrite the track constraints so that we -never ever- get a track
   // that is over 720p when requesting a new video track
   if (opts && opts.video && typeof opts.video === "object") {
-    console.log(opts);
     opts.video = {
       ...opts.video,
       frameRate: { ideal: 5, max: 5 },

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -548,11 +548,17 @@ class Voice {
                 width:
                   quality.resolution.width === 0
                     ? undefined
-                    : { max: quality.resolution.width },
+                    : {
+                        ideal: quality.resolution.width,
+                        max: quality.resolution.width,
+                      },
                 height:
                   quality.resolution.width === 0
                     ? undefined
-                    : { max: quality.resolution.height },
+                    : {
+                        ideal: quality.resolution.width,
+                        max: quality.resolution.height,
+                      },
               });
               localTrack.videoTrack.mediaStreamTrack.contentHint =
                 quality.contentHint;

--- a/packages/client/components/rtc/virtualMic.ts
+++ b/packages/client/components/rtc/virtualMic.ts
@@ -1,48 +1,11 @@
 export const stoatSinkName = "stoat-virtual-source";
 
-export function setupVirtualMic() {
-  if (window.native?.isWayland?.()) {
-    const original = navigator.mediaDevices.getDisplayMedia;
-
-    async function getVirtmic() {
-      try {
-        const devices = await navigator.mediaDevices.enumerateDevices();
-        const audioDevice = devices.find(
-          ({ label }) => label === stoatSinkName,
-        );
-        return audioDevice?.deviceId;
-      } catch {
-        return null;
-      }
-    }
-
-    navigator.mediaDevices.getDisplayMedia = async function (opts) {
-      const stream: MediaStream = await original.call(this, opts);
-      if (opts && !opts.audio) return stream;
-      const id = await getVirtmic();
-
-      console.debug("Virt mic acquired:", id);
-
-      if (id) {
-        const audio = await navigator.mediaDevices.getUserMedia({
-          audio: {
-            deviceId: {
-              exact: id,
-            },
-            autoGainControl: false,
-            echoCancellation: false,
-            noiseSuppression: false,
-            channelCount: 2,
-            sampleRate: 48000,
-            sampleSize: 16,
-          },
-        });
-
-        stream.getAudioTracks().forEach((t) => stream.removeTrack(t));
-        stream.addTrack(audio.getAudioTracks()[0]);
-      }
-
-      return stream;
-    };
+export async function getVirtmic() {
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const audioDevice = devices.find(({ label }) => label === stoatSinkName);
+    return audioDevice?.deviceId;
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
Many users are having an issue where they get kicked from the call when screen sharing. This PR might fix that, though I am unable to replicate it so I don't know for sure.

This PR forces the stream to always start at max 420p no matter what. The stream is then enlarged to the correct size afterwards.

No UI changes

## How was this PR tested?

Started streams and checked they met the expected resolution and framerate

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1497 :point\_left:
