### PR TITLE
feat: add deafened icon in voice channel aside the mic_off icon when a user is deafened

### DIFF
--- a/packages/client/components/rtc/hooks/useIsDeafened.ts
+++ b/packages/client/components/rtc/hooks/useIsDeafened.ts
@@ -1,0 +1,26 @@
+import type { Participant } from "livekit-client";
+import { Accessor } from "solid-js";
+import { useEnsureParticipant } from "solid-livekit-components";
+
+import { useVoice } from "../state";
+
+/**
+ * The `useIsDeafened` hook returns a boolean accessor indicating if the participant is deafened.
+ *
+ * @example
+ * ```tsx
+ * const isDeafened = useIsDeafened(participant);
+ * ```
+ */
+export function useIsDeafened(participant?: Participant): Accessor<boolean> {
+  const p = useEnsureParticipant(participant);
+  const voice = useVoice();
+
+  return () => {
+    if (p.isLocal || p.identity === voice.room()?.localParticipant.identity) {
+      return voice.deafen();
+    }
+    const voiceParticipant = voice.channel()?.voiceParticipants.get(p.identity);
+    return voiceParticipant ? !voiceParticipant.isReceiving() : false;
+  };
+}

--- a/packages/client/components/rtc/index.ts
+++ b/packages/client/components/rtc/index.ts
@@ -4,6 +4,7 @@ export { useVoice, VoiceContext } from "./state";
 
 export { InRoom } from "./components/InRoom";
 export { RoomAudioManager } from "./components/RoomAudioManager";
+export { useIsDeafened } from "./hooks/useIsDeafened";
 export { stoatSinkName } from "./virtualMic";
 
 const originalMediaCall = navigator.mediaDevices.getDisplayMedia;

--- a/packages/client/components/ui/components/features/voice/VoiceChannelPreview.tsx
+++ b/packages/client/components/ui/components/features/voice/VoiceChannelPreview.tsx
@@ -14,7 +14,7 @@ import { styled } from "styled-system/jsx";
 
 import { UserContextMenu } from "@revolt/app";
 import { useUser } from "@revolt/markdown/users";
-import { InRoom } from "@revolt/rtc";
+import { InRoom, useIsDeafened } from "@revolt/rtc";
 
 import { Avatar, Ripple, typography } from "../../design";
 import { Row } from "../../layout";
@@ -80,13 +80,14 @@ function ParticipantLive() {
   });
 
   const isSpeaking = useIsSpeaking(participant);
+  const isDeafened = useIsDeafened(participant);
 
   return (
     <CommonUser
       userId={participant.identity}
       speaking={isSpeaking()}
       muted={isMuted()}
-      deafened={false}
+      deafened={isDeafened()}
       camera={false}
       screenshare={false}
       isLive

--- a/packages/client/components/ui/components/features/voice/VoiceStatefulUserIcons.tsx
+++ b/packages/client/components/ui/components/features/voice/VoiceStatefulUserIcons.tsx
@@ -44,7 +44,17 @@ export function VoiceStatefulUserIcons(props: {
         </Symbol>
       </Show>
       <Show when={props.deafened}>
-        <Symbol size={16}>headset_off</Symbol>
+        <Symbol
+          size={16}
+          use:floating={{
+            tooltip: {
+              placement: "top",
+              content: t`User is deafened.`,
+            },
+          }}
+        >
+          headset_off
+        </Symbol>
       </Show>
       <Show when={props.camera}>
         <Symbol size={16}>camera_video</Symbol>

--- a/packages/client/components/ui/components/features/voice/callCard/ParticipantTile.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/ParticipantTile.tsx
@@ -14,7 +14,7 @@ import { styled } from "styled-system/jsx";
 
 import { UserContextMenu } from "@revolt/app";
 import { useUser } from "@revolt/markdown/users";
-import { useVoice } from "@revolt/rtc";
+import { useIsDeafened, useVoice } from "@revolt/rtc";
 import { useState } from "@revolt/state";
 import { Avatar } from "@revolt/ui/components/design";
 import { Row } from "@revolt/ui/components/layout";
@@ -72,6 +72,7 @@ export function ParticipantTile(props: TileProps) {
   const isVideo = () => !isVideoMuted();
   const isScreenShare = () => track.source === Track.Source.ScreenShare;
   const isSpeaking = useIsSpeaking(participant);
+  const isDeafened = useIsDeafened(participant);
 
   const getHeight = () => {
     if (!props.focus || videoDims().height == 0) return {};
@@ -165,6 +166,7 @@ export function ParticipantTile(props: TileProps) {
                 <VoiceStatefulUserIcons
                   userId={participant.identity}
                   muted={isMuted()}
+                  deafened={isDeafened()}
                   camera={isVideo()}
                 />
               )}

--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
@@ -14,7 +14,7 @@ import { Track } from "livekit-client";
 import { styled } from "styled-system/jsx";
 
 import { useUser } from "@revolt/markdown/users";
-import { useVoice } from "@revolt/rtc";
+import { useIsDeafened, useVoice } from "@revolt/rtc";
 import { Avatar } from "@revolt/ui/components/design";
 import { Row } from "@revolt/ui/components/layout";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
@@ -64,6 +64,7 @@ function ConnectedUser() {
   });
 
   const isSpeaking = useIsSpeaking(participant);
+  const isDeafened = useIsDeafened(participant);
   const user = useUser(participant.identity);
 
   return (
@@ -74,8 +75,15 @@ function ConnectedUser() {
         fallback={user().username}
         shape="square"
       />
-      <Show when={isMuted()}>
-        <Symbol background="rgba(0,0,0,.5)">mic_off</Symbol>
+      <Show
+        when={isDeafened()}
+        fallback={
+          <Show when={isMuted()}>
+            <Symbol background="rgba(0,0,0,.5)">mic_off</Symbol>
+          </Show>
+        }
+      >
+        <Symbol background="rgba(0,0,0,.5)">headset_off</Symbol>
       </Show>
     </UserIcon>
   );


### PR DESCRIPTION
## Summary
Adds a deafened status icon (`headset_off`) next to the mic off icon in the voice channel sidebar, call tiles, and PiP mode.

Closes #1208

Signed-off-by: Luiz Montuani <luizfelipe.8@hotmail.com>

### GenAI Disclosure
This PR was developed with the assistance of Generative AI (Google Antigravity).