### PR TITLE
feat: Add discover buttons and flow for bots and servers

### DIFF
--- a/packages/client/components/app/interface/settings/ServerSettings.tsx
+++ b/packages/client/components/app/interface/settings/ServerSettings.tsx
@@ -15,6 +15,7 @@ import { EmojiList } from "./server/emojis/EmojiList";
 import { ListServerInvites } from "./server/invites/ListServerInvites";
 import { ServerRoleEditor } from "./server/roles/ServerRoleEditor";
 import { ServerRoleOverview } from "./server/roles/ServerRoleOverview";
+import { Discoverable } from "./shared/Discoverable";
 import { BackCard } from "./user/_AccountCard";
 
 const Config: SettingsConfiguration<Server> = {
@@ -62,6 +63,8 @@ const Config: SettingsConfiguration<Server> = {
     switch (id) {
       case "overview":
         return <Overview server={server} />;
+      case "discover":
+        return <Discoverable discoverable={server} fullPage={true} />;
       case "emojis":
         return <EmojiList server={server} />;
       case "roles":
@@ -96,6 +99,12 @@ const Config: SettingsConfiguration<Server> = {
               id: "overview",
               icon: <Symbol size={20}>info</Symbol>,
               title: <Trans>Overview</Trans>,
+            },
+            {
+              id: "discover",
+              hidden: !(server.ownerId === user()?.id),
+              icon: <Symbol size={20}>public</Symbol>,
+              title: <Trans>Discover</Trans>,
             },
           ],
         },

--- a/packages/client/components/app/interface/settings/shared/Discoverable.tsx
+++ b/packages/client/components/app/interface/settings/shared/Discoverable.tsx
@@ -125,6 +125,27 @@ export function Discoverable(props: {
                           </Trans>
                         </Text>
                       </MessagePreview>
+                      <CategoryButton.Group>
+                        <CategoryButton
+                          description={
+                            <Trans>
+                              Cancel your discover request and remove it from
+                              the review queue
+                            </Trans>
+                          }
+                          icon={<Symbol size={22}>cancel</Symbol>}
+                          action="chevron"
+                          onClick={() =>
+                            props.discoverable
+                              .cancelDiscoverRequest()
+                              .then(async () =>
+                                discoverRequestActions.refetch(),
+                              )
+                          }
+                        >
+                          <Trans>Cancel discover request</Trans>
+                        </CategoryButton>
+                      </CategoryButton.Group>
                     </Match>
                     <Match
                       when={

--- a/packages/client/components/app/interface/settings/shared/Discoverable.tsx
+++ b/packages/client/components/app/interface/settings/shared/Discoverable.tsx
@@ -24,15 +24,17 @@ export function Discoverable(props: {
   const { isStoat } = useInstance();
   const err = useError();
 
-  const [discoverRequest, discoverRequestActions] = createResource(
-    () => props.discoverable.discoverRequestStatus(),
-    () => props.discoverable.discoverRequestStatus(),
+  const [discoverRequest, discoverRequestActions] = createResource(() =>
+    props.discoverable.discoverRequestStatus(),
   );
 
-  const onDiscoverRequestClick = () => {
-    props.discoverable
-      .requestDiscover()
-      .then(async () => discoverRequestActions.refetch());
+  // We don't need to subscribe to props.discoverable.
+  // eslint-disable-next-line solid/reactivity
+  const onDiscoverRequestClick = (reset?: () => void) => () => {
+    props.discoverable.requestDiscover().then(async () => {
+      discoverRequestActions.refetch();
+      reset?.();
+    });
   };
 
   return (
@@ -64,14 +66,14 @@ export function Discoverable(props: {
       >
         <Suspense fallback={<CircularProgress />}>
           <ErrorBoundary
-            fallback={(e: Error) => {
+            fallback={(e: Error, reset) => {
               // Parse the error because a 404 means you can request.
               const parsed = JSON.parse(e.message);
               if (parsed.type === "NotFound") {
                 return (
                   <DiscoverButton
                     discoverable={props.discoverable}
-                    onDiscoverRequestClick={onDiscoverRequestClick}
+                    onDiscoverRequestClick={onDiscoverRequestClick(reset)}
                   />
                 );
               }
@@ -87,6 +89,7 @@ export function Discoverable(props: {
           >
             <Show
               when={discoverRequest()}
+              keyed={true}
               fallback={
                 <MessagePreview>
                   <Text class="title" size="small">
@@ -96,8 +99,7 @@ export function Discoverable(props: {
                 </MessagePreview>
               }
             >
-              {(discoverRequest) => {
-                const dr = discoverRequest();
+              {(dr) => {
                 return (
                   <Switch>
                     <Match
@@ -155,7 +157,7 @@ export function Discoverable(props: {
                       </MessagePreview>
                       <DiscoverButton
                         discoverable={props.discoverable}
-                        onDiscoverRequestClick={onDiscoverRequestClick}
+                        onDiscoverRequestClick={onDiscoverRequestClick()}
                       />
                     </Match>
                     <Match

--- a/packages/client/components/app/interface/settings/shared/Discoverable.tsx
+++ b/packages/client/components/app/interface/settings/shared/Discoverable.tsx
@@ -1,0 +1,233 @@
+import { Trans } from "@lingui/solid/macro";
+import {
+  createResource,
+  ErrorBoundary,
+  Match,
+  Show,
+  Suspense,
+  Switch,
+} from "solid-js";
+
+import { Bot, Server } from "stoat.js";
+import { styled } from "styled-system/jsx";
+
+import { useError } from "@revolt/i18n";
+import { useInstance } from "@revolt/instance";
+import { CategoryButton, CircularProgress, iconSize, Text } from "@revolt/ui";
+
+import MdPublic from "@material-design-icons/svg/outlined/public.svg?component-solid";
+
+export function Discoverable(props: {
+  discoverable: Bot | Server;
+  fullPage?: boolean;
+}) {
+  const { isStoat } = useInstance();
+  const err = useError();
+
+  const [discoverRequest, discoverRequestActions] = createResource(
+    () => props.discoverable.discoverRequestStatus(),
+    () => props.discoverable.discoverRequestStatus(),
+  );
+
+  const onDiscoverRequestClick = () => {
+    props.discoverable
+      .requestDiscover()
+      .then(async () => discoverRequestActions.refetch());
+  };
+
+  return (
+    <Show when={isStoat}>
+      <Show when={!props.fullPage}>
+        <Text class="title" size="medium">
+          <Trans>Discover</Trans>
+        </Text>
+      </Show>
+      <Show
+        when={!props.discoverable.discoverable}
+        fallback={
+          <MessagePreview>
+            <Text class="title" size="small">
+              <Trans>
+                This {props.discoverable instanceof Bot ? "bot" : "server"} is
+                discoverable
+              </Trans>
+            </Text>
+            <Text>
+              <Trans>
+                Contact support to remove this{" "}
+                {props.discoverable instanceof Bot ? "bot" : "server"} from
+                discover
+              </Trans>
+            </Text>
+          </MessagePreview>
+        }
+      >
+        <Suspense fallback={<CircularProgress />}>
+          <ErrorBoundary
+            fallback={(e: Error) => {
+              // Parse the error because a 404 means you can request.
+              const parsed = JSON.parse(e.message);
+              if (parsed.type === "NotFound") {
+                return (
+                  <DiscoverButton
+                    discoverable={props.discoverable}
+                    onDiscoverRequestClick={onDiscoverRequestClick}
+                  />
+                );
+              }
+              return (
+                <MessagePreview>
+                  <Text class="title" size="small">
+                    <Trans>Can't get discover request status right now</Trans>
+                  </Text>
+                  <Text>{err(e.message)}</Text>
+                </MessagePreview>
+              );
+            }}
+          >
+            <Show
+              when={discoverRequest()}
+              fallback={
+                <MessagePreview>
+                  <Text class="title" size="small">
+                    <Trans>Can't get discover request status right now</Trans>
+                  </Text>
+                  <Text>Please try again later</Text>
+                </MessagePreview>
+              }
+            >
+              {(discoverRequest) => {
+                const dr = discoverRequest();
+                return (
+                  <Switch>
+                    <Match
+                      when={
+                        dr.status === "Pending" || dr.status === "UnderReview"
+                      }
+                    >
+                      <MessagePreview>
+                        <Text class="title" size="small">
+                          <Trans>
+                            Your{" "}
+                            {props.discoverable instanceof Bot
+                              ? "bot"
+                              : "server"}{" "}
+                            is under review
+                          </Trans>
+                        </Text>
+                        <Text>
+                          <Trans>
+                            Check back often to see if your{" "}
+                            {props.discoverable instanceof Bot
+                              ? "bot"
+                              : "server"}{" "}
+                            has been approved!
+                          </Trans>
+                        </Text>
+                      </MessagePreview>
+                    </Match>
+                    <Match
+                      when={
+                        typeof dr.status === "object" &&
+                        (dr.status as { Denied: string | null }).Denied !==
+                          undefined
+                      }
+                    >
+                      <MessagePreview>
+                        <Text class="title" size="small">
+                          <Trans>Your discover request has been denied</Trans>
+                        </Text>
+                        <Text>
+                          {(dr.status as { Denied: string | null }).Denied ? (
+                            <>
+                              <Trans>
+                                Reason:{" "}
+                                {
+                                  (dr.status as { Denied: string | null })
+                                    .Denied
+                                }
+                              </Trans>
+                              <br />
+                            </>
+                          ) : undefined}
+                          <Trans>You can request again below</Trans>
+                        </Text>
+                      </MessagePreview>
+                      <DiscoverButton
+                        discoverable={props.discoverable}
+                        onDiscoverRequestClick={onDiscoverRequestClick}
+                      />
+                    </Match>
+                    <Match
+                      when={
+                        typeof dr.status === "object" &&
+                        (dr.status as { Removed: string | null }).Removed !==
+                          undefined
+                      }
+                    >
+                      <MessagePreview>
+                        <Text class="title" size="small">
+                          <Trans>Your discover request has been removed</Trans>
+                        </Text>
+                        <Text>
+                          {(dr.status as { Removed: string | null }).Removed ? (
+                            <>
+                              <Trans>
+                                Reason:{" "}
+                                {
+                                  (dr.status as { Removed: string | null })
+                                    .Removed
+                                }{" "}
+                                Contact support for more information.
+                              </Trans>
+                              <br />
+                            </>
+                          ) : undefined}
+                        </Text>
+                      </MessagePreview>
+                    </Match>
+                  </Switch>
+                );
+              }}
+            </Show>
+          </ErrorBoundary>
+        </Suspense>
+      </Show>
+    </Show>
+  );
+}
+
+function DiscoverButton(props: {
+  discoverable: Bot | Server;
+  onDiscoverRequestClick: () => void;
+}) {
+  return (
+    <CategoryButton.Group>
+      <CategoryButton
+        description={
+          props.discoverable instanceof Bot ? (
+            <Trans>
+              Allow others to add your bot to their servers from Discover
+            </Trans>
+          ) : (
+            <Trans>Allow others to join your server from Discover</Trans>
+          )
+        }
+        icon={<MdPublic {...iconSize(22)} />}
+        action="chevron"
+        onClick={props.onDiscoverRequestClick}
+      >
+        <Trans>Submit to Discover</Trans>
+      </CategoryButton>
+    </CategoryButton.Group>
+  );
+}
+
+const MessagePreview = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    padding: "var(--gap-md)",
+    gap: "var(--message-group-spacing)",
+  },
+});

--- a/packages/client/components/app/interface/settings/shared/Discoverable.tsx
+++ b/packages/client/components/app/interface/settings/shared/Discoverable.tsx
@@ -13,9 +13,7 @@ import { styled } from "styled-system/jsx";
 
 import { useError } from "@revolt/i18n";
 import { useInstance } from "@revolt/instance";
-import { CategoryButton, CircularProgress, iconSize, Text } from "@revolt/ui";
-
-import MdPublic from "@material-design-icons/svg/outlined/public.svg?component-solid";
+import { CategoryButton, CircularProgress, Symbol, Text } from "@revolt/ui";
 
 export function Discoverable(props: {
   discoverable: Bot | Server;
@@ -215,7 +213,7 @@ function DiscoverButton(props: {
             <Trans>Allow others to join your server from Discover</Trans>
           )
         }
-        icon={<MdPublic {...iconSize(22)} />}
+        icon={<Symbol size={22}>public</Symbol>}
         action="chevron"
         onClick={props.onDiscoverRequestClick}
       >

--- a/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
+++ b/packages/client/components/app/interface/settings/user/bots/ViewBot.tsx
@@ -1,4 +1,6 @@
 import { Trans, useLingui } from "@lingui/solid/macro";
+import { IFormControl } from "solid-forms";
+
 import { Bot } from "stoat.js";
 
 import { createProfileResource } from "@revolt/client/resources";
@@ -18,10 +20,9 @@ import MdDelete from "@material-design-icons/svg/outlined/delete.svg?component-s
 import MdKey from "@material-design-icons/svg/outlined/key.svg?component-solid";
 import MdLink from "@material-design-icons/svg/outlined/link.svg?component-solid";
 import MdPersonAdd from "@material-design-icons/svg/outlined/person_add.svg?component-solid";
-import MdPublic from "@material-design-icons/svg/outlined/public.svg?component-solid";
 import MdToken from "@material-design-icons/svg/outlined/token.svg?component-solid";
 
-import { IFormControl } from "solid-forms";
+import { Discoverable } from "../../shared/Discoverable";
 import { UserSummary } from "../account/index";
 import { UserProfileEditor } from "../profile/UserProfileEditor";
 
@@ -73,9 +74,6 @@ export function ViewBot(props: { bot: Bot }) {
           </Form2.Checkbox>
         )}
       </UserProfileEditor>
-      {/* <ErrorBoundary fallback={<>Failed to load profile</>}>
-        <Suspense fallback={<>loading...</>}>{profile.data?.content}</Suspense>
-      </ErrorBoundary> */}
 
       <CategoryButton.Group>
         <CategoryButton
@@ -97,17 +95,6 @@ export function ViewBot(props: { bot: Bot }) {
           }
         >
           <Trans>Change Username</Trans>
-        </CategoryButton>
-        <CategoryButton
-          description={
-            <Trans>
-              Allow others to add your bot to their servers from Discover
-            </Trans>
-          }
-          icon={<MdPublic {...iconSize(22)} />}
-          action="chevron"
-        >
-          <Trans>Submit to Discover</Trans>
         </CategoryButton>
       </CategoryButton.Group>
 
@@ -176,6 +163,8 @@ export function ViewBot(props: { bot: Bot }) {
           <Trans>Delete Bot</Trans>
         </CategoryButton>
       </CategoryButton.Group>
+
+      <Discoverable discoverable={props.bot} />
     </Column>
   );
 }

--- a/packages/client/components/i18n/errors.tsx
+++ b/packages/client/components/i18n/errors.tsx
@@ -28,7 +28,7 @@ function cleanError(
 export function useError() {
   const { t } = useLingui();
 
-  return (error: unknown) => {
+  return (error: unknown, context?: string) => {
     error = cleanError(error);
 
     // TODO: HTTP errors
@@ -54,6 +54,8 @@ export function useError() {
         case "AlreadySentRequest":
           return t`You've already sent a request to this user.`;
         case "Banned":
+          if (context === "discover")
+            return t`You may not submit this item to discover.`;
           return t`You are banned from this server.`;
         case "Blocked":
           return t`You have this user blocked.`;
@@ -132,6 +134,25 @@ export function useError() {
           return t`This account is not activated! Please check your account's inbox and try again.`;
         case "TotpAlreadyEnabled":
           return t`Multi-factor authentication is already enabled for this account.`;
+        case "ContactSupport":
+          switch (err.locale) {
+            case "discover.bot_removal_approved":
+              return t`The bot is already on discover, the user must contact support to have it removed`;
+            case "discover.bot_removal_removed":
+              return t`The bot has been removed from discover by moderators, the user must contact support.`;
+            case "discover.server_removal_approved":
+              return t`The server is already on discover, the user must contact support to have it removed.`;
+            case "discover.server_removal_removed":
+              return t`The server has been removed from discover by moderators, the user must contact support.`;
+            case "discover.declined_apply_again":
+              return t`The Discover request was declined. Declined requests cannot be removed, but the user may submit again.`;
+            case "discover.cannot_auto_remove":
+              return t`The Discover request is approved or the item has been removed from discover. In either case, the user must contact support.`;
+            case "discover.removed_cannot_apply":
+              return t`The item was removed by moderators, and as such future applications are prohibited. Contact support for more information.`;
+            default:
+              return t`Your request failed. Please contact support.`;
+          }
 
         // unreachable errors (in theory)
         case "FileTooLarge":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,8 +561,8 @@ importers:
         specifier: 1.9.14
         version: 1.9.14
       stoat-api:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.15.3
+        version: 0.15.3
       ulid:
         specifier: ^3.0.2
         version: 3.0.2
@@ -6188,8 +6188,8 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
-  stoat-api@0.14.3:
-    resolution: {integrity: sha512-OCsHP8jPFp2pwwIxiSnLhgfI+bNJJ4kkUBOAOIGQedLR6iRYoJojxSB+uk/TJNinnc1ADGM+QZb8Q115p6+POA==}
+  stoat-api@0.15.3:
+    resolution: {integrity: sha512-r08FplgeZWft4Hd2CK1tZ7EEzhocUyy/aeeOGBrKC6vy3ANsDhcMzGdJioYQ3jpzH+jFIPLQJzBaJK27Wf3Vug==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -13610,7 +13610,7 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  stoat-api@0.14.3:
+  stoat-api@0.15.3:
     dependencies:
       json-with-bigint: 3.4.4
 


### PR DESCRIPTION
Add discover buttons and flow for bots and servers. Uses a unified element for both. It's not the most beautiful thing but this is a high priority to get out asap.

Updates stoat.js and stoat-api

Closes #1553

Requires <https://github.com/stoatchat/javascript-client-sdk/pull/191>

## How was this PR tested?

Submitted a bunch of bots and servers and had tom deny them all. I also simulated successful discover requests.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

No discover request ever made: <img width="831" height="344" alt="image" src="https://github.com/user-attachments/assets/9d0e6850-bdd2-4fdd-806c-81dac2bf49eb" />

Pending or under review discover request: <img width="934" height="318" alt="image" src="https://github.com/user-attachments/assets/a9f62aab-f93b-49ab-901b-a50bdaca74cc" />

Denied without reason: <img width="831" height="344" alt="image" src="https://github.com/user-attachments/assets/f3154607-89cc-4246-8386-13368533a3fd" />

Denied with a reason: <img width="831" height="344" alt="image" src="https://github.com/user-attachments/assets/9744ab23-5d75-4b7c-a6a3-5f275f6746bb" />

Contact support error (message varies based on reason): <img width="831" height="344" alt="image" src="https://github.com/user-attachments/assets/791e3017-cea0-4361-9bd8-f819ad3560f8" />

Item is discoverable: <img width="831" height="344" alt="image" src="https://github.com/user-attachments/assets/379418a3-c33c-472e-b279-cb11863caefd" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1572 :point\_left:
