### PR TITLE
fix: External link and invite paths on self-hosted

### DIFF
--- a/packages/client/components/instance/Instance.ts
+++ b/packages/client/components/instance/Instance.ts
@@ -5,15 +5,15 @@ import { CONFIGURATION } from "@revolt/common";
 import { AppConfig, STOAT_HOST } from "@revolt/common/lib/env";
 import { Client, UserLimits } from "stoat.js";
 
-import { DefaultHost, StoatOrigin } from ".";
+import { DefaultHost } from ".";
 
 const R_RelPath = /^\/i\/[^/]+/;
 
 export default class Instance {
+  /** Undefined on default host */
   readonly host?: string;
   readonly origin: string;
   readonly isStoat: boolean;
-  readonly #base;
   readonly #nav;
 
   readonly apiUrl: string;
@@ -57,7 +57,6 @@ export default class Instance {
     const hostUrl = new URL(`https://${host}`);
     this.origin = hostUrl.origin;
     this.isStoat = host === STOAT_HOST;
-    this.#base = this.isStoat ? "" : `/i/${host}`;
     this.#nav = nav;
   }
 
@@ -74,21 +73,28 @@ export default class Instance {
   }
 
   /** Prepend a relative path with instance base URL
-   * @param pathOnly Get only the path component and not URL
-   * @param base Defaults to the base path of this instance
+   * @param absPath Get path component relative to base
+   * @param base Defaults to this instance's host
    */
-  href = (path: string, pathOnly?: boolean, base?: string) =>
-    (pathOnly ? "" : StoatOrigin) + (base ? `/i/${base}` : this.#base) + path;
+  href(path: string, absPath?: boolean, base = this.host) {
+    return (
+      (absPath ? "" : this.origin) +
+      (absPath && base ? `/i/${base}` : "") +
+      path
+    );
+  }
 
   /** Convert path to relative form, stripping instance prefix (if any)
    * @param path Defaults to `location.pathname` (non-reactive,
    * try `useLocation().pathname` if you need reactivity)
    */
-  static relPath = (path = location.pathname) => path.replace(R_RelPath, "");
+  static relPath = (path = location.pathname) =>
+    path.replace(R_RelPath, "") || "/";
 
   /** Switch to a new instance and redirect the client */
-  switchTo = (host: string) =>
+  switchTo(host: string) {
     this.#nav(this.href(Instance.relPath(), true, host));
+  }
 
   /** Create a new Stoat.js client, disposing the old one */
   newClient() {


### PR DESCRIPTION
Fixes #1501

This is caused by some early intentional behavior from #999 sneaking into instance PR (maybe caused by rebases/splitting PRs up.)

The idea was that links need to follow some sort of format for multiuser to be able to detect them and display them nicely. Using stoat.chat as the base domain is one way to achieve that, but has the downside of not keeping self-hosted instances "isolated," e.g. if you want the user to be directed to a custom altered client on your domain instead of the main one (even tho it would support the link and enable logging in). Current solution in multiuser is different and involves polling the new JSON endpoint we added.

But that's neither here nor there, point is this is due to old code that wound up in the Instance class, and is now fixed. Links internal to the client shall be rewritten such that it doesn't yeet you onto a foreign domain by accident, but external links you can copy (eg. invites, channel/message links, etc) reflect the domain of the currently chosen host.

## How was this PR tested?

Building the client with several different values for VITE\_HOST and VITE\_API\_URL, then logging in.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

You can tell I didn't because the clanker didn't apologize 37 times for repeatedly making the same head-slamming-into-wall-level mistake. I can do that just fine on my own!

- `main` <!-- branch-stack -->
  - \#1521 :point\_left:
