### PR TITLE
fix: website embed title overflowing card, double icon on embed

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/TextEmbed.tsx
@@ -34,6 +34,7 @@ const InformationRow = styled("div", {
   base: {
     display: "flex",
     flexDirection: "row",
+    width: "100%",
     alignItems: "center",
     gap: "var(--gap-md)",
   },
@@ -113,7 +114,7 @@ export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
 
         <Show when={props.embed.title}>
           <InformationRow>
-            <Show when={props.embed.iconUrl}>
+            <Show when={props.embed.iconUrl && props.embed.type !== "Website"}>
               <Favicon
                 loading="lazy"
                 draggable={false}
@@ -121,11 +122,11 @@ export function TextEmbed(props: { embed: TextEmbedClass | WebsiteEmbed }) {
                 onError={(e) => (e.currentTarget.style.display = "none")}
               />
             </Show>
-            <RenderAnchor href={props.embed.url}>
-              <Title>
+            <Title>
+              <RenderAnchor href={props.embed.url}>
                 <OverflowingText>{props.embed.title}</OverflowingText>
-              </Title>
-            </RenderAnchor>
+              </RenderAnchor>
+            </Title>
           </InformationRow>
         </Show>
 


### PR DESCRIPTION
## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Long embed titles of websites no longer overflow
- [x] No second icon when it's a website embed

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

### Before

<img width="914" height="474" alt="image" src="https://github.com/user-attachments/assets/adcdbf00-1ae6-4050-8723-9e15b359fc51" />

### After

<img width="744" height="509" alt="image" src="https://github.com/user-attachments/assets/c5f6acaf-8a3a-4392-a9de-efd7b59799bc" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used to write or author this pull request.
