### PR TITLE
fix: limit users in voice call preview to 3, like on android

### DIFF
--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPreview.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPreview.tsx
@@ -83,7 +83,7 @@ const Avatars = styled("div", {
     height: "fit-content",
 
     "& :not(:first-child)": {
-      marginInlineStart: "-6px",
+      marginInlineStart: "-9px",
     },
   },
 });

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPreview.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPreview.tsx
@@ -6,9 +6,9 @@ import { styled } from "styled-system/jsx";
 
 import { useUsers } from "@revolt/markdown/users";
 import { useVoice } from "@revolt/rtc";
-import { Avatar, Ripple, Text } from "@revolt/ui/components/design";
-import { Row } from "@revolt/ui/components/layout";
+import { Avatar, Ripple, Text, typography } from "@revolt/ui/components/design";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
+import { css } from "styled-system/css";
 
 /**
  * Call card (preview)
@@ -25,19 +25,25 @@ export function VoiceCallCardPreview(props: { channel: Channel }) {
       .map((user) => user?.username)
       .filter((x) => x);
 
-    return names.length ? t`With ${names.join(", ")}` : t`Start the call`;
+    if (names.length > 3) {
+      return t`with ${names.length} others`;
+    } else if (names.length && names.length !== 0) {
+      return t`with ${names.join(", ")}`;
+    } else {
+      return t`Start the call`;
+    }
   }
 
   return (
     <Preview onClick={() => voice.connect(props.channel)}>
       <Ripple />
-      <Row>
+      <Avatars>
         <For each={users()} fallback={<Symbol size={24}>voice_chat</Symbol>}>
           {(user) => (
             <Avatar size={24} src={user?.avatar} fallback={user?.username} />
           )}
         </For>
-      </Row>
+      </Avatars>
       <Text class="title" size="large">
         <Show
           when={voice.state() === "READY"}
@@ -46,7 +52,9 @@ export function VoiceCallCardPreview(props: { channel: Channel }) {
           <Trans>Join the voice channel</Trans>
         </Show>
       </Text>
-      <Text class="body">{subtext()}</Text>
+      <p class={css(typography.raw({ class: "body" }), LineClampText)}>
+        {subtext()}
+      </p>
     </Preview>
   );
 }
@@ -66,4 +74,22 @@ const Preview = styled("div", {
 
     color: "var(--md-sys-color-on-surface)",
   },
+});
+
+const Avatars = styled("div", {
+  base: {
+    display: "flex",
+    flexShrink: 0,
+    height: "fit-content",
+
+    "& :not(:first-child)": {
+      marginInlineStart: "-6px",
+    },
+  },
+});
+
+const LineClampText = css.raw({
+  lineClamp: "2",
+  overflow: "hidden",
+  display: "-webkit-box",
 });


### PR DESCRIPTION
The voice call preview card was overflowing when multiple people joined at once. This PR makes it so that
it doesn't overflow when there are too many people inside of it, matching the behaviour present on Stoat for Android.

## How was this PR tested?

- [x] Call card shows "With <user 1>, <user 2>, <user 3>" when there are at least 3 people in the call
- [x] Call card shows "With <no. of users in call>" when there are more than 3 people in the call
- [x] Call card shows "Start the call" when there are no people in the call

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

## With more than 3 users
<img width="480" height="164" alt="image" src="https://github.com/user-attachments/assets/91bde602-3d06-4a6a-bc72-25f7e67e33f1" />

## With three users or less
<img width="480" height="164" alt="image" src="https://github.com/user-attachments/assets/a4cb34c4-cc1a-4ce1-b19d-7465a4bcb329" />

## With no users in the call
<img width="480" height="164" alt="image" src="https://github.com/user-attachments/assets/7e4cb1d3-5412-4ba1-9ac3-52f2ab581ec6" />

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used when authoring this pull request.
