### PR TITLE
fix: Make slowmode tooltip work

### DIFF
--- a/packages/client/src/interface/channels/text/CompositionInfo.tsx
+++ b/packages/client/src/interface/channels/text/CompositionInfo.tsx
@@ -8,6 +8,7 @@ import { useClient } from "@revolt/client";
 import { useDurationFormat } from "@revolt/i18n/durations";
 import { useUsers } from "@revolt/markdown/users";
 import { Avatar, OverflowingText, Symbol, typography } from "@revolt/ui";
+import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 interface Props {
@@ -128,7 +129,8 @@ export function CompositionInfo(props: Props) {
         </OverflowingText>
       </Show>
       <Show when={props.channel.slowmode}>
-        <SlowmodeHolder
+        <div
+          class={SlowmodeHolder()}
           use:floating={{
             tooltip: {
               placement: "top",
@@ -143,7 +145,7 @@ export function CompositionInfo(props: Props) {
               <Match when={cooldownRemaining() > 0}>{slowmodeText()}</Match>
             </Switch>
           </SlowmodeText>
-        </SlowmodeHolder>
+        </div>
       </Show>
     </Bar>
   );
@@ -193,13 +195,14 @@ const Dummy = styled("div", {
   },
 });
 
-const SlowmodeHolder = styled("div", {
+const SlowmodeHolder = cva({
   base: {
     display: "flex",
     alignItems: "center",
     marginLeft: "auto",
     gap: "var(--gap-sm)",
     color: "var(--md-sys-color-outline)",
+    flexShrink: 0,
   },
 });
 


### PR DESCRIPTION
A regression with the slowmode/typing indicator pr just merged, the tooltip wasn't working. This PR fixes that.

No meaningful UI changes.

## How was this PR tested?

Hovered over a tool tip

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1547 :point\_left:
