### PR TITLE
fix: actually fetch the user in the background without blocking ui

### DIFF
--- a/packages/client/components/markdown/users.ts
+++ b/packages/client/components/markdown/users.ts
@@ -1,8 +1,4 @@
-import {
-  type Accessor,
-  type InitializedResource,
-  createResource,
-} from "solid-js";
+import { type Accessor, createMemo } from "solid-js";
 
 import { ServerMember, User } from "stoat.js";
 
@@ -57,39 +53,6 @@ export function userInformation(user?: User, member?: ServerMember) {
   };
 }
 
-async function getOrFetchUsers(options: {
-  ids: string[];
-  params: Accessor<{ serverId?: string }>;
-  filterNull?: boolean;
-}) {
-  const client = useClient();
-  const serverId = options.params().serverId;
-  return Promise.all(
-    options.ids.map(async (id) => {
-      const user =
-        client().users.get(id) ??
-        (await client()
-          .users.fetch(id)
-          .catch(() => null));
-
-      // Edge case: what if user fails to fetch on a spotty/intermittent conenction?
-      // Promise.all fails as soon as possible, so if one fetch fails, everything else
-      // does too and we don't get any data at all
-      if (!user) return undefined;
-
-      return userInformation(
-        user,
-        serverId
-          ? client().serverMembers.getByKey({
-              server: serverId,
-              user: user.id,
-            })
-          : undefined,
-      );
-    }),
-  ).then((arr) => (options.filterNull ? arr.filter((x) => x) : arr));
-}
-
 /**
  * Resolve multiple users by their ID within the current context
  * @param ids User IDs
@@ -99,18 +62,47 @@ async function getOrFetchUsers(options: {
 export function useUsers(
   ids: string[] | Accessor<string[]>,
   filterNull?: boolean,
-): InitializedResource<(UserInformation | undefined)[]> {
+): Accessor<(UserInformation | undefined)[]> {
   // TODO: use a context here for when we do multi view :)
   const params = useSmartParams();
-  const [users] = createResource(
-    {
-      ids: typeof ids === "function" ? ids() : ids,
-      params,
-      filterNull,
-    },
-    getOrFetchUsers,
-    { initialValue: [] as (UserInformation | undefined)[] },
-  );
+  const clientAccessor = useClient();
+
+  const pending = new Map<string, Promise<unknown>>();
+  function ensureUser(id: string) {
+    if (clientAccessor().users.has(id) || pending.has(id)) return;
+    const promise = clientAccessor()
+      .users.fetch(id)
+      .catch(() => undefined);
+
+    pending.set(id, promise);
+
+    promise.finally(() => {
+      pending.delete(id);
+    });
+  }
+
+  const users = createMemo(() => {
+    const list = (typeof ids === "function" ? ids() : ids).map((id) => {
+      const user = clientAccessor().users.get(id);
+      if (!user) {
+        // Fetch the user in the background and return an unknown user for now
+        ensureUser(id);
+        return userInformation();
+      }
+
+      return userInformation(
+        user,
+        params().serverId
+          ? clientAccessor().serverMembers.getByKey({
+              server: params().serverId!,
+              user: user.id,
+            })
+          : undefined,
+      );
+    });
+
+    return filterNull ? list.filter((x) => x) : list;
+  });
 
   return users;
 }


### PR DESCRIPTION
fixes the fix in #1529 because it was done wrong and introduced a very bad regression

it made ViewBot hang and typing indicators not appear and more stuff

in hindsight, i should've done this from the start
one could say this is a 56 /shrug

## How was this PR tested?

- [x] Typing indicators appear again
- [x] Channels now load without the loading indicator briefly appearing
- [x] Viewing bots no longer completely hangs the client
- [x] The fix fixes the issue that it was supposed to fix (unknown users in voice calls)

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

no ai was used to author this pull request
