### PR TITLE
fix: Improve file size error message in FormFileInput component

### DIFF
--- a/packages/client/components/ui/components/utils/Form2.tsx
+++ b/packages/client/components/ui/components/utils/Form2.tsx
@@ -28,6 +28,7 @@ import { TextEditor2 } from "../features/texteditor/TextEditor2";
 import { Row } from "../layout";
 
 import { FileInput, humanFileSize } from "./files";
+import { Symbol } from "./Symbol";
 
 /**
  * Form wrapper for TextField
@@ -179,10 +180,10 @@ const FormFileInput = (
             local.maxSize &&
             files[0].size > local.maxSize
           ) {
+            const maxSizeFormatted = humanFileSize(local.maxSize);
+
             local.control.setErrors({
-              error: new Error(
-                t`File must be smaller than ${humanFileSize(local.maxSize)}`,
-              ),
+              error: t`File must be smaller than ${maxSizeFormatted}`,
             });
             local.control.markTouched(true);
             return;
@@ -205,15 +206,38 @@ const FormFileInput = (
           !local.hideErrors && local.control.isTouched && !local.control.isValid
         }
       >
-        <For each={Object.keys(local.control.errors!)}>
-          {(errorMsg: string) => (
-            <small>{local.control.errors![errorMsg]}</small>
-          )}
-        </For>
+        <FileError role="alert">
+          <Symbol size={18}>error</Symbol>
+          <div>
+            <For each={Object.keys(local.control.errors!)}>
+              {(errorMsg: string) => (
+                <div>{local.control.errors![errorMsg]}</div>
+              )}
+            </For>
+          </div>
+        </FileError>
       </Show>
     </>
   );
 };
+
+const FileError = styled("div", {
+  base: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: "var(--gap-sm)",
+    marginTop: "var(--gap-sm)",
+    padding: "var(--gap-sm) var(--gap-md)",
+
+    backgroundColor: "var(--md-sys-color-error-container)",
+    color: "var(--md-sys-color-on-error-container)",
+    borderRadius: "var(--borderRadius-sm)",
+    overflowWrap: "anywhere",
+
+    fontSize: "0.75rem",
+    lineHeight: "1rem",
+  },
+});
 
 /**
  * Form wrapper for Checkbox


### PR DESCRIPTION
  ## Summary

  Improves oversized image validation feedback in `Form2.FileInput`.

  The error is now displayed as a clear, accessible inline alert with an error icon, error-container styling, and the maximum allowed size. This applies to profile and server avatars/banners and other image fields
  that use the shared component.

  ## How was this PR tested?

  - [x] Started the client locally with `mise dev`
  - [x] Selected an image larger than the configured limit
  - [x] Confirmed that the image is rejected and a visible inline error is shown
  - [x] Confirmed that a visible inline error shows the allowed maximum size
  - [x] Ran `pnpm --filter client exec prettier --check components/ui/components/utils/Form2.tsx`
  - [x] Ran `pnpm --filter client exec tsc --noEmit`

  <details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

  <!-- Add a screenshot showing the inline error here. -->
  
<img width="722" height="372" alt="screenshot-file-size-error-feedback" src="https://github.com/user-attachments/assets/958564a0-aa3b-4cb0-8cb2-b72573f10138" />

  </details>

  ## Checklist:

  - [x] I have carefully read the contributing guidelines
  - [x] I have performed a self-review of my own code
  - [x] I have made corresponding changes to the documentation if applicable
  - [x] I have no unrelated changes in the PR
  - [x] I have confirmed that no new dependencies are necessary
  - [ ] I have written tests for new code (no existing component test setup covers this UI path)
  - [x] I have followed naming conventions/patterns in the surrounding code

  ## Please declare, if any, LLM usage involved in creating this PR

  Codex was used to assist with investigation and implementation. The change was reviewed and tested manually by the contributor.