### PR TITLE
feat: join voice automatically when opening a voice channel

### DIFF
--- a/packages/client/src/interface/channels/text/TextChannel.tsx
+++ b/packages/client/src/interface/channels/text/TextChannel.tsx
@@ -16,6 +16,7 @@ import { DraftMessages, Messages } from "@revolt/app";
 import { useClient } from "@revolt/client";
 import { Keybind, KeybindAction, createKeybind } from "@revolt/keybinds";
 import { useNavigate, useSmartParams } from "@revolt/routing";
+import { useVoice } from "@revolt/rtc";
 import { useState } from "@revolt/state";
 import { LAYOUT_SECTIONS } from "@revolt/state/stores/Layout";
 import {
@@ -76,6 +77,7 @@ const LARGE_SERVERS = [
 export function TextChannel(props: ChannelPageProps) {
   const state = useState();
   const client = useClient();
+  const voice = useVoice();
 
   // Last unread message id
   const [lastId, setLastId] = createSignal<string>();
@@ -92,6 +94,29 @@ export function TextChannel(props: ChannelPageProps) {
 
   const canConnect = () =>
     props.channel.isVoice && props.channel.havePermission("Connect");
+
+  // Opening a voice channel is already the intent to join it, so connect right
+  // away instead of making the user click the call card as well.
+  //
+  // Two cases are deliberately left out:
+  //  - DMs and groups, which are voice capable but must never start ringing
+  //    someone just because their conversation was opened;
+  //  - any channel opened while already in a call, since that would drop the
+  //    current call; switching stays a manual action on the call card.
+  createEffect(
+    on(
+      () => props.channel.id,
+      () => {
+        if (
+          props.channel.type === "TextChannel" &&
+          canConnect() &&
+          voice.state() === "READY"
+        ) {
+          voice.connect(props.channel);
+        }
+      },
+    ),
+  );
 
   // Get a reference to the message box's load latest function
   let jumpToBottomRef: ((nearby?: string) => void) | undefined;


### PR DESCRIPTION
Opening a voice channel already expresses the intent to join it, but today connecting takes a second click on the "Join the voice channel" card. This connects on navigation instead.

`TextChannel` gains an effect keyed on the channel id that calls the same `voice.connect()` the call card's `onClick` already used, so there is no new connection path — only an earlier trigger for the existing one.

Two cases are deliberately excluded:

- **DMs and groups.** `Channel#isVoice` is also true for `DirectMessage` and `Group`, so without the `type === "TextChannel"` guard, opening a conversation would start ringing the other side.
- **Opening a channel while already in a call.** `connect()` disconnects first, so auto-connecting here would drop an ongoing call just because another voice channel was opened to read its chat. The card keeps showing "Switch to this voice channel" and switching stays a manual action.

## How was this PR tested?

- [x] `tsc --noEmit` on `packages/client` (after building `stoat.js` and `solid-livekit-components`) reports no errors from this change; the only remaining error is the pre-existing missing generated lingui catalog.
- [x] `prettier --check` and `eslint` are clean on the changed file.
- [ ] Not exercised at runtime against a live instance — the behaviour itself is unverified and worth a reviewer's attention.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

The patch and this description were drafted by Claude Code (Claude Opus 5), working from my report of the behaviour I wanted. I reviewed the diff and the two scoping decisions above — excluding DMs/groups, and refusing to drop an ongoing call — before opening the PR.

I am aware the contributing guide asks contributors to avoid PRs generated entirely by language models; I am declaring this openly rather than passing it off as hand-written, and I am happy to rework or close it if that is not acceptable here.