### PR TITLE
fix: guard against bot.user being undefined in delete confirmation dialog

### DIFF
--- a/packages/client/components/modal/modals/DeleteBot.tsx
+++ b/packages/client/components/modal/modals/DeleteBot.tsx
@@ -29,7 +29,9 @@ export function DeleteBotModal(
     <Dialog
       show={props.show}
       onClose={props.onClose}
-      title={<Trans>Delete {props.bot.user!.displayName}?</Trans>}
+      title={
+        <Trans>Delete {props.bot.user?.displayName ?? props.bot.id}?</Trans>
+      }
       actions={[
         { text: <Trans>Cancel</Trans> },
         {


### PR DESCRIPTION

<!-- Describe your changes -->
`Bot.user` in the SDK (`packages/stoat.js/src/classes/Bot.ts`) is typed `User | undefined` it's a live lookup (`client.users.get(this.id)`), not a guaranteed value. `DeleteBot.tsx`'s dialog title used `props.bot.user!`, asserting it away, which throws `Cannot read properties of undefined (reading 'user')` when it's actually undefined at render time.

That crash is also why the modal doesn't navigate back after a successful delete: `Dialog.tsx` only auto-closes when the button's `onClick` promise resolves (`value.then(props.onClose)`); a rejected promise hits its `.catch(() => {})` and leaves the dialog open, while `onError: showError` shows the error toast. The bot is already deleted server-side by this point (`Bot.delete()` calls the API before touching local state), so the user is left stuck on a dialog for something that's already gone.

Fixing the crash lets the mutation resolve normally, which lets the existing `.then(props.onClose)` close the dialog as intended no change needed to `Dialog.tsx` itself.

Fixes #1508 

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] `pnpm --filter client exec tsc --noEmit` (the same command CI's Typecheck job runs, per `.mise/tasks/build/check`) zero errors in the changed file. (Five pre-existing errors elsewhere in the repo, unrelated to this change and not introduced by it.)
- [ ] Have not been able to reproduce the original crash live to confirm the fix end-to-end.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

...
