### PR TITLE
feat: add silent typing

### DIFF
--- a/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
+++ b/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
@@ -441,6 +441,19 @@ export function AppearanceMenu() {
         >
           <Trans>Hide typing indicators from other users</Trans>
         </Checkbox>
+        <Checkbox
+          checked={state.settings.getValue(
+            "appearance:show_silent_typing_quick_toggle",
+          )}
+          onChange={(e) =>
+            state.settings.setValue(
+              "appearance:show_silent_typing_quick_toggle",
+              e.currentTarget.checked,
+            )
+          }
+        >
+          <Trans>Show silent typing toggle in message bar</Trans>
+        </Checkbox>
       </Column>
     </Column>
   );

--- a/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
+++ b/packages/client/components/app/interface/settings/user/appearance/AppearanceMenu.tsx
@@ -426,6 +426,22 @@ export function AppearanceMenu() {
           </For>
         </FloatingSelect>
       </Column>
+      <Column>
+        <Text class="title" size="small">
+          <Trans>Silent typing</Trans>
+        </Text>
+        <Checkbox
+          checked={state.settings.getValue("privacy:silent_typing")}
+          onChange={(e) =>
+            state.settings.setValue(
+              "privacy:silent_typing",
+              e.currentTarget.checked,
+            )
+          }
+        >
+          <Trans>Hide typing indicators from other users</Trans>
+        </Checkbox>
+      </Column>
     </Column>
   );
 }

--- a/packages/client/components/state/stores/Settings.ts
+++ b/packages/client/components/state/stores/Settings.ts
@@ -39,6 +39,11 @@ interface SettingsDefinition {
   "notifications:push": NotificationPermissionState;
 
   /**
+   * Whether to send typing notifications
+   */
+  "privacy:silent_typing": boolean;
+
+  /**
    * Selected unicode emoji
    */
   "appearance:unicode_emoji": UnicodeEmojiPacks;
@@ -103,6 +108,7 @@ type ValueType<T extends keyof SettingsDefinition> =
 const EXPECTED_TYPES: { [K in keyof SettingsDefinition]: ValueType<K> } = {
   "notifications:desktop": "string",
   "notifications:push": "string",
+  "privacy:silent_typing": "boolean",
   "appearance:unicode_emoji": "string",
   "appearance:show_send_button": "boolean",
   "appearance:compact_mode": "boolean",
@@ -146,6 +152,7 @@ export class Settings extends AbstractStore<"settings", TypeSettings> {
     return {
       "notifications:desktop": "default",
       "notifications:push": "default",
+      "privacy:silent_typing": false,
       "appearance:unicode_emoji": "fluent-3d",
       "appearance:show_send_button": true,
       "appearance:compact_mode": false,

--- a/packages/client/components/state/stores/Settings.ts
+++ b/packages/client/components/state/stores/Settings.ts
@@ -44,6 +44,11 @@ interface SettingsDefinition {
   "privacy:silent_typing": boolean;
 
   /**
+   * Whether to add a silent-typing quick toggle to the message composition bar
+   */
+  "appearance:show_silent_typing_quick_toggle": boolean;
+
+  /**
    * Selected unicode emoji
    */
   "appearance:unicode_emoji": UnicodeEmojiPacks;
@@ -109,6 +114,7 @@ const EXPECTED_TYPES: { [K in keyof SettingsDefinition]: ValueType<K> } = {
   "notifications:desktop": "string",
   "notifications:push": "string",
   "privacy:silent_typing": "boolean",
+  "appearance:show_silent_typing_quick_toggle": "boolean",
   "appearance:unicode_emoji": "string",
   "appearance:show_send_button": "boolean",
   "appearance:compact_mode": "boolean",
@@ -153,6 +159,7 @@ export class Settings extends AbstractStore<"settings", TypeSettings> {
       "notifications:desktop": "default",
       "notifications:push": "default",
       "privacy:silent_typing": false,
+      "appearance:show_silent_typing_quick_toggle": false,
       "appearance:unicode_emoji": "fluent-3d",
       "appearance:show_send_button": true,
       "appearance:compact_mode": false,

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -464,6 +464,34 @@ export function MessageComposition(props: Props) {
               </MessageBox.FloatingAction>
             </Show>
             <MessageBox.ActionContainer>
+              <Show
+                when={state.settings.getValue(
+                  "appearance:show_silent_typing_quick_toggle",
+                )}
+              >
+                <MessageBox.InlineIcon>
+                  <IconButton
+                    onPress={() => {
+                      state.settings.setValue(
+                        "privacy:silent_typing",
+                        !state.settings.getValue("privacy:silent_typing"),
+                      );
+                    }}
+                    use:floating={{
+                      tooltip: {
+                        placement: "top",
+                        content: t`Silent typing`,
+                      },
+                    }}
+                  >
+                    <Symbol>
+                      {state.settings.getValue("privacy:silent_typing")
+                        ? "keyboard_off"
+                        : "keyboard"}
+                    </Symbol>
+                  </IconButton>
+                </MessageBox.InlineIcon>
+              </Show>
               <CompositionMediaPicker
                 onMessage={sendMessage}
                 onTextReplacement={(text) => setNodeReplacement([text])}

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -205,6 +205,7 @@ export function MessageComposition(props: Props) {
    * Send typing packet
    */
   function startTyping() {
+    if (state.settings.getValue("privacy:silent_typing")) return;
     if (typeof isTyping === "number" && +new Date() < isTyping) return;
 
     const ws = client()!.events;


### PR DESCRIPTION
Adds a setting to disable sending typing indications, as well as an option to add a toggle for it to the message composition bar as described in #1336.

I've added the two settings to the Appearance section, they're stored in the [`Settings`](https://github.com/gabgutf/stoatchat-for-web/blob/4c134e9bc08757cc01f9c536d216aef7e9c32d77/packages/client/components/state/stores/Settings.ts) store as `"privacy:silent_typing"` and `"appearance:show_silent_typing_quick_toggle"`. I'm not sure whether the appearance section is the correct place for them, nor whether adding a new `"privacy:*"` namespace to the Settings store is correct, but they're easy to change.

Fixes #1336

## How was this PR tested?

- [x] Checked that both settings are kept between page reloads.
- [x] Checked that silent typing disables indicators when on.
- [x] Checked that indicators are shown when silent typing is off.
- [x] Checked that using the quick toggle works, even mid-composition.

<details><summary><h2>Screenshots & Screencasts</h2></summary>

<div align="center">

![Appearance section of the settings menu](https://github.com/user-attachments/assets/68cf2782-eeb5-40c7-8950-12c06106d082)
*Appearance section of the settings menu*

<br />

![Message composition bar with quick toggle set to ON](https://github.com/user-attachments/assets/4e250a7b-9f9c-409e-a4ae-fa0d56d819f9)
*Message composition bar with quick toggle set to On*

![Message composition bar with quick toggle set to OFF](https://github.com/user-attachments/assets/58475005-8e14-4d0c-88d6-385b85d8fbbd)
*Quick toggle set to Off*

<br />

https://github.com/user-attachments/assets/73fff45c-402d-4903-8d4b-edc706926010

</div>

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None.
