### PR TITLE
fix: prevent message draft loss when re-entering a channel through an unwritable one

### DIFF
--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -3,6 +3,7 @@ import {
   Show,
   createEffect,
   createMemo,
+  createRenderEffect,
   createSignal,
   on,
   onCleanup,
@@ -113,7 +114,14 @@ export function MessageComposition(props: Props) {
   state.draft._setNodeReplacement = setNodeReplacement;
   onCleanup(() => (state.draft._setNodeReplacement = undefined));
 
-  createEffect(
+  // MessageBox unmounts/remounts the editor when sendingAllowed toggles
+  // (e.g. navigating through a channel we can't send in), and that
+  // toggle is read directly in JSX rather than through an effect. A
+  // plain createEffect here would update initialValue one tick after
+  // that remount, so the fresh editor could seed itself from the
+  // previous channel's (stale) content. createRenderEffect runs in the
+  // same synchronous pass as the JSX re-render, so it's not.
+  createRenderEffect(
     on(
       () => props.channel,
       () => setInitialValue([currentValue()]),


### PR DESCRIPTION
<!-- Describe your changes -->

`MessageComposition` (`Composition.tsx`) stays mounted for the whole session, but `MessageBox.tsx` renders the actual editor (`TextEditor2`) inside a `<Switch>`/`<Match when={!props.sendingAllowed}>` so the editor is genuinely unmounted (not hidden) while viewing a channel you can't send in, and a fresh instance mounts when you return to a writable one.

`TextEditor2` seeds its content once, at construction, from `props.initialValue`. That value was kept in sync via a plain `createEffect(on(() => props.channel, ...))`, which in Solid runs *after* the current render pass, not during it. `sendingAllowed` (which drives the `<Switch>`) is read directly in JSX, so it updates in the same synchronous pass as the channel change. That means when you navigate back to a writable channel, the fresh `TextEditor2` can mount *before* `initialValue` has been updated for the new channel so it seeds itself from whatever was left over from the unwritable channel you just came from (empty), even though the actual draft is still sitting untouched in the draft store.

Fix: switch that one effect to `createRenderEffect`, which runs in the same synchronous render pass as the JSX, closing the gap. The other effect in this file (clearing the draft after a message sends) is untouched it isn't tied to this mount/unmount timing at all.

Fixes #1191 

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Reproduced the original bug locally (draft → navigate to a channel without send permission → navigate back → draft gone), then confirmed this change fixes it: draft now correctly persists through that navigation.
- [x] `pnpm --filter client exec tsc --noEmit` (same command CI's Typecheck job runs) zero errors in the changed file; the 5 pre-existing errors elsewhere in the repo are unchanged and unrelated to this change.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

...
