### PR TITLE
fix: Ensures virtualMic finds pipewire sink with or without prefix

### DIFF
--- a/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
+++ b/packages/client/components/app/interface/settings/user/voice/VoiceInputOptions.tsx
@@ -74,7 +74,7 @@ function SelectInput(props: { kind: MediaDeviceKind }) {
     const devs = media()
       .devices()
       // Filter out the virtual sink
-      .filter((dev) => dev.label !== stoatSinkName);
+      .filter((dev) => dev.label.split(":").pop() !== stoatSinkName);
 
     //Ensure default is at top
     let d = devs.find((d) => d.deviceId === "default");

--- a/packages/client/components/rtc/virtualMic.ts
+++ b/packages/client/components/rtc/virtualMic.ts
@@ -3,7 +3,9 @@ export const stoatSinkName = "stoat-virtual-source";
 export async function getVirtmic() {
   try {
     const devices = await navigator.mediaDevices.enumerateDevices();
-    const audioDevice = devices.find(({ label }) => label === stoatSinkName);
+    const audioDevice = devices.find(
+      ({ label }) => label.split(":").pop() === stoatSinkName,
+    );
     return audioDevice?.deviceId;
   } catch {
     return null;


### PR DESCRIPTION
node-pipewire creates a sink with added "node-pipewire:" prefix, so `getVirtmic` never finds the desktop sink.

## How was this PR tested?

Stoat through docker was having issues with the stoat-for-desktop and after a lot of testing, the desktop virtualMic files was being completely ignored, we managed to get it working by manually creating the sink and attaching the nodes until we realized the input list was showing `node-pipewire:stoat-virtual-source`. After checking the rust repo we confirmed the module actually adds that to the label, and the for-web was just not finding the correct one.

I don't think there's a screenshot to be provided in this context as I can't show off screenshare audio without stoat voice in a screenshot.

## Checklist:

- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No LLM involved at all
