### PR TITLE
feat(voice): add expandable and compact call layouts

### DIFF
--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -79,6 +79,12 @@ class Voice {
   fullscreen: Accessor<boolean>;
   #setFullscreen: Setter<boolean>;
 
+  internalExpanded: Accessor<boolean>;
+  #setInternalExpanded: Setter<boolean>;
+
+  internalCollapsed: Accessor<boolean>;
+  #setInternalCollapsed: Setter<boolean>;
+
   focusId: Accessor<string | undefined>;
   #setFocus: Setter<string | undefined>;
 
@@ -132,6 +138,14 @@ class Voice {
     const [fullscreen, setFullscreen] = createSignal(false);
     this.fullscreen = fullscreen;
     this.#setFullscreen = setFullscreen;
+
+    const [internalExpanded, setInternalExpanded] = createSignal(false);
+    this.internalExpanded = internalExpanded;
+    this.#setInternalExpanded = setInternalExpanded;
+
+    const [internalCollapsed, setInternalCollapsed] = createSignal(false);
+    this.internalCollapsed = internalCollapsed;
+    this.#setInternalCollapsed = setInternalCollapsed;
 
     const [focus, setFocus] = createSignal<string>();
     this.focusId = focus;
@@ -331,6 +345,8 @@ class Voice {
         this.#setRoom();
         this.#setChannel();
         this.#setFullscreen(false);
+        this.#setInternalExpanded(false);
+        this.#setInternalCollapsed(false);
         this.vidTracks = () => [];
       });
 
@@ -626,7 +642,26 @@ class Voice {
   }
 
   toggleFullscreen(fullscreen: boolean = !this.fullscreen()) {
+    if (fullscreen) {
+      this.#setInternalExpanded(false);
+      this.#setInternalCollapsed(false);
+    }
     this.#setFullscreen(fullscreen);
+  }
+
+  /** Expand the call and channel view without using browser fullscreen. */
+  toggleInternalExpanded(expanded: boolean = !this.internalExpanded()) {
+    if (expanded) this.#setInternalCollapsed(false);
+    this.#setInternalExpanded(expanded);
+  }
+
+  /** Collapse the call card while keeping the call actions accessible. */
+  toggleInternalCollapsed(collapsed: boolean = !this.internalCollapsed()) {
+    if (collapsed) {
+      this.#setFullscreen(false);
+      this.#setInternalExpanded(false);
+    }
+    this.#setInternalCollapsed(collapsed);
   }
 
   trackId(t: TrackReferenceOrPlaceholder) {

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCard.tsx
@@ -20,7 +20,10 @@ import { useVoice } from "@revolt/rtc";
 import { useState } from "@revolt/state";
 import { SlideState } from "@revolt/ui/components/navigation/SlideDrawer";
 
-import { VoiceCallCardActiveRoom } from "./VoiceCallCardActiveRoom";
+import {
+  VoiceCallCardActiveRoom,
+  VoiceCallCardCollapsed,
+} from "./VoiceCallCardActiveRoom";
 import { VoiceCallCardPiP } from "./VoiceCallCardPiP";
 import { VoiceCallCardPreview } from "./VoiceCallCardPreview";
 
@@ -30,6 +33,8 @@ type FloatType = "tl" | "tr" | "bl" | "br";
 type Info = {
   channel: Channel;
   pos: DOMRect;
+  container: DOMRect;
+  contentHeight: number;
   drawer?: SlideState;
 };
 
@@ -109,10 +114,21 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
     if (voice.fullscreen()) {
       sty.transform = ``;
       sty.width = `100%`;
+      sty.height = "";
+      setMode();
+    } else if (
+      voice.internalExpanded() &&
+      inf?.container &&
+      (!inf.drawer || inf.drawer === SlideState.SHOWN)
+    ) {
+      sty.transform = `translate(${inf.container.x}px, ${inf.container.y}px)`;
+      sty.width = `${inf.container.width}px`;
+      sty.height = `${inf.contentHeight}px`;
       setMode();
     } else if (inf?.pos && (!inf.drawer || inf.drawer === SlideState.SHOWN)) {
       sty.transform = `translate(${inf.pos.x}px, ${inf.pos.y}px)`;
       sty.width = `${inf.pos.width}px`;
+      sty.height = "";
       setMode();
     } else if (!inCall()) {
       const y = inf?.pos.y ?? ref.getBoundingClientRect().y;
@@ -170,6 +186,7 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
           mode={mode()}
           onPointerDown={mouseDown}
           fullscreen={voice.fullscreen()}
+          expanded={voice.internalExpanded()}
         >
           <Switch>
             <Match when={mode() && inCall()}>
@@ -181,6 +198,8 @@ export function VoiceCallCardContext(props: { children: JSX.Element }) {
                 inCall={inCall()}
                 showCard={voice.showCard(channel()!)}
                 fullscreen={voice.fullscreen()}
+                expanded={voice.internalExpanded()}
+                collapsed={voice.internalCollapsed()}
               />
             </Match>
           </Switch>
@@ -216,6 +235,10 @@ const Float = styled("div", {
       },
       false: {},
     },
+    expanded: {
+      true: {},
+      false: {},
+    },
   },
   compoundVariants: [
     {
@@ -239,11 +262,14 @@ export function VoiceChannelCallCardMount(props: { channel: Channel }) {
 
   function updateInfo() {
     const vc = voice.channel();
+    const container = ref!.parentElement!.getBoundingClientRect();
     setInfo(
       !vc || vc.id === props.channel.id
         ? {
             channel: props.channel,
             pos: ref!.getBoundingClientRect(),
+            container,
+            contentHeight: container.height,
             drawer: state.appDrawer()?.state,
           }
         : undefined,
@@ -273,16 +299,25 @@ function VoiceCallCard(props: {
   inCall: boolean;
   showCard: boolean;
   fullscreen: boolean;
+  expanded: boolean;
+  collapsed: boolean;
 }) {
   return (
     <Show when={props.showCard}>
-      <Base fullscreen={props.fullscreen}>
-        <Card active={props.inCall} fullscreen={props.fullscreen}>
+      <Base fullscreen={props.fullscreen} expanded={props.expanded}>
+        <Card
+          active={props.inCall}
+          fullscreen={props.fullscreen}
+          expanded={props.expanded}
+          collapsed={props.collapsed}
+        >
           <Show
             when={props.inCall}
             fallback={<VoiceCallCardPreview channel={props.channel} />}
           >
-            <VoiceCallCardActiveRoom />
+            <Show when={props.collapsed} fallback={<VoiceCallCardActiveRoom />}>
+              <VoiceCallCardCollapsed />
+            </Show>
           </Show>
         </Card>
       </Base>
@@ -313,6 +348,14 @@ const Base = styled("div", {
         height: "100%",
         padding: 0,
       },
+    },
+    expanded: {
+      true: {
+        top: 0,
+        height: "100%",
+        padding: 0,
+      },
+      false: {},
     },
   },
 });
@@ -346,11 +389,27 @@ const Card = styled("div", {
       },
       false: {},
     },
+    expanded: {
+      true: {
+        height: "100%",
+      },
+      false: {},
+    },
+    collapsed: {
+      true: {
+        width: "fit-content",
+        height: "auto",
+        background: "transparent",
+      },
+      false: {},
+    },
   },
   compoundVariants: [
     {
       active: [true],
       fullscreen: [false],
+      expanded: [false],
+      collapsed: [false],
       css: {
         height: "40vh",
       },

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActions.tsx
@@ -10,7 +10,10 @@ import { useState } from "@revolt/state";
 import { Button, IconButton } from "@revolt/ui/components/design";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
 
-export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
+export function VoiceCallCardActions(props: {
+  size: "xs" | "sm";
+  compact?: boolean;
+}) {
   const voice = useVoice();
   const state = useState();
   const navigate = useNavigate();
@@ -35,6 +38,21 @@ export function VoiceCallCardActions(props: { size: "xs" | "sm" }) {
           }}
         >
           <Symbol>arrow_top_left</Symbol>
+        </IconButton>
+      </Show>
+      <Show when={props.compact}>
+        <IconButton
+          variant="standard"
+          size={props.size}
+          onPress={() => voice.toggleInternalCollapsed(false)}
+          use:floating={{
+            tooltip: {
+              placement: "top",
+              content: t`Expand call controls`,
+            },
+          }}
+        >
+          <Symbol>unfold_more</Symbol>
         </IconButton>
       </Show>
       <IconButton

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActiveRoom.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardActiveRoom.tsx
@@ -22,6 +22,8 @@ export function VoiceCallCardActiveRoom() {
       <Participants />
       <VoiceCallControls>
         <VoiceCallControlHolder right>
+          <VoiceCallInternalCollapse />
+          <VoiceCallInternalExpand />
           <VoiceCallFullscreen />
         </VoiceCallControlHolder>
         <VoiceCallCardActions size="sm" />
@@ -30,6 +32,64 @@ export function VoiceCallCardActiveRoom() {
         </VoiceCallControlHolder>
       </VoiceCallControls>
     </View>
+  );
+}
+
+/** Compact call card that leaves only call actions available. */
+export function VoiceCallCardCollapsed() {
+  return (
+    <CompactView>
+      <VoiceCallCardActions size="sm" compact />
+    </CompactView>
+  );
+}
+
+function VoiceCallInternalCollapse() {
+  const voice = useVoice();
+  const { t } = useLingui();
+
+  return (
+    <IconButton
+      size="sm"
+      variant="standard"
+      onPress={() => voice.toggleInternalCollapsed()}
+      use:floating={{
+        tooltip: {
+          placement: "top",
+          content: t`Compact call controls`,
+        },
+      }}
+    >
+      <Symbol>unfold_less</Symbol>
+    </IconButton>
+  );
+}
+
+function VoiceCallInternalExpand() {
+  const voice = useVoice();
+  const { t } = useLingui();
+
+  return (
+    <IconButton
+      size="sm"
+      variant="standard"
+      onPress={() => voice.toggleInternalExpanded()}
+      use:floating={{
+        tooltip: {
+          placement: "top",
+          content: voice.internalExpanded()
+            ? t`Collapse call view`
+            : t`Expand call view`,
+        },
+      }}
+    >
+      <Show
+        when={voice.internalExpanded()}
+        fallback={<Symbol>open_in_full</Symbol>}
+      >
+        <Symbol>close_fullscreen</Symbol>
+      </Show>
+    </IconButton>
   );
 }
 
@@ -162,6 +222,14 @@ const View = styled("div", {
     flexDirection: "column",
     gap: "var(--gap-md)",
     padding: "var(--gap-md)",
+  },
+});
+
+const CompactView = styled("div", {
+  base: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
   },
 });
 


### PR DESCRIPTION
## Summary

This PR improves the in-call layout without requiring browser fullscreen.

- Added an internal expand mode that grows the call view downward within the chat area.
- Keeps the application navigation and channel headers visible while the call is expanded.
- Added a compact mode that hides participant tiles and leaves only the call action controls visible.
- Added controls to restore the full call view from compact mode.
- Ensures the internal expand, compact, and browser fullscreen modes reset correctly when leaving a call.
- No new dependencies or packages were added.

## How was this PR tested?

- Ran TypeScript validation:

  ```sh
  packages/client/node_modules/.bin/tsc --noEmit -p packages/client/tsconfig.json
  ```

- Verified the following call layout states manually:
  - Expanding the call within the chat area.
  - Collapsing the call to action controls only.
  - Restoring the full call view.
  - Switching between internal expand, compact mode, and browser fullscreen.
  - Leaving a call resets the layout state.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<img width="1918" height="919" alt="Default" src="https://github.com/user-attachments/assets/e056b6e4-efea-47cf-be34-351aeda97bb2" />

<img width="1918" height="921" alt="Collapsed" src="https://github.com/user-attachments/assets/60714004-65ac-4163-8d93-43eac91f0a02" />

<img width="1914" height="918" alt="Expansed" src="https://github.com/user-attachments/assets/e4a5270f-53de-40e2-80f1-f6a098cf9f44" />

<img width="1919" height="924" alt="Expansed Sharing" src="https://github.com/user-attachments/assets/f3a2e6e8-ecfd-4011-bf28-9d89dfd1b4bc" />

<img width="1912" height="922" alt="Expansed Sharing 2" src="https://github.com/user-attachments/assets/16c030b9-eaef-4e9d-80d5-a61ac3f18d63" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Codex/OpenAI was used to implement and review the changes.
