### PR TITLE
fix: publish screen shares at the selected frame rate, add a 1080p60 quality

### DIFF
--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -70,6 +70,25 @@ type ScreenShareQuality = {
   contentHint: string;
 };
 
+/**
+ * Frame rate for the "smooth" screen share quality.
+ *
+ * livekit-client ships no 60fps screen share preset, so this one is built by
+ * hand from the 1080p30 preset.
+ */
+const SMOOTH_FRAME_RATE = 60;
+
+/**
+ * Bitrate for the "smooth" screen share quality.
+ *
+ * A higher frame rate needs more bitrate to stay legible while the picture is
+ * moving, or the encoder trades the frame rate straight back away and there is
+ * nothing to gain over 1080p30. 60fps does compress better per frame than
+ * 30fps, so this sits above the 5Mbps of 1080p30 without doubling it, and
+ * stays under the 7Mbps the `original` preset already asks for.
+ */
+const SMOOTH_MAX_BITRATE = 6_000_000;
+
 class Voice {
   #settings: VoiceSettings;
 
@@ -464,6 +483,22 @@ class Voice {
         encoding: ScreenSharePresets.h1080fps30.encoding,
         degradationPreference: "maintain-framerate",
         fullName: `1080p 30FPS`,
+        contentHint: "motion",
+      };
+
+      qualities.smooth = {
+        name: "smooth",
+        resolution: {
+          ...ScreenSharePresets.h1080fps30.resolution,
+          frameRate: SMOOTH_FRAME_RATE,
+        },
+        encoding: {
+          maxBitrate: SMOOTH_MAX_BITRATE,
+          maxFramerate: SMOOTH_FRAME_RATE,
+          priority: "medium",
+        },
+        degradationPreference: "maintain-framerate",
+        fullName: `1080p 60FPS`,
         contentHint: "motion",
       };
 

--- a/packages/client/components/rtc/state.tsx
+++ b/packages/client/components/rtc/state.tsx
@@ -19,6 +19,7 @@ import {
   Room,
   ScreenSharePresets,
   Track,
+  VideoEncoding,
   VideoResolution,
 } from "livekit-client";
 import { Channel } from "stoat.js";
@@ -49,6 +50,22 @@ type State =
 type ScreenShareQuality = {
   name: ScreenShareQualityName;
   resolution: VideoResolution;
+  /**
+   * Publish encoding for this quality.
+   *
+   * This has to be provided explicitly: livekit-client defaults
+   * `publishDefaults.screenShareEncoding` to `ScreenSharePresets.h1080fps15`,
+   * so leaving it out caps every share at 15fps no matter what the capture
+   * constraints say.
+   */
+  encoding: VideoEncoding;
+  /**
+   * What to give up first when there is not enough bandwidth or CPU.
+   *
+   * Motion qualities keep the frame rate and shed resolution; the text quality
+   * wants the opposite, since it exists to keep small text readable.
+   */
+  degradationPreference: RTCDegradationPreference;
   fullName: string;
   contentHint: string;
 };
@@ -426,7 +443,9 @@ class Voice {
     > = {
       low: {
         name: "low",
-        resolution: ScreenSharePresets.h720fps30.resolution,
+        resolution: { ...ScreenSharePresets.h720fps30.resolution },
+        encoding: ScreenSharePresets.h720fps30.encoding,
+        degradationPreference: "maintain-framerate",
         fullName: `720p 30FPS`,
         contentHint: "motion",
       },
@@ -441,17 +460,24 @@ class Voice {
     ) {
       qualities.high = {
         name: "high",
-        resolution: ScreenSharePresets.h1080fps30.resolution,
+        resolution: { ...ScreenSharePresets.h1080fps30.resolution },
+        encoding: ScreenSharePresets.h1080fps30.encoding,
+        degradationPreference: "maintain-framerate",
         fullName: `1080p 30FPS`,
         contentHint: "motion",
       };
-      const originalResolution = ScreenSharePresets.original.resolution;
-      originalResolution.frameRate = 5;
-      originalResolution.aspectRatio = 0;
 
-      const limit = this.limits().video_resolution;
-      originalResolution.width = limit[0];
-      originalResolution.height = limit[1];
+      // copy: `ScreenSharePresets.original` is a singleton exported by
+      // livekit-client, so writing to its resolution corrupts the preset for
+      // the rest of the session
+      const originalResolution: VideoResolution = {
+        ...ScreenSharePresets.original.resolution,
+        frameRate: 5,
+        aspectRatio: 0,
+        width: limit[0],
+        height: limit[1],
+      };
+
       // If both resolutions are limited, set aspect ratio
       if (originalResolution.height !== 0 && originalResolution.width !== 0) {
         originalResolution.aspectRatio =
@@ -461,12 +487,55 @@ class Voice {
       qualities.text = {
         name: "text",
         resolution: originalResolution,
+        encoding: {
+          ...ScreenSharePresets.original.encoding,
+          maxFramerate: 5,
+        },
+        // this quality exists to keep small text readable, so give up frames
+        // before resolution -- the opposite of the motion qualities
+        degradationPreference: "maintain-resolution",
         fullName: `Source 5FPS`,
         contentHint: "text",
       };
     }
 
     return qualities;
+  }
+
+  /**
+   * Push a quality's publish encoding onto an already published screen share.
+   *
+   * `applyConstraints` only changes what gets captured; the frame rate and
+   * bitrate that actually go out are fixed on the sender at publish time, so
+   * they have to be updated separately when the quality is chosen from the
+   * picker or the settings modal.
+   */
+  async applyScreenShareEncoding(
+    publication: LocalTrackPublication,
+    quality: ScreenShareQuality,
+  ) {
+    const sender = publication.videoTrack?.sender;
+    if (!sender) return;
+
+    try {
+      const params = sender.getParameters();
+      if (!params.encodings?.length) return;
+
+      for (const encoding of params.encodings) {
+        encoding.maxFramerate = quality.encoding.maxFramerate;
+
+        // simulcast layers are scaled down copies of the same picture, so the
+        // full bitrate budget only belongs to the full resolution layer
+        const scale = encoding.scaleResolutionDownBy ?? 1;
+        encoding.maxBitrate = Math.round(
+          quality.encoding.maxBitrate / (scale * scale),
+        );
+      }
+
+      await sender.setParameters(params);
+    } catch (err) {
+      console.error("Failed to apply screen share encoding", err);
+    }
   }
 
   async toggleScreenshare() {
@@ -511,13 +580,14 @@ class Voice {
       }
 
       try {
+        const initialQuality =
+          qualities[this.#settings.screenShareQuality || "low"] ??
+          qualities.low!;
+
         const localTrack = await room.localParticipant.setScreenShareEnabled(
           true,
           {
-            resolution:
-              this.getEnabledScreenShareQualities()[
-                this.#settings.screenShareQuality || "low"
-              ]?.resolution,
+            resolution: initialQuality.resolution,
             audio: {
               autoGainControl: false,
               echoCancellation: false,
@@ -525,6 +595,15 @@ class Voice {
               voiceIsolation: false,
               restrictOwnAudio: true,
             },
+          },
+          {
+            // Without this livekit falls back to `publishDefaults`, whose
+            // `screenShareEncoding` is `ScreenSharePresets.h1080fps15` -- every
+            // share was capped at 15fps no matter which quality was picked.
+            screenShareEncoding: initialQuality.encoding,
+            // Motion qualities trade resolution away before frame rate; the
+            // text quality does the reverse.
+            degradationPreference: initialQuality.degradationPreference,
           },
         );
 
@@ -556,7 +635,13 @@ class Voice {
 
             if (localTrack.videoTrack) {
               await localTrack.videoTrack.mediaStreamTrack.applyConstraints({
-                frameRate: { max: quality.resolution.frameRate },
+                // `ideal` matters as much as `max` here: capture starts clamped
+                // to 5fps (see the getDisplayMedia override in ./index.ts), and
+                // a bare `max` does not ask the source to speed back up
+                frameRate: {
+                  ideal: quality.resolution.frameRate,
+                  max: quality.resolution.frameRate,
+                },
                 width:
                   quality.resolution.width === 0
                     ? undefined
@@ -565,15 +650,20 @@ class Voice {
                         max: quality.resolution.width,
                       },
                 height:
-                  quality.resolution.width === 0
+                  quality.resolution.height === 0
                     ? undefined
                     : {
-                        ideal: quality.resolution.width,
+                        ideal: quality.resolution.height,
                         max: quality.resolution.height,
                       },
               });
               localTrack.videoTrack.mediaStreamTrack.contentHint =
                 quality.contentHint;
+
+              // the publish encoding was fixed when the track went out, so a
+              // quality picked afterwards has to be pushed to the sender too
+              await this.applyScreenShareEncoding(localTrack, quality);
+
               if (!audio && screenAudioTrack?.track) {
                 room.localParticipant.unpublishTrack(screenAudioTrack.track);
               }

--- a/packages/client/components/state/stores/Voice.ts
+++ b/packages/client/components/state/stores/Voice.ts
@@ -14,9 +14,10 @@ const NoiseSuppresionStates: NoiseSuppresionState[] = [
 ];
 
 /**
- * Possible screen share qualities. Low is 720p@30fps, high 1080p@30fps and text is source@5fps.
+ * Possible screen share qualities. Low is 720p@30fps, high 1080p@30fps,
+ * smooth is 1080p@60fps and text is source@5fps.
  */
-export type ScreenShareQualityName = "low" | "high" | "text";
+export type ScreenShareQualityName = "low" | "high" | "smooth" | "text";
 
 /**
  * Array of available screen share quality names.
@@ -24,6 +25,7 @@ export type ScreenShareQualityName = "low" | "high" | "text";
 export const ScreenShareQualityNames: ScreenShareQualityName[] = [
   "low",
   "high",
+  "smooth",
   "text",
 ];
 


### PR DESCRIPTION
### The bug

Every screen share goes out at 15fps, whichever quality is selected.

`toggleScreenshare` calls `setScreenShareEnabled` with capture options but no publish options:

```ts
await room.localParticipant.setScreenShareEnabled(true, { resolution, audio });
```

so livekit falls back to `publishDefaults`, and livekit-client sets:

```js
publishDefaults = {
  ...
  screenShareEncoding: ScreenSharePresets.h1080fps15.encoding,  // 2.5Mbps, 15fps
};
```

That is a hard cap on the encoder. The `applyConstraints` call afterwards only touches the capture side, which is why the source runs at 30fps while what arrives at the far end is 15fps — and why the picker can keep saying "1080p 30FPS" while it is not true.

### The fix

Each quality now carries the `VideoEncoding` it wants, and it is passed through on publish.

The encoding is fixed on the sender when the track goes out, so picking a quality afterwards (from the desktop source picker, or the "always ask" modal) also has to push it onto the sender directly via `setParameters` — otherwise only the value already in settings would ever apply. Simulcast layers are scaled-down copies of the same picture, so the bitrate is divided by the square of `scaleResolutionDownBy` and only the full-resolution layer gets the whole budget.

Four smaller things in the same path:

- **`degradationPreference` is now set, per quality.** Nothing was requested before, so frame rate was the first thing shed under pressure. Motion qualities now ask for `maintain-framerate` and the text quality for `maintain-resolution`, matching the `contentHint` each already sets — the text quality exists to keep small text readable, so it should give up frames, not sharpness.
- **The height constraint was built from the width.** For 1080p it asked for `{ ideal: 1920, max: 1080 }` — an ideal above its own max — and the `=== 0` guard beside it tested `width` as well.
- **`applyConstraints` only set `frameRate.max`.** Capture starts clamped to `{ ideal: 5, max: 5 }` by the `getDisplayMedia` override added in #1497, and a bare `max` does not ask the source to speed back up, so `ideal` is sent too.
- **`getEnabledScreenShareQualities` wrote through to `ScreenSharePresets.original.resolution`.** That object is a singleton exported by livekit-client, so the preset stayed corrupted for the rest of the session. It builds its own object now.

### The new quality

A "1080p 60FPS" option, for sharing where motion matters more than detail. livekit ships no 60fps screen share preset, so the encoding is built from the 1080p30 one at 6Mbps — a higher frame rate needs more budget to stay legible while moving, or the encoder trades the frame rate straight back away and there is nothing to gain over 1080p30. It sits behind the same server-side resolution check that gates 1080p30.

Related to #1318, which asks for configurable quality but does not mention that the current options do not deliver what they advertise.

### Heads up on load

This does increase real bandwidth use. Today every share is capped at 2.5Mbps/15fps; afterwards "1080p 30FPS" actually uses the 5Mbps it promises. That is the intended behaviour, but it is a genuine change in server load — so if you would rather take the correctness fix on its own, I am happy to split the 60fps quality out into a separate PR.

### Testing

`mise build:check`, `mise lint` and `mise format` all pass.

I have **not** verified this at runtime — no measured fps in a real call — so confirmation from someone able to check the outbound `framesPerSecond` in `getStats()` before and after would be worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
