### PR TITLE
fix: Limit camera to 720p

### DIFF
--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -218,6 +218,11 @@ class Voice {
         deviceId: this.#settings.preferredAudioOutputDevice,
       },
       videoCaptureDefaults: {
+        resolution: {
+          width: 1280,
+          height: 720,
+          frameRate: 30,
+        },
         deviceId: this.#settings.preferredVideoDevice,
       },
     });


### PR DESCRIPTION
Many users are disconnecting when starting their camera. I think this will fix it. Related to previous fix forcing screen share to be 720p.

No UI changes

## How was this PR tested?

I started camera and didn't get kicked

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1513 :point\_left:
