### PR TITLE
fix: unknown users when full member list is not loaded

### DIFF
--- a/packages/client/components/markdown/users.ts
+++ b/packages/client/components/markdown/users.ts
@@ -1,4 +1,8 @@
-import { Accessor, createMemo } from "solid-js";
+import {
+  type Accessor,
+  type InitializedResource,
+  createResource,
+} from "solid-js";
 
 import { ServerMember, User } from "stoat.js";
 
@@ -53,6 +57,39 @@ export function userInformation(user?: User, member?: ServerMember) {
   };
 }
 
+async function getOrFetchUsers(options: {
+  ids: string[];
+  params: Accessor<{ serverId?: string }>;
+  filterNull?: boolean;
+}) {
+  const client = useClient();
+  const serverId = options.params().serverId;
+  return Promise.all(
+    options.ids.map(async (id) => {
+      const user =
+        client().users.get(id) ??
+        (await client()
+          .users.fetch(id)
+          .catch(() => null));
+
+      // Edge case: what if user fails to fetch on a spotty/intermittent conenction?
+      // Promise.all fails as soon as possible, so if one fetch fails, everything else
+      // does too and we don't get any data at all
+      if (!user) return undefined;
+
+      return userInformation(
+        user,
+        serverId
+          ? client().serverMembers.getByKey({
+              server: serverId,
+              user: user.id,
+            })
+          : undefined,
+      );
+    }),
+  ).then((arr) => (options.filterNull ? arr.filter((x) => x) : arr));
+}
+
 /**
  * Resolve multiple users by their ID within the current context
  * @param ids User IDs
@@ -62,33 +99,20 @@ export function userInformation(user?: User, member?: ServerMember) {
 export function useUsers(
   ids: string[] | Accessor<string[]>,
   filterNull?: boolean,
-): Accessor<(UserInformation | undefined)[]> {
-  const clientAccessor = useClient();
-
+): InitializedResource<(UserInformation | undefined)[]> {
   // TODO: use a context here for when we do multi view :)
   const params = useSmartParams();
+  const [users] = createResource(
+    {
+      ids: typeof ids === "function" ? ids() : ids,
+      params,
+      filterNull,
+    },
+    getOrFetchUsers,
+    { initialValue: [] as (UserInformation | undefined)[] },
+  );
 
-  // eslint-disable-next-line solid/reactivity
-  return createMemo(() => {
-    const client = clientAccessor()!;
-    const list = (typeof ids === "function" ? ids() : ids).map((id) => {
-      const user = client.users.get(id)!;
-
-      if (user) {
-        return userInformation(
-          user,
-          params().serverId
-            ? client.serverMembers.getByKey({
-                server: params().serverId!,
-                user: user.id,
-              })
-            : undefined,
-        );
-      }
-    });
-
-    return filterNull ? list.filter((x) => x) : list;
-  });
+  return users;
 }
 
 /**


### PR DESCRIPTION
Fixes #1441

Should fix users not being completely loaded on the channel sidebar and inside a voice chat (if the user hasn't
sent a message inside the channel yet.)

The only api facing change is that useUsers is now using a resource instead of being a memo, which has the advantage
of allowing async functions while only recalculating the values when the supplied IDs change. It should also handle
the edge case of having a spotty connection and not being able to fetch a user (by falling back to "unknown user".)

Nothing broke on my very limited testing of this change.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] User loaded when they weren't in cache already 
- [x] Checked that users could load from cache and from the network where we use `useUser` and `useUsers`

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used to author this pull request
