### PR TITLE
fix: missing file size in banner

### DIFF
--- a/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
+++ b/packages/client/components/app/interface/settings/user/profile/UserProfileEditor.tsx
@@ -173,7 +173,7 @@ export function UserProfileEditor(props: Props) {
           imageAspect="232/100"
           imageRounded={false}
           imageJustify={false}
-          maxSize={instance.limits().file_upload_size_limits["background"]}
+          maxSize={instance.limits().file_upload_size_limits["backgrounds"]}
         />
         <Form2.TextField
           minlength={2}


### PR DESCRIPTION
a typo prevented the file size of banners to appear

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] file size for banners appears
- [ ] Test B

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->
<img width="433" height="210" alt="image" src="https://github.com/user-attachments/assets/df009e5c-d0c7-490a-bc64-81d036b035c1" />

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

i didn't use a llm to add a singular character, why would i
