### PR TITLE
fix: Visual padding issues

### DIFF
--- a/packages/client/components/app/interface/channels/text/CompositionInfo.tsx
+++ b/packages/client/components/app/interface/channels/text/CompositionInfo.tsx
@@ -1,7 +1,8 @@
 import { createCountdownFromNow } from "@solid-primitives/date";
-import { For, Match, Setter, Show, Switch, createMemo } from "solid-js";
+import { For, Match, Show, Switch, createMemo, onMount } from "solid-js";
 
 import { Trans, useLingui } from "@lingui/solid/macro";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 import { Channel, User } from "stoat.js";
 import { cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
@@ -13,7 +14,7 @@ import { Avatar, OverflowingText, Symbol, typography } from "@revolt/ui";
 
 interface Props {
   channel: Channel;
-  showPad: Setter<boolean>;
+  scrollRef?: HTMLElement | null;
 }
 
 /**
@@ -95,15 +96,25 @@ export function CompositionInfo(props: Props) {
     true,
   );
 
-  const showInfo = createMemo(() => {
-    const info = props.channel.slowmode || users().length;
-    props.showPad(!info);
-    return info;
-  });
+  let barRef: HTMLDivElement | undefined;
+
+  onMount(() => createResizeObserver(() => props.scrollRef, setBarWidth));
+
+  function setBarRef(r?: HTMLDivElement) {
+    barRef = r;
+    setBarWidth();
+  }
+
+  function setBarWidth() {
+    if (barRef && props.scrollRef)
+      barRef.style.width = `calc(100% - ${
+        props.scrollRef.offsetWidth - props.scrollRef.clientWidth
+      }px)`;
+  }
 
   return (
-    <Show when={showInfo()}>
-      <Bar>
+    <Show when={props.channel.slowmode || users().length || setBarRef()}>
+      <Bar ref={setBarRef}>
         <Show when={users().length} fallback={<Dummy />}>
           <Avatars>
             <For each={users()}>
@@ -179,11 +190,9 @@ const Avatars = styled("div", {
  */
 const Bar = styled("div", {
   base: {
-    width: "100%",
     minHeight: "26px",
-
-    padding: "0 var(--gap-lg)",
-    borderRadius: "var(--borderRadius-lg)",
+    paddingLeft: "var(--gap-lg)",
+    paddingRight: "var(--gap-md)",
 
     display: "flex",
     gap: "var(--gap-md)",
@@ -193,6 +202,7 @@ const Bar = styled("div", {
     flexDirection: "row",
 
     color: "var(--md-sys-color-on-surface)",
+    background: "var(--md-sys-color-surface-container-lowest)",
   },
 });
 

--- a/packages/client/components/app/interface/channels/text/CompositionInfo.tsx
+++ b/packages/client/components/app/interface/channels/text/CompositionInfo.tsx
@@ -1,18 +1,19 @@
 import { createCountdownFromNow } from "@solid-primitives/date";
-import { For, Match, Show, Switch, createMemo } from "solid-js";
-
-import { Channel, User } from "stoat.js";
+import { For, Match, Setter, Show, Switch, createMemo } from "solid-js";
 
 import { Trans, useLingui } from "@lingui/solid/macro";
+import { Channel, User } from "stoat.js";
+import { cva } from "styled-system/css";
+import { styled } from "styled-system/jsx";
+
 import { useClient } from "@revolt/client";
 import { useDurationFormat } from "@revolt/i18n/durations";
 import { useUsers } from "@revolt/markdown/users";
 import { Avatar, OverflowingText, Symbol, typography } from "@revolt/ui";
-import { cva } from "styled-system/css";
-import { styled } from "styled-system/jsx";
 
 interface Props {
   channel: Channel;
+  showPad: Setter<boolean>;
 }
 
 /**
@@ -23,9 +24,7 @@ export function CompositionInfo(props: Props) {
   const durationFormat = useDurationFormat();
   const client = useClient();
 
-  const isSlowmodeExempt = (): boolean => {
-    return props.channel.havePermission("BypassSlowmode");
-  };
+  const isSlowmodeExempt = () => props.channel.havePermission("BypassSlowmode");
 
   const slowmodeCountdown = createMemo(() => {
     if (!props.channel.slowmode || isSlowmodeExempt()) return 0;
@@ -81,73 +80,82 @@ export function CompositionInfo(props: Props) {
    * Generate list of user IDs
    * @returns User IDs
    */
-  const userIds = () =>
-    (
-      props.channel.typing.filter(
-        (user) =>
-          typeof user !== "undefined" &&
-          user.id !== client().user!.id &&
-          user.relationship !== "Blocked",
-      ) as User[]
-    )
-      .sort((a, b) => a!.id.toUpperCase().localeCompare(b!.id.toUpperCase()))
-      .map((user) => user.id);
+  const users = useUsers(
+    () =>
+      (
+        props.channel.typing.filter(
+          (user) =>
+            typeof user !== "undefined" &&
+            user.id !== client().user!.id &&
+            user.relationship !== "Blocked",
+        ) as User[]
+      )
+        .sort((a, b) => a!.id.toUpperCase().localeCompare(b!.id.toUpperCase()))
+        .map((user) => user.id),
+    true,
+  );
 
-  const users = useUsers(userIds, true);
+  const showInfo = createMemo(() => {
+    const info = props.channel.slowmode || users().length;
+    props.showPad(!info);
+    return info;
+  });
 
   return (
-    <Bar>
-      <Show when={users().length} fallback={<Dummy />}>
-        <Avatars>
-          <For each={users()}>
-            {(user, index) => (
-              <Avatar
-                src={user!.avatar}
-                size={15}
-                holepunch={
-                  index() + 1 < users().length ? "overlap-subtle" : "none"
-                }
-              />
-            )}
-          </For>
-        </Avatars>
-        <OverflowingText class={typography({ class: "body", size: "small" })}>
-          <Switch fallback={<Trans>Several people are typing…</Trans>}>
-            <Match when={users().length === 1}>
-              <Trans>{users()[0]!.username} is typing…</Trans>
-            </Match>
-            <Match when={users().length < 5}>
-              <Trans>
-                {users()
-                  .slice(0, -1)
-                  .map((user) => user!.username)
-                  .join(", ")}{" "}
-                and {users().slice(-1)[0]!.username} are typing…
-              </Trans>
-            </Match>
-          </Switch>
-        </OverflowingText>
-      </Show>
-      <Show when={props.channel.slowmode}>
-        <div
-          class={SlowmodeHolder()}
-          use:floating={{
-            tooltip: {
-              placement: "top",
-              content: t`Members can send one message every ${slowmodeWaitTime()}.`,
-            },
-          }}
-        >
-          <Symbol style={{ "font-size": "1rem" }}>schedule</Symbol>
-          <SlowmodeText>
-            <Switch fallback={t`Slowmode is enabled.`}>
-              <Match when={isSlowmodeExempt()}>{t`Slowmode Immune`}</Match>
-              <Match when={cooldownRemaining() > 0}>{slowmodeText()}</Match>
+    <Show when={showInfo()}>
+      <Bar>
+        <Show when={users().length} fallback={<Dummy />}>
+          <Avatars>
+            <For each={users()}>
+              {(user, index) => (
+                <Avatar
+                  src={user!.avatar}
+                  size={15}
+                  holepunch={
+                    index() + 1 < users().length ? "overlap-subtle" : "none"
+                  }
+                />
+              )}
+            </For>
+          </Avatars>
+          <OverflowingText class={typography({ class: "body", size: "small" })}>
+            <Switch fallback={<Trans>Several people are typing…</Trans>}>
+              <Match when={users().length === 1}>
+                <Trans>{users()[0]!.username} is typing…</Trans>
+              </Match>
+              <Match when={users().length < 5}>
+                <Trans>
+                  {users()
+                    .slice(0, -1)
+                    .map((user) => user!.username)
+                    .join(", ")}{" "}
+                  and {users().slice(-1)[0]!.username} are typing…
+                </Trans>
+              </Match>
             </Switch>
-          </SlowmodeText>
-        </div>
-      </Show>
-    </Bar>
+          </OverflowingText>
+        </Show>
+        <Show when={props.channel.slowmode}>
+          <div
+            class={SlowmodeHolder()}
+            use:floating={{
+              tooltip: {
+                placement: "top",
+                content: t`Members can send one message every ${slowmodeWaitTime()}.`,
+              },
+            }}
+          >
+            <Symbol style={{ "font-size": "1rem" }}>schedule</Symbol>
+            <SlowmodeText>
+              <Switch fallback={t`Slowmode is enabled.`}>
+                <Match when={isSlowmodeExempt()}>{t`Slowmode Immune`}</Match>
+                <Match when={cooldownRemaining() > 0}>{slowmodeText()}</Match>
+              </Switch>
+            </SlowmodeText>
+          </div>
+        </Show>
+      </Bar>
+    </Show>
   );
 }
 

--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -31,11 +31,12 @@ import {
   JumpToBottom,
   MessageDivider,
 } from "@revolt/ui";
-
 import {
   ListView2,
   ListView2Update,
 } from "@revolt/ui/components/utils/ListView2";
+
+import { CompositionInfo } from "./CompositionInfo";
 import { Message } from "./Message";
 import { useMessageCache } from "./MessageCache";
 
@@ -126,6 +127,9 @@ export function Messages(props: Props) {
    * Whether the current fetch has failed
    */
   const [failure, setFailure] = createSignal(false);
+
+  /** Whether to show padding at bottom */
+  const [showPad, setShowPad] = createSignal(false);
 
   /**
    * Collect messages during fetches
@@ -954,6 +958,9 @@ export function Messages(props: Props) {
                   tail: pendingMessageIsTrailing(),
                   ids: sentMessageIdempotency(),
                 })}
+                <Show when={showPad()}>
+                  <Padding />
+                </Show>
               </Show>
             </div>
           </div>
@@ -964,6 +971,7 @@ export function Messages(props: Props) {
           <JumpToBottom onClick={jumpToBottom} />
         </AnchorToEnd>
       </Show>
+      <CompositionInfo channel={props.channel} showPad={setShowPad} />
     </>
   );
 }
@@ -981,6 +989,15 @@ const AnchorToEnd = styled("div", {
       position: "absolute",
       bottom: "var(--gap-md)",
     },
+  },
+});
+
+/**
+ * Container padding
+ */
+const Padding = styled("div", {
+  base: {
+    height: "26px",
   },
 });
 

--- a/packages/client/components/app/interface/channels/text/Messages.tsx
+++ b/packages/client/components/app/interface/channels/text/Messages.tsx
@@ -128,9 +128,6 @@ export function Messages(props: Props) {
    */
   const [failure, setFailure] = createSignal(false);
 
-  /** Whether to show padding at bottom */
-  const [showPad, setShowPad] = createSignal(false);
-
   /**
    * Collect messages during fetches
    *
@@ -147,7 +144,7 @@ export function Messages(props: Props) {
   /**
    * Reference for the list container so we can scroll to elements
    */
-  let listRef: HTMLDivElement | undefined;
+  const [listRef, setListRef] = createSignal<HTMLDivElement>();
 
   /**
    * Whether we can fetch
@@ -281,7 +278,7 @@ export function Messages(props: Props) {
       // If we're not at the end, restore scroll position
       if (existingState && !existingState.atEnd) {
         setTimeout(() =>
-          listRef?.scrollTo({
+          listRef()?.scrollTo({
             top: existingState.scrollTop!,
             behavior: "instant",
           }),
@@ -290,7 +287,7 @@ export function Messages(props: Props) {
       // Or... reset scroll to the end
       else if (atEnd()) {
         setTimeout(() =>
-          listRef?.scrollTo({
+          listRef()?.scrollTo({
             top: 9999999,
             behavior: "instant",
           }),
@@ -462,7 +459,7 @@ export function Messages(props: Props) {
 
     // Scroll to the bottom if we're already at the end
     if (atEnd()) {
-      const containerChild = findScrollContainer(listRef!)!.children[0];
+      const containerChild = findScrollContainer(listRef()!)!.children[0];
       containerChild!.scrollIntoView({
         behavior: "smooth",
         block: "end",
@@ -516,7 +513,7 @@ export function Messages(props: Props) {
 
         // Animate scroll to bottom
         setTimeout(() => {
-          const containerChild = findScrollContainer(listRef!)!.children[0];
+          const containerChild = findScrollContainer(listRef()!)!.children[0];
 
           containerChild!.scrollIntoView({
             behavior: "instant",
@@ -554,7 +551,7 @@ export function Messages(props: Props) {
         (entry) => entry.t === 0 && entry.message.id === messageId,
       ); // use localeCompare
 
-      listRef!.children[index + (atStart() ? 1 : 0)].scrollIntoView({
+      listRef()!.children[index + (atStart() ? 1 : 0)].scrollIntoView({
         behavior: "smooth",
         block: "center",
       });
@@ -627,7 +624,7 @@ export function Messages(props: Props) {
               messages: messages(),
               atStart: atStart(),
               atEnd: atEnd(),
-              scrollTop: listRef?.scrollTop,
+              scrollTop: listRef()?.scrollTop,
             });
           }
         });
@@ -934,7 +931,7 @@ export function Messages(props: Props) {
       >
         <Deferred>
           <div>
-            <div ref={listRef}>
+            <div ref={setListRef}>
               <Show when={atStart()}>
                 <ConversationStart channel={props.channel} />
               </Show>
@@ -958,20 +955,26 @@ export function Messages(props: Props) {
                   tail: pendingMessageIsTrailing(),
                   ids: sentMessageIdempotency(),
                 })}
-                <Show when={showPad()}>
-                  <Padding />
-                </Show>
+                <Padding />
               </Show>
             </div>
           </div>
         </Deferred>
       </ListView2>
-      <Show when={!atEnd()}>
-        <AnchorToEnd>
-          <JumpToBottom onClick={jumpToBottom} />
-        </AnchorToEnd>
-      </Show>
-      <CompositionInfo channel={props.channel} showPad={setShowPad} />
+      <AnchorToEnd>
+        <div>
+          <Show when={!atEnd()}>
+            <JumpToBottom onClick={jumpToBottom} />
+          </Show>
+          <CompositionInfo
+            channel={props.channel}
+            scrollRef={
+              listRef()?.parentElement?.parentElement?.parentElement
+                ?.parentElement
+            }
+          />
+        </div>
+      </AnchorToEnd>
     </>
   );
 }
@@ -987,7 +990,7 @@ const AnchorToEnd = styled("div", {
     "& > div": {
       width: "100%",
       position: "absolute",
-      bottom: "var(--gap-md)",
+      bottom: 0,
     },
   },
 });

--- a/packages/client/components/ui/components/design/TextField.tsx
+++ b/packages/client/components/ui/components/design/TextField.tsx
@@ -93,7 +93,7 @@ export function TextField(props: Props) {
   return (
     <mdui-text-field
       {...props}
-      class={field()}
+      class={field() + (props.class ? " " + props.class : "")}
       // @codegen directives props=props include=autoComplete
     />
   );

--- a/packages/client/components/ui/components/features/messaging/bars/JumpToBottom.tsx
+++ b/packages/client/components/ui/components/features/messaging/bars/JumpToBottom.tsx
@@ -1,11 +1,11 @@
 import { Trans } from "@lingui/solid/macro";
+import { css } from "styled-system/css";
 
 import { iconSize } from "@revolt/ui";
 
 import MdArrowForward from "@material-design-icons/svg/filled/arrow_forward.svg?component-solid";
 
 import { Ripple } from "../../../../components/design";
-
 import { FloatingIndicator } from "./FloatingIndicator";
 
 interface Props {
@@ -20,7 +20,11 @@ interface Props {
  */
 export function JumpToBottom(props: Props) {
   return (
-    <FloatingIndicator position="bottom" onClick={props.onClick}>
+    <FloatingIndicator
+      position="bottom"
+      class={css({ marginBottom: "var(--gap-md)" })}
+      onClick={props.onClick}
+    >
       <Ripple />
       <span style={{ "flex-grow": 1 }}>
         <Trans>Viewing older messages</Trans>

--- a/packages/client/components/ui/components/features/messaging/bars/JumpToBottom.tsx
+++ b/packages/client/components/ui/components/features/messaging/bars/JumpToBottom.tsx
@@ -15,6 +15,8 @@ interface Props {
   onClick: () => void;
 }
 
+const indStyle = css({ marginBottom: "var(--gap-md)" });
+
 /**
  * Component indicating user can jump back to present messages
  */
@@ -22,7 +24,7 @@ export function JumpToBottom(props: Props) {
   return (
     <FloatingIndicator
       position="bottom"
-      class={css({ marginBottom: "var(--gap-md)" })}
+      class={indStyle}
       onClick={props.onClick}
     >
       <Ripple />

--- a/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/picker/EmojiPicker.tsx
@@ -10,7 +10,7 @@ import {
 
 import { VirtualContainer } from "@minht11/solid-virtual-container";
 import { Emoji, Server } from "stoat.js";
-import { cva } from "styled-system/css";
+import { css, cva } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
@@ -156,6 +156,7 @@ export function EmojiPicker() {
         placeholder="Search for emojis..."
         value={filter()}
         onInput={(e) => setFilter(e.currentTarget.value)}
+        class={searchBar}
       />
       <Row gap={"none"} class={compositionContent()}>
         <div
@@ -295,6 +296,10 @@ const Stack = styled("div", {
     flexDirection: "column",
     gap: "var(--gap-md)",
   },
+});
+
+const searchBar = css({
+  paddingInline: "var(--gap-md)",
 });
 
 const scrollContainer = cva({

--- a/packages/client/components/ui/components/layout/Header.tsx
+++ b/packages/client/components/ui/components/layout/Header.tsx
@@ -31,15 +31,12 @@ export const Header = styled("div", {
     "& svg": {
       flexShrink: 0,
     },
-
-    _phone: {
-      marginLeft: "var(--gap-lg)",
-    },
   },
   variants: {
     placement: {
       primary: {
         margin: "var(--gap-md) var(--gap-md) var(--gap-md) 0",
+        _phone: { marginLeft: "var(--gap-lg)" },
       },
       secondary: {
         margin: "var(--gap-md)",
@@ -62,16 +59,23 @@ export const Header = styled("div", {
           background: "linear-gradient(0deg, black, transparent)",
         },
       },
-      false: {},
     },
     transparent: {
       true: {
         width: "calc(100% - var(--gap-md))",
         zIndex: "10",
       },
-      false: {},
     },
   },
+  compoundVariants: [
+    {
+      placement: "secondary",
+      image: false,
+      css: {
+        marginLeft: "var(--gap-lg)",
+      },
+    },
+  ],
   defaultVariants: {
     placement: "primary",
     image: false,

--- a/packages/client/components/ui/components/layout/Header.tsx
+++ b/packages/client/components/ui/components/layout/Header.tsx
@@ -16,7 +16,6 @@ export const Header = styled("div", {
     flex: "0 auto",
     display: "flex",
     flexShrink: 0,
-    padding: "0 16px",
     alignItems: "center",
     fontWeight: 600,
     userSelect: "none",
@@ -33,8 +32,8 @@ export const Header = styled("div", {
       flexShrink: 0,
     },
 
-    _tablet: {
-      paddingRight: 0,
+    _phone: {
+      marginLeft: "16px",
     },
   },
   variants: {
@@ -52,7 +51,6 @@ export const Header = styled("div", {
         color: "white",
         fill: "white",
 
-        padding: 0,
         alignItems: "flex-end",
         justifyContent: "stretch",
         textShadow: "0px 0px 1px var(--md-sys-color-shadow)",

--- a/packages/client/components/ui/components/layout/Header.tsx
+++ b/packages/client/components/ui/components/layout/Header.tsx
@@ -33,7 +33,7 @@ export const Header = styled("div", {
     },
 
     _phone: {
-      marginLeft: "16px",
+      marginLeft: "var(--gap-lg)",
     },
   },
   variants: {

--- a/packages/client/components/ui/components/layout/Main.tsx
+++ b/packages/client/components/ui/components/layout/Main.tsx
@@ -16,16 +16,14 @@ export const main = cva({
     flexDirection: "column",
 
     paddingInline: "var(--gap-md)",
-    marginInline: "var(--gap-md)",
-    marginBlockEnd: "var(--gap-md)",
+    margin: "0 var(--gap-md) var(--gap-md) 0",
     borderRadius: "var(--borderRadius-xl)",
     background: "var(--md-sys-color-surface-container-lowest)",
     paddingBottom: "env(keyboard-inset-height)",
 
     _tablet: {
       margin: 0,
-      borderBottomRightRadius: 0,
-      borderBottomLeftRadius: 0,
+      borderRadius: "var(--borderRadius-xl) 0 0 0",
     },
 
     _phone: {

--- a/packages/client/src/Interface.tsx
+++ b/packages/client/src/Interface.tsx
@@ -183,9 +183,14 @@ const Content = styled("div", {
   variants: {
     sidebar: {
       false: {
+        paddingLeft: "var(--gap-md)",
         borderTopLeftRadius: "var(--borderRadius-lg)",
         borderBottomLeftRadius: "var(--borderRadius-lg)",
         overflow: "hidden",
+
+        _tablet: {
+          paddingLeft: 0,
+        },
       },
     },
   },

--- a/packages/client/src/interface/channels/text/TextChannel.tsx
+++ b/packages/client/src/interface/channels/text/TextChannel.tsx
@@ -32,7 +32,6 @@ import { ChannelPageProps } from "../ChannelPage";
 
 import { Channel } from "stoat.js";
 import { MessageComposition } from "./Composition";
-import { CompositionInfo } from "./CompositionInfo";
 import { MemberSidebar } from "./MemberSidebar";
 import { TextSearchSidebar } from "./TextSearchSidebar";
 
@@ -234,8 +233,6 @@ export function TextChannel(props: ChannelPageProps) {
             jumpToBottomRef={(ref) => (jumpToBottomRef = ref)}
             atEnd={[atEnd, setEnd]}
           />
-
-          <CompositionInfo channel={props.channel} />
 
           <MessageComposition
             channel={props.channel}

--- a/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
@@ -206,7 +206,7 @@ export const HomeSidebar = (props: Props) => {
  */
 const SidebarTitle = styled("p", {
   base: {
-    paddingBlock: "calc(var(--gap-md) + 15px)",
+    paddingBlock: "calc(var(--gap-md) + var(--gap-lg))",
     paddingInline: "var(--gap-md)",
 
     ...typography.raw({ class: "title" }),

--- a/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
@@ -72,9 +72,9 @@ export const HomeSidebar = (props: Props) => {
     <SidebarBase class="channel_bar home">
       <div ref={scrollTargetElement} use:invisibleScrollable>
         <List>
-          <SidebarTitle>
+          <Header>
             <Trans>Conversations</Trans>
-          </SidebarTitle>
+          </Header>
 
           <MenuButton
             href="/app"
@@ -201,15 +201,20 @@ export const HomeSidebar = (props: Props) => {
   );
 };
 
-/**
- * Sidebar title
- */
-const SidebarTitle = styled("p", {
+export const Header = styled("div", {
   base: {
-    paddingBlock: "calc(var(--gap-md) + var(--gap-lg))",
-    paddingInline: "var(--gap-md)",
-
-    ...typography.raw({ class: "title" }),
+    alignItems: "center",
+    fontWeight: 600,
+    userSelect: "none",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    height: "48px",
+    lineHeight: "48px",
+    verticalAlign: "middle",
+    margin: "var(--gap-md)",
+    marginLeft: "var(--gap-lg)",
+    color: "var(--md-sys-color-on-surface)",
+    backgroundColor: "var(--md-sys-color-surface-variant)",
   },
 });
 

--- a/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/HomeSidebar.tsx
@@ -406,7 +406,6 @@ function Entry(
  */
 const List = styled("div", {
   base: {
-    paddingLeft: "var(--gap-md)",
     width: "var(--layout-width-channel-sidebar)",
   },
 });

--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -400,6 +400,10 @@ const CategorySection = styled("div", {
     paddingBlock: "var(--gap-sm)",
     borderRadius: "var(--borderRadius-sm)",
     background: "var(--md-sys-color-surface-container-low)",
+
+    "&:first-child": {
+      paddingTop: 0,
+    },
   },
 });
 


### PR DESCRIPTION
- Fix #1541 issue where the indicator area never disappears when no indicators/info is shown
- Move new CompositionInfo component to under the `components/` folder where it probably should be (idk the directory tree of this project is a mess lmao)
- Add back padding to the bottom of message list when you scroll to the end
- Make padding on left & right of channel sidebar equal (someone pointed this out to me and now I can't unsee the asymmetry lol)
- Fix DM channel list padding size not matching server channel list
- Match emoji search box padding to GIF picker search padding

## How was this PR tested?

Visual inspection and testing message indicators

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Before:\
<img width=400 src="https://github.com/user-attachments/assets/3d577337-f9f6-43e4-b12f-e95988635080" />

After:\
<img width=400 src="https://github.com/user-attachments/assets/d53583d2-ce1d-4c3f-8fb8-8eb9ef5bcbe4" />

Banner appears dynamically when needed (but floats above scroll window so that the chat won't scroll)\
<img width=350 src="https://github.com/user-attachments/assets/a79fc5dd-faae-46f6-badc-ee4b21b44276" />

Before / After:\
<img width=200 src="https://github.com/user-attachments/assets/4e760b0e-4c9b-4fdf-8528-f8e738d92e33" /> <img width=200 src="https://github.com/user-attachments/assets/189be1b8-21eb-411a-931f-d191e6778323" />

Before / After:\
<img width=300 src="https://github.com/user-attachments/assets/1885401f-a807-4313-a302-f202cce1c449" /> <img width=300 src="https://github.com/user-attachments/assets/0a03d584-a50e-4893-848b-19a474050271" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

It's false. No way. Not this time. We created it. It's pure fiction. Wrong. It never happened. It's a total fabrication.

- `main` <!-- branch-stack -->
  - \#1558 :point\_left:
