### PR TITLE
chore: Add assets to .prettierignore and force deinit on mise assets

### DIFF
--- a/.mise/tasks/assets/fallback
+++ b/.mise/tasks/assets/fallback
@@ -2,4 +2,4 @@
 #MISE description="Remove Stoat brand assets and use fallback"
 set -e
 
-git submodule deinit packages/client/assets
+git submodule deinit -f packages/client/assets

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@
 
 # test results
 **/test-results/**
+
+packages/client/assets/*


### PR DESCRIPTION
There's a json file in the assets dir that is messing with prettier. This PR adds the assets dir to the prettier ignore so it won't mess with it anymore.

No UI changes

## How was this PR tested?

`mise format`

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1548 :point\_left:
