### PR TITLE
feat(auth): add custom server login

### DIFF
--- a/packages/client/components/auth/src/flows/FlowConnect.tsx
+++ b/packages/client/components/auth/src/flows/FlowConnect.tsx
@@ -1,0 +1,88 @@
+import { createSignal, Show } from "solid-js";
+
+import { Trans, useLingui } from "@lingui/solid/macro";
+import { useNavigate } from "@solidjs/router";
+
+import { Button, Column, iconSize, Row, Text, TextField } from "@revolt/ui";
+
+import MdArrowBack from "@material-design-icons/svg/filled/arrow_back.svg?component-solid";
+
+import { FlowTitle } from "./Flow";
+
+/**
+ * Select a self-hosted Stoat instance before signing in.
+ */
+export default function FlowConnect() {
+  const navigate = useNavigate();
+  const { t } = useLingui();
+  const [error, setError] = createSignal<string>();
+
+  function connect(event: SubmitEvent) {
+    event.preventDefault();
+
+    const form = new FormData(event.currentTarget as HTMLFormElement);
+    const input = form.get("server")?.toString().trim();
+    if (!input) return;
+
+    try {
+      const url = new URL(input.includes("://") ? input : `https://${input}`);
+
+      if (
+        url.protocol !== "https:" ||
+        url.username ||
+        url.password ||
+        url.pathname !== "/" ||
+        url.search ||
+        url.hash
+      ) {
+        throw new Error();
+      }
+
+      navigate(`/i/${url.host}/login`);
+    } catch {
+      setError(t`Enter a valid HTTPS server address.`);
+    }
+  }
+
+  return (
+    <>
+      <FlowTitle subtitle={<Trans>Connect to another Stoat server</Trans>}>
+        <Trans>Add a server</Trans>
+      </FlowTitle>
+
+      <form onSubmit={connect}>
+        <Column gap="lg">
+          <Text>
+            <Trans>
+              Enter the address of the server you want to sign in to.
+            </Trans>
+          </Text>
+          <TextField
+            required
+            type="text"
+            name="server"
+            label={t`Server address`}
+            placeholder="chat.example.com"
+            autocomplete="url"
+            onInput={() => setError()}
+          />
+          <Show when={error()}>
+            <span style={{ color: "var(--md-sys-color-error)" }}>
+              {error()}
+            </span>
+          </Show>
+          <Row align justify>
+            <a href="..">
+              <Button variant="text">
+                <MdArrowBack {...iconSize("1.2em")} /> <Trans>Back</Trans>
+              </Button>
+            </a>
+            <Button type="submit">
+              <Trans>Connect</Trans>
+            </Button>
+          </Row>
+        </Column>
+      </form>
+    </>
+  );
+}

--- a/packages/client/components/auth/src/flows/FlowHome.tsx
+++ b/packages/client/components/auth/src/flows/FlowHome.tsx
@@ -79,6 +79,13 @@ export default function FlowHome() {
                   </Button>
                 </Column>
               </a>
+              <a href="/login/connect">
+                <Column>
+                  <Button variant="text">
+                    <Trans>Connect to another server</Trans>
+                  </Button>
+                </Column>
+              </a>
             </Column>
           </Column>
         </>

--- a/packages/client/components/instance/index.tsx
+++ b/packages/client/components/instance/index.tsx
@@ -32,7 +32,7 @@ export function InstanceContext(props: { children?: JSXElement }) {
 
   const [inst, setInst] = createSignal<Instance>();
 
-  //Check Stoat instance
+  // Check Stoat instance
   const host = normalizeHost(params.host);
 
   function onError(e: unknown) {
@@ -51,10 +51,9 @@ export function InstanceContext(props: { children?: JSXElement }) {
   }
 
   (async () => {
-    //Redirect default instance
-    //TODO This redirects ALL instance paths to default until multi-instance is ready
-    // Replace with `if (host === DefaultHost)` when ready
-    if (host) return nav(Instance.relPath(), { replace: true });
+    // Keep the default instance on the root route, while allowing custom
+    // instances to load their configuration from their own domain.
+    if (host === DefaultHost) return nav(Instance.relPath(), { replace: true });
 
     try {
       const appCfg: AppConfig = host

--- a/packages/client/e2e/it-works.spec.ts
+++ b/packages/client/e2e/it-works.spec.ts
@@ -10,3 +10,13 @@ test("shows a working login page", async ({ page }) => {
 
   await expect(page.getByText(/Sign into Stoat/)).toBeVisible();
 });
+
+test("allows selecting another server from the login page", async ({
+  page,
+}) => {
+  await page.goto("");
+
+  await page.getByRole("button", { name: "Connect to another server" }).click();
+  await expect(page.getByText(/Connect to another Stoat server/)).toBeVisible();
+  await expect(page.getByLabel("Server address")).toBeVisible();
+});

--- a/packages/client/e2e/it-works.spec.ts
+++ b/packages/client/e2e/it-works.spec.ts
@@ -20,3 +20,26 @@ test("allows selecting another server from the login page", async ({
   await expect(page.getByText(/Connect to another Stoat server/)).toBeVisible();
   await expect(page.getByLabel("Server address")).toBeVisible();
 });
+
+test("rejects an insecure custom server address", async ({ page }) => {
+  await page.goto("/login/connect");
+
+  await page.getByLabel("Server address").fill("http://chat.example.com");
+  await page.getByRole("button", { name: "Connect" }).click();
+
+  await expect(
+    page.getByText("Enter a valid HTTPS server address."),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/login\/connect$/);
+});
+
+test("routes a valid custom server address to its login page", async ({
+  page,
+}) => {
+  await page.goto("/login/connect");
+
+  await page.getByLabel("Server address").fill("chat.example.com");
+  await page.getByRole("button", { name: "Connect" }).click();
+
+  await expect(page).toHaveURL(/\/i\/chat\.example\.com\/login$/);
+});

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -15,6 +15,7 @@ import { PublicBot, PublicChannelInvite } from "stoat.js";
 
 import FlowCheck from "@revolt/auth/src/flows/FlowCheck";
 import FlowConfirmReset from "@revolt/auth/src/flows/FlowConfirmReset";
+import FlowConnect from "@revolt/auth/src/flows/FlowConnect";
 import FlowCreate from "@revolt/auth/src/flows/FlowCreate";
 import FlowDeleteAccount from "@revolt/auth/src/flows/FlowDelete";
 import FlowHome from "@revolt/auth/src/flows/FlowHome";
@@ -151,6 +152,7 @@ const routes = () => (
       <Route path="/create" component={FlowCreate} />
       <Route path="/create/:code" component={FlowCreate} />
       <Route path="/auth" component={FlowLogin} />
+      <Route path="/connect" component={FlowConnect} />
       <Route path="/resend" component={FlowResend} />
       <Route path="/reset" component={FlowReset} />
       <Route path="/verify/:token" component={FlowVerify} />


### PR DESCRIPTION
## Summary

This PR adds support for connecting to self-hosted Stoat instances from the login flow.

- Added a “Connect to another server” action on the home/login screen.
- Added a custom-server connection form with HTTPS-only address validation.
- Added routing to the selected instance’s login page.
- Updated instance handling so custom hosts are loaded instead of being redirected to the default instance.
- Added E2E coverage for the custom-server flow.
- No new dependencies or packages were added.

## How was this PR tested?

- Ran TypeScript validation:

  ```sh
  packages/client/node_modules/.bin/tsc --noEmit -p packages/client/tsconfig.json
  ```

- Added Playwright tests covering:
  - Opening the custom-server connection flow.
  - Rejecting insecure HTTP server addresses.
  - Routing valid HTTPS server addresses to the selected instance login page.

- The full Playwright suite could not complete locally because the `mise` web-server setup did not finish before test execution. The added scenarios are intended to run in CI.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>


<img width="535" height="652" alt="Login Page" src="https://github.com/user-attachments/assets/c1f81739-a599-422a-a4b3-67be033c4234" />

<img width="411" height="380" alt="Custom server" src="https://github.com/user-attachments/assets/ee1435bb-e882-4599-9533-4c82d2fb90c0" />


</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Codex/OpenAI was used to implement and review the changes.
