### PR TITLE
fix: emoji/gif picker search input cannot regain focus

### DIFF
--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -155,11 +155,6 @@ export function EmojiPicker() {
         variant="outlined"
         placeholder="Search for emojis..."
         value={filter()}
-        onMouseDown={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          e.stopImmediatePropagation();
-        }}
         onInput={(e) => setFilter(e.currentTarget.value)}
       />
       <Row gap={"none"} class={compositionContent()}>

--- a/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/GifPicker.tsx
@@ -84,11 +84,6 @@ export function GifPicker() {
           variant="outlined"
           placeholder="Search for GIFs..."
           value={filter()}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            e.stopImmediatePropagation();
-          }}
           onChange={(e) => setFilter(e.currentTarget.value)}
         />
       </SearchArea>


### PR DESCRIPTION
<!-- Describe your changes -->
Fixes #1486

Removed the `onMouseDown` handler on the search inputs in both the emoji and GIF pickers.

Calling `preventDefault()` on an `<input>` stops the browser from focusing it on click. Once focus moved away from the search field (like clicking an emoji or anywhere inside the picker frame), clicking back into the input wouldn't return focus, forcing you to close and reopen the picker to type again.

Removing the handler lets standard click focus work normally. The `stopPropagation()` / `stopImmediatePropagation()` calls alongside it were removed as redundant: the dismissal listener on window checks `floating()?.contains(e.target)` before closing, so letting the event through changes nothing.

Intentionally left untouched:
- `onMouseDown` on the emoji picker's server rail items and on the GIF picker's tiles, categories, and other clickable areas (suppressing focus there is correct).
- The search input's `autoFocus` prop (picker still opens with focus in the search box).
- Text insertion behavior (`TextEditor` manages its own focus and selection insertion on selection).

For reference on the full inventory across both files:
- **EmojiPicker:** 2 handlers total (search input removed; `ServerItem` kept).
- **GifPicker:** 7 handlers total (search input removed; back-to-categories button, Gifbox explainer, category tiles, empty-state, GIF tiles, end-of-results kept).

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Opened emoji picker, clicked an item/picker area to lose search focus, clicked back into the search box to verify focus returns and typing works.
- [x] Verified the same focus/refocus behavior in the GIF picker search input.
- [x] Confirmed selecting emojis/GIFs still inserts into the editor as expected.
- [x] Checked that initial autoFocus on picker open still works.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

N/A

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None