### PR TITLE
fix: keep Save file in current tab when supported

### DIFF
--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -49,6 +49,7 @@ export function MessageContextMenu(props: {
   const instance = useInstance();
   const client = useClient();
   const { openModal, showError } = useModals();
+  const supportsDownload = "download" in document.createElement("a");
 
   /**
    * Reply to this message
@@ -172,7 +173,7 @@ export function MessageContextMenu(props: {
           <Trans>Copy file link</Trans>
         </ContextMenuButton>
         <a
-          target="_blank"
+          target={supportsDownload ? undefined : "_blank"}
           download={props.file?.filename}
           href={props.file?.originalUrl}
         >

--- a/packages/client/components/app/menus/MessageContextMenu.tsx
+++ b/packages/client/components/app/menus/MessageContextMenu.tsx
@@ -4,6 +4,7 @@ import { Trans } from "@lingui/solid/macro";
 import { File, Message } from "stoat.js";
 
 import { useClient, useUser } from "@revolt/client";
+import { supportsAnchorDownload } from "@revolt/common";
 import { useInstance } from "@revolt/instance";
 import { CustomEmoji, UnicodeEmoji } from "@revolt/markdown/emoji";
 import { useModals } from "@revolt/modal";
@@ -49,7 +50,6 @@ export function MessageContextMenu(props: {
   const instance = useInstance();
   const client = useClient();
   const { openModal, showError } = useModals();
-  const supportsDownload = "download" in document.createElement("a");
 
   /**
    * Reply to this message
@@ -173,7 +173,7 @@ export function MessageContextMenu(props: {
           <Trans>Copy file link</Trans>
         </ContextMenuButton>
         <a
-          target={supportsDownload ? undefined : "_blank"}
+          target={supportsAnchorDownload ? undefined : "_blank"}
           download={props.file?.filename}
           href={props.file?.originalUrl}
         >

--- a/packages/client/components/common/index.tsx
+++ b/packages/client/components/common/index.tsx
@@ -1,4 +1,5 @@
 export * from "./Device";
 export { debounce } from "./lib/debounce";
+export { supportsAnchorDownload } from "./lib/download";
 export { default as CONFIGURATION } from "./lib/env";
 export { insecureUniqueId } from "./lib/unique";

--- a/packages/client/components/common/lib/download.ts
+++ b/packages/client/components/common/lib/download.ts
@@ -1,0 +1,5 @@
+/**
+ * Whether the browser supports the anchor `download` attribute.
+ */
+export const supportsAnchorDownload =
+  "download" in document.createElement("a");

--- a/packages/client/components/modal/modals/ImageViewer.tsx
+++ b/packages/client/components/modal/modals/ImageViewer.tsx
@@ -14,10 +14,10 @@ import Panzoom, { PanzoomObject } from "@panzoom/panzoom";
 import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
+import { supportsAnchorDownload } from "@revolt/common";
+import { isGifBox } from "@revolt/common/lib/gifs";
 import { Column, Dialog, DialogProps, IconButton, Text } from "@revolt/ui";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
-
-import { isGifBox } from "@revolt/common/lib/gifs";
 import { Modals } from "../types";
 
 export function ImageViewerModal(
@@ -117,7 +117,7 @@ export function ImageViewerModal(
                     </IconButton>
                     <Show when={props.file}>
                       <a
-                        target="_blank"
+                        target={supportsAnchorDownload ? undefined : "_blank"}
                         href={props.file?.originalUrl}
                         download={props.file?.filename}
                       >

--- a/packages/client/components/ui/components/features/messaging/elements/FileInfo.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/FileInfo.tsx
@@ -10,6 +10,7 @@ import { Match, Show, Switch } from "solid-js";
 import { File, MessageEmbed } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
+import { supportsAnchorDownload } from "@revolt/common";
 import { IconButton, Text } from "@revolt/ui/components/design";
 import { Column, Row } from "@revolt/ui/components/layout";
 import { humanFileSize } from "@revolt/ui/components/utils";
@@ -74,7 +75,7 @@ export function FileInfo(props: Props) {
       </Column>
       <Show when={props.file}>
         <a
-          target="_blank"
+          target={supportsAnchorDownload ? undefined : "_blank"}
           href={props.file?.originalUrl}
           download={props.file?.filename}
         >


### PR DESCRIPTION
## Summary

- keep the current tab when the browser supports the `download` attribute
- preserve the existing `_blank` fallback for browsers that do not support it
- apply the behavior consistently to the context menu, file information, and image viewer download actions
- centralize the browser capability check in `supportsAnchorDownload`

I SOLVED IT, PASSED IT, then AI generated the PR.

This change is intentionally limited to file download behavior.