### PR TITLE
fix: Normalize regex format

### DIFF
--- a/packages/client/components/markdown/emoji/util.ts
+++ b/packages/client/components/markdown/emoji/util.ts
@@ -1,11 +1,7 @@
 import emojiRegex from "emoji-regex";
 
+import { RE_CUSTOM_EMOJI } from "stoat.js";
 import { MarkdownProps } from "..";
-
-/**
- * Regex for custom emoji
- */
-export const RE_CUSTOM_EMOJI = /:([0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}):/g;
 
 /**
  * Regex for any emoji

--- a/packages/client/components/markdown/plugins/channels.tsx
+++ b/packages/client/components/markdown/plugins/channels.tsx
@@ -1,8 +1,7 @@
 import { useInstance } from "@revolt/instance";
+import { RE_CHANNELS } from "stoat.js";
 import { Plugin } from "unified";
 import { visit } from "unist-util-visit";
-
-const RE_CHANNEL = /<#([A-z0-9]{26})>/g;
 
 export const remarkChannels: Plugin = () => (tree) => {
   const instance = useInstance();
@@ -15,7 +14,7 @@ export const remarkChannels: Plugin = () => (tree) => {
       idx,
       parent: { children: unknown[] },
     ) => {
-      const elements = node.value.split(RE_CHANNEL);
+      const elements = node.value.split(RE_CHANNELS);
       if (elements.length === 1) return; // no matches
 
       const newNodes = elements.map((value, index) => {

--- a/packages/client/components/markdown/plugins/customEmoji.tsx
+++ b/packages/client/components/markdown/plugins/customEmoji.tsx
@@ -1,6 +1,7 @@
 import { Match, Switch, createSignal, onMount } from "solid-js";
 
 import { Handler } from "mdast-util-to-hast";
+import { RE_CUSTOM_EMOJI } from "stoat.js";
 import { cva } from "styled-system/css";
 import { Plugin } from "unified";
 import { visit } from "unist-util-visit";
@@ -8,7 +9,7 @@ import { visit } from "unist-util-visit";
 import { useClient } from "@revolt/client";
 import { Avatar, Column, Row } from "@revolt/ui";
 
-import { CustomEmoji, Emoji, RE_CUSTOM_EMOJI } from "../emoji";
+import { CustomEmoji, Emoji } from "../emoji";
 
 /**
  * Render a custom emoji

--- a/packages/client/components/markdown/plugins/mentions.tsx
+++ b/packages/client/components/markdown/plugins/mentions.tsx
@@ -120,7 +120,7 @@ const RoleIcon = styled("div", {
 });
 
 const RE_MENTION =
-  /(<@[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}>|@everyone|@online|<%[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}>)/;
+  /(<@[ABCDEFGHJKMNPQRSTVWXYZ\d]{26}>|@everyone|@online|<%[ABCDEFGHJKMNPQRSTVWXYZ\d]{26}>)/;
 
 export const remarkMentions: Plugin = () => (tree) => {
   visit(

--- a/packages/client/components/routing/index.tsx
+++ b/packages/client/components/routing/index.tsx
@@ -19,20 +19,20 @@ export {
   useParams,
 } from "@solidjs/router";
 
-const RE_SERVER = /\/server\/([A-Z0-9]{26})/;
-const RE_CHANNEL = /\/channel\/([A-Z0-9]{26})/;
-const RE_MESSAGE_ID = /\/channel\/[A-Z0-9]{26}\/([A-Z0-9]{26})/;
-const RE_BOT_ID = /\/bot\/([A-Z0-9]{26})/;
+const RE_SERVER = /\/server\/([A-Z\d]{26})/;
+const RE_CHANNEL = /\/channel\/([A-Z\d]{26})/;
+const RE_MESSAGE_ID = /\/channel\/[A-Z\d]{26}\/([A-Z\d]{26})/;
+const RE_BOT_ID = /\/bot\/([A-Z\d]{26})/;
 const RE_HOST = /^\/i\/([\w:.]+)\//;
 
-const RE_INVITE_EXACT = /^(?:\/i\/[\w:.]+)?\/invite\/([\w\d]+)$/;
-const RE_BOT_ID_EXACT = /^(?:\/i\/[\w:.]+)?\/bot\/[A-Z0-9]{26}$/;
+const RE_INVITE_EXACT = /^(?:\/i\/[\w:.]+)?\/invite\/(\w+)$/;
+const RE_BOT_ID_EXACT = /^(?:\/i\/[\w:.]+)?\/bot\/[A-Z\d]{26}$/;
 
-const RE_SERVER_EXACT = /^(?:\/i\/[\w:.]+)?\/server\/([A-Z0-9]{26})$/;
+const RE_SERVER_EXACT = /^(?:\/i\/[\w:.]+)?\/server\/([A-Z\d]{26})$/;
 const RE_CHANNEL_EXACT =
-  /^(?:\/i\/[\w:.]+)?(?:\/server\/[A-Z0-9]{26})?\/channel\/([A-Z0-9]{26})(?:\/[A-Z0-9]{26})?$/;
+  /^(?:\/i\/[\w:.]+)?(?:\/server\/[A-Z\d]{26})?\/channel\/([A-Z\d]{26})(?:\/[A-Z\d]{26})?$/;
 const RE_MESSAGE_ID_EXACT =
-  /^(?:\/i\/[\w:.]+)?(?:\/server\/[A-Z0-9]{26})?\/channel\/[A-Z0-9]{26}\/([A-Z0-9]{26})$/;
+  /^(?:\/i\/[\w:.]+)?(?:\/server\/[A-Z\d]{26})?\/channel\/[A-Z\d]{26}\/([A-Z\d]{26})$/;
 
 /**
  * Route parameters available globally


### PR DESCRIPTION
Sister PR to <https://github.com/stoatchat/javascript-client-sdk/pull/188>

I left it as A-Z in `routing/index.tsx` because that is validated by one of the other ones first before it reaches that point (this method is for parsing, not validation of link format), and there's just a lot of them so it would look ugly lol.

## How was this PR tested?

Making sure the app starts and channels/users/mentions in messages didn't look broken

## Please declare, if any, LLM usage involved in creating this PR

Le-*no*-vo

- `main` <!-- branch-stack -->
  - \#1538 :point\_left:
