### PR TITLE
feat: e2eeeeeeeeee

### DIFF
--- a/packages/client/components/app/interface/channels/text/EditMessage.tsx
+++ b/packages/client/components/app/interface/channels/text/EditMessage.tsx
@@ -6,7 +6,7 @@ import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
-import { KeybindAction, createKeybind } from "@revolt/keybinds";
+import { createKeybind, KeybindAction } from "@revolt/keybinds";
 import { useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
 import { Text } from "@revolt/ui";
@@ -18,7 +18,7 @@ export function EditMessage(props: { message: Message }) {
   const client = useClient();
   const { openModal, isOpen, pop } = useModals();
 
-  const initialValue = [state.draft.editingMessageContent || ""] as const;
+  const initialValue = state.draft.editingMessageContent || "";
 
   const change = useMutation(() => ({
     mutationFn: (content: string) => props.message.edit({ content }),
@@ -30,15 +30,12 @@ export function EditMessage(props: { message: Message }) {
     },
   }));
 
-  function saveMessage() {
+  async function saveMessage() {
     const content = state.draft.editingMessageContent;
 
     if (content?.length) {
       state.draft._setNodeReplacement?.(["_focus"]); // focus message box
-      if (content === props.message.content) {
-        return;
-      }
-
+      if (content === initialValue) return;
       change.mutate(content);
     } else if (isOpen("delete_message")) {
       void props.message.delete();
@@ -65,7 +62,7 @@ export function EditMessage(props: { message: Message }) {
           autoFocus
           onComplete={saveMessage}
           onChange={state.draft.setEditingMessageContent}
-          initialValue={initialValue}
+          initialValue={[initialValue]}
           autoCompleteSearchSpace={searchSpace}
         />
       </EditorBox>
@@ -77,7 +74,13 @@ export function EditMessage(props: { message: Message }) {
             <Action onClick={() => state.draft.setEditingMessage(undefined)}>
               cancel
             </Action>{" "}
-            &middot; enter to <Action onClick={saveMessage}>save</Action>
+            &middot; enter to{" "}
+            <Action
+              onClick={saveMessage}
+              disabled={state.draft.editingMessageContent === initialValue}
+            >
+              save
+            </Action>
           </Text>
         }
       >
@@ -101,7 +104,16 @@ const EditorBox = styled("div", {
 const Action = styled("span", {
   base: {
     fontWeight: 600,
-    cursor: "pointer",
-    color: "var(--md-sys-color-primary)",
+  },
+  variants: {
+    disabled: {
+      false: {
+        cursor: "pointer",
+        color: "var(--md-sys-color-primary)",
+      },
+    },
+  },
+  defaultVariants: {
+    disabled: false,
   },
 });

--- a/packages/client/components/app/interface/channels/text/Message.tsx
+++ b/packages/client/components/app/interface/channels/text/Message.tsx
@@ -222,86 +222,93 @@ export function Message(props: Props) {
           </For>
         }
         info={
-          <Switch fallback={<div />}>
-            <Match when={props.message.iconRole}>
-              <Tooltip content={props.message.iconRole!.name} placement="top">
-                <Avatar
-                  size={16}
-                  shape="rounded-square"
-                  src={props.message.iconRole!.icon?.previewUrl}
-                />
-              </Tooltip>
-            </Match>
-            <Match
-              when={
-                props.message.masquerade &&
-                props.message.authorId === "01FHGJ3NPP7XANQQH8C2BE44ZY"
-              }
-            >
-              <Tooltip
-                content={t`Message was sent on another platform`}
-                placement="top"
+          <>
+            <Switch fallback={<div />}>
+              <Match when={props.message.iconRole}>
+                <Tooltip content={props.message.iconRole!.name} placement="top">
+                  <Avatar
+                    size={16}
+                    shape="rounded-square"
+                    src={props.message.iconRole!.icon?.previewUrl}
+                  />
+                </Tooltip>
+              </Match>
+              <Match
+                when={
+                  props.message.masquerade &&
+                  props.message.authorId === "01FHGJ3NPP7XANQQH8C2BE44ZY"
+                }
               >
-                <Symbol size={16}>link</Symbol>
-              </Tooltip>
-            </Match>
-            <Match when={props.message.author?.privileged}>
-              <Tooltip content={t`Official Communication`} placement="top">
-                <Symbol size={16}>brightness_alert</Symbol>
-              </Tooltip>
-            </Match>
-            <Match when={props.message.author?.bot}>
-              <Tooltip content={t`Bot`} placement="top">
-                <Symbol size={16} fill>
-                  smart_toy
-                </Symbol>
-              </Tooltip>
-            </Match>
-            <Match when={props.message.webhook}>
-              <Tooltip content={t`Webhook`} placement="top">
-                <Symbol size={16} fill>
-                  cloud
-                </Symbol>
-              </Tooltip>
-            </Match>
-            <Match when={props.message.isSuppressed}>
-              <Tooltip content={t`Silent`} placement="top">
-                <Symbol size={16} fill>
-                  notifications_off
-                </Symbol>
-              </Tooltip>
-            </Match>
-            <Match
-              when={
-                props.message.authorId &&
-                dayjs().diff(decodeTime(props.message.authorId), "day") < 1
-              }
-            >
-              <NewUser>
-                <Tooltip content={t`New to Stoat`} placement="top">
+                <Tooltip
+                  content={t`Message was sent on another platform`}
+                  placement="top"
+                >
+                  <Symbol size={16}>link</Symbol>
+                </Tooltip>
+              </Match>
+              <Match when={props.message.author?.privileged}>
+                <Tooltip content={t`Official Communication`} placement="top">
+                  <Symbol size={16}>brightness_alert</Symbol>
+                </Tooltip>
+              </Match>
+              <Match when={props.message.author?.bot}>
+                <Tooltip content={t`Bot`} placement="top">
                   <Symbol size={16} fill>
-                    spa
+                    smart_toy
                   </Symbol>
                 </Tooltip>
-              </NewUser>
-            </Match>
-            <Match
-              when={
-                props.message.member &&
-                dayjs().diff(props.message.member.joinedAt, "day") < 1
-              }
-            >
-              <NewUser>
-                <Tooltip content={t`New to the server`} placement="top">
-                  <Symbol size={16}>spa</Symbol>
+              </Match>
+              <Match when={props.message.webhook}>
+                <Tooltip content={t`Webhook`} placement="top">
+                  <Symbol size={16} fill>
+                    cloud
+                  </Symbol>
                 </Tooltip>
-              </NewUser>
-            </Match>
-            {/* <Match when={props.message.authorId === "01EX2NCWQ0CHS3QJF0FEQS1GR4"}>
+              </Match>
+              <Match when={props.message.isSuppressed}>
+                <Tooltip content={t`Silent`} placement="top">
+                  <Symbol size={16} fill>
+                    notifications_off
+                  </Symbol>
+                </Tooltip>
+              </Match>
+              <Match
+                when={
+                  props.message.authorId &&
+                  dayjs().diff(decodeTime(props.message.authorId), "day") < 1
+                }
+              >
+                <NewUser>
+                  <Tooltip content={t`New to Stoat`} placement="top">
+                    <Symbol size={16} fill>
+                      spa
+                    </Symbol>
+                  </Tooltip>
+                </NewUser>
+              </Match>
+              <Match
+                when={
+                  props.message.member &&
+                  dayjs().diff(props.message.member.joinedAt, "day") < 1
+                }
+              >
+                <NewUser>
+                  <Tooltip content={t`New to the server`} placement="top">
+                    <Symbol size={16}>spa</Symbol>
+                  </Tooltip>
+                </NewUser>
+              </Match>
+              {/* <Match when={props.message.authorId === "01EX2NCWQ0CHS3QJF0FEQS1GR4"}>
             <span />
             <span>placeholder &middot; </span>
           </Match> */}
-          </Switch>
+            </Switch>
+            <Show when={props.message.channel?.e2e}>
+              <Tooltip content={t`This message is encrypted`} placement="top">
+                <Symbol size={16}>lock</Symbol>
+              </Tooltip>
+            </Show>
+          </>
         }
         compact={
           !!props.message.systemMessage ||

--- a/packages/client/components/app/interface/settings/channel/Overview.tsx
+++ b/packages/client/components/app/interface/settings/channel/Overview.tsx
@@ -1,8 +1,9 @@
 import { createFormControl, createFormGroup } from "solid-forms";
-import { Match, Show, Switch } from "solid-js";
+import { Show } from "solid-js";
 
 import { Trans, useLingui } from "@lingui/solid/macro";
 import type { API } from "stoat.js";
+import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
 import { useDurationFormat } from "@revolt/i18n/durations";
@@ -181,14 +182,62 @@ export default function ChannelOverview(props: ChannelSettingsProps) {
               })
             }
           >
-            <Switch fallback={<Trans>Mark as Mature</Trans>}>
-              <Match when={props.channel.mature}>
-                <Trans>Unmark as Mature</Trans>
-              </Match>
-            </Switch>
+            <Show
+              when={props.channel.mature}
+              fallback={<Trans>Mark as Mature</Trans>}
+            >
+              <Trans>Unmark as Mature</Trans>
+            </Show>
+          </Button>
+        </div>
+      </Column>
+      <Column>
+        <Text class="label">
+          <Trans>End-to-End Encryption</Trans>
+        </Text>
+        <Text>
+          <Trans>
+            Secure this channel via{" "}
+            <Link
+              href="https://en.wikipedia.org/wiki/End-to-end_encryption"
+              target="_blank"
+            >
+              end-to-end encryption
+            </Link>
+            . Messages and attachments are encrypted with AES-256, so only users
+            with the <i>secret password</i> can read the content. Once you
+            enable this, it can't be disabled.
+          </Trans>
+        </Text>
+        <div>
+          <Button
+            isDisabled={props.channel.e2e}
+            use:floating={{
+              tooltip: props.channel.e2e
+                ? {
+                    placement: "top",
+                    content: t`Encryption is already enabled`,
+                  }
+                : undefined,
+            }}
+            onPress={() =>
+              openModal({
+                type: "channel_e2ee",
+                channel: props.channel,
+              })
+            }
+          >
+            <Trans>Enable Encryption</Trans>
           </Button>
         </div>
       </Column>
     </Column>
   );
 }
+
+const Link = styled("a", {
+  base: {
+    color: "var(--md-sys-color-primary)",
+    "&:hover": { textDecoration: "underline" },
+  },
+});

--- a/packages/client/components/common/index.tsx
+++ b/packages/client/components/common/index.tsx
@@ -1,4 +1,5 @@
 export * from "./Device";
+export { getChannelIcon } from "./lib/channels";
 export { debounce } from "./lib/debounce";
 export { default as CONFIGURATION } from "./lib/env";
 export { insecureUniqueId } from "./lib/unique";

--- a/packages/client/components/common/lib/channels.ts
+++ b/packages/client/components/common/lib/channels.ts
@@ -1,0 +1,19 @@
+import { Channel } from "stoat.js";
+
+const TEXT_SIDEBAR = "grid_3x3",
+  TEXT_MENTION = "tag",
+  VOICE = "headset_mic";
+
+/**
+ * Returns the icon for a given channel
+ * @param context - defaults to sidebar, use "mention" for mention icon
+ */
+export const getChannelIcon = (
+  channel?: Channel,
+  context?: "sidebar" | "mention",
+) =>
+  channel?.isVoice
+    ? VOICE
+    : context === "mention"
+      ? TEXT_MENTION
+      : TEXT_SIDEBAR;

--- a/packages/client/components/i18n/errors.tsx
+++ b/packages/client/components/i18n/errors.tsx
@@ -1,12 +1,11 @@
-import { Trans, useLingui } from "@lingui/solid/macro";
 import { createMemo, Match, Switch } from "solid-js";
-import { API } from "stoat.js";
+
+import { Trans, useLingui } from "@lingui/solid/macro";
+import { API, EncryptError } from "stoat.js";
 
 const RE_BREAK = /\s*\n\s*/g;
 
-function cleanError(
-  error: unknown,
-): { type?: never } | { message?: never } | string | undefined {
+function cleanError(error: unknown) {
   // Attempt to parse the incoming error as JSON if it is a string,
   // as some errors (e.g on login) are sent to this function as a string,
   // which then causes the error message to be unlocalised and unhelpful.
@@ -15,12 +14,13 @@ function cleanError(
       return JSON.parse(error);
     } catch {
       // Ignore JSON parse errors
-      return error;
     }
   }
-
-  return error as { type?: never } | { message?: never } | undefined;
+  return error;
 }
+
+/** Any error we can translate */
+type KnownError = API.Error | EncryptError;
 
 /**
  * Translate any error
@@ -30,15 +30,13 @@ export function useError() {
 
   return (error: unknown, context?: string) => {
     error = cleanError(error);
+    console.error(error);
 
     // TODO: HTTP errors
 
     // handle Revolt API errors
-    if (
-      (error as { type?: never } | undefined)?.type &&
-      typeof (error as { type: never }).type === "string"
-    ) {
-      const err = error as API.Error;
+    if (typeof (error as { type: never })?.type === "string") {
+      const err = error as KnownError;
 
       switch (err.type) {
         case "AlreadyFriends":
@@ -98,7 +96,7 @@ export function useError() {
         case "InvalidCredentials":
           return t`Provided email or password is wrong.`;
         case "InvalidSession":
-          return t`Please log in again.`;
+          return t`You were logged out!`;
         case "InvalidUsername":
           return t`This username is not allowed.`;
         case "MissingPermission":
@@ -153,6 +151,15 @@ export function useError() {
             default:
               return t`Your request failed. Please contact support.`;
           }
+        case "EncryptError":
+          switch (err.name) {
+            case "bad_version":
+              return t`Invalid e2ee protocol version.`;
+            case "no_key":
+              return t`No encryption key!`;
+            default:
+              return `EncryptionError: ${err.name}`;
+          }
 
         // unreachable errors (in theory)
         case "FileTooLarge":
@@ -190,10 +197,7 @@ export function useError() {
     }
 
     // pass-through pre-localised errors with new Error({ message: <> })
-    if (
-      (error as { message?: never } | undefined)?.message &&
-      typeof (error as { message: never }).message === "string"
-    ) {
+    if (typeof (error as { message: never })?.message === "string") {
       const message = (error as { message: string }).message.trim();
       if (message) return message;
     } else if (typeof error === "string") {

--- a/packages/client/components/markdown/plugins/anchors.tsx
+++ b/packages/client/components/markdown/plugins/anchors.tsx
@@ -5,6 +5,7 @@ import { cva } from "styled-system/css";
 
 import { MessageContextMenu, useMessage } from "@revolt/app";
 import { useClient } from "@revolt/client";
+import { getChannelIcon } from "@revolt/common";
 import { STOAT_HOST } from "@revolt/common/lib/env";
 import { DefaultHost, useInstance } from "@revolt/instance";
 import { useModals } from "@revolt/modal";
@@ -137,7 +138,7 @@ export function RenderAnchor(
               disabled={props.disabled}
               href={internalUrl()}
             >
-              <Symbol>tag</Symbol>
+              <Symbol>{getChannelIcon(channel(), "mention")}</Symbol>
               {remote ? <Trans>Remote Channel</Trans> : channel()!.name}
               {params.exactMessage && (
                 <>

--- a/packages/client/components/modal/modals.tsx
+++ b/packages/client/components/modal/modals.tsx
@@ -9,6 +9,7 @@ import { AddMembersToGroupModal } from "./modals/AddMembersToGroup";
 import { BanMemberModal } from "./modals/BanMember";
 import { BanNonMemberModal } from "./modals/BanNonMember";
 import { ChangelogModal } from "./modals/Changelog";
+import { ChannelEncryptModal } from "./modals/ChannelEcrypt";
 import { ChannelInfoModal } from "./modals/ChannelInfo";
 import { ChannelToggleMatureModal } from "./modals/ChannelToggleMature";
 import { CreateBotModal } from "./modals/CreateBot";
@@ -96,6 +97,8 @@ export function RenderModal(props: ActiveModal & { onClose: () => void }) {
       return <ChannelInfoModal {...modalProps} />;
     case "channel_toggle_mature":
       return <ChannelToggleMatureModal {...modalProps} />;
+    case "channel_e2ee":
+      return <ChannelEncryptModal {...modalProps} />;
     case "create_bot":
       return <CreateBotModal {...modalProps} />;
     case "create_category":

--- a/packages/client/components/modal/modals/ChannelEcrypt.tsx
+++ b/packages/client/components/modal/modals/ChannelEcrypt.tsx
@@ -1,0 +1,72 @@
+import { Trans, useLingui } from "@lingui/solid/macro";
+import { useMutation } from "@tanstack/solid-query";
+import { createFormControl, createFormGroup } from "solid-forms";
+
+import { useState } from "@revolt/state";
+import { PwdMinLength } from "@revolt/state/stores/Encrypted";
+import { Column, Dialog, DialogProps, Form2 } from "@revolt/ui";
+
+import { useModals } from "..";
+import { Modals } from "../types";
+
+export function ChannelEncryptModal(
+  props: DialogProps & Modals & { type: "channel_e2ee" },
+) {
+  const state = useState();
+  const { showError } = useModals();
+  const { t } = useLingui();
+
+  const change = useMutation(() => ({
+    mutationFn: (e2e: boolean) => props.channel.edit({ e2e }),
+    onError: showError,
+  }));
+  const group = createFormGroup({
+    pwd: createFormControl(),
+  });
+
+  async function submit() {
+    if (!Form2.canSubmit(group)) return;
+    await change.mutateAsync(true);
+    state.e2e.setPass(props.channel, group.controls.pwd.value);
+    props.onClose();
+  }
+
+  return (
+    <Dialog
+      show={props.show}
+      onClose={props.onClose}
+      title={<Trans>Enable encryption?</Trans>}
+      actions={[
+        { text: <Trans>Nevermind</Trans> },
+        {
+          text: <Trans>Enable encryption</Trans>,
+          onClick: () => {
+            submit();
+            return false;
+          },
+          isDisabled: !group.controls.pwd.value || !Form2.canSubmit(group),
+        },
+      ]}
+      isDisabled={change.isPending}
+    >
+      <Column>
+        <b>
+          <Trans>Whoa there!</Trans>
+        </b>
+        <div>
+          <Trans>
+            This is a permanent action, and any existing messages will be
+            cleared. Make sure you <b>write down your password</b>- we can't
+            recover it for you!
+          </Trans>
+        </div>
+        <Form2.TextField
+          name="pwd"
+          control={group.controls.pwd}
+          label={t`Password`}
+          minlength={PwdMinLength}
+        />
+      </Column>
+    </Dialog>
+  );
+}

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -63,6 +63,10 @@ export type Modals =
       channel: Channel;
     }
   | {
+      type: "channel_e2ee";
+      channel: Channel;
+    }
+  | {
       type: "create_bot";
       client: Client;
       onCreate: (bot: Bot) => void;

--- a/packages/client/components/state/index.tsx
+++ b/packages/client/components/state/index.tsx
@@ -20,6 +20,7 @@ import { SlideDrawer } from "@revolt/ui/components/navigation/SlideDrawer";
 import { AbstractStore, Store } from "./stores";
 import { Auth } from "./stores/Auth";
 import { Draft } from "./stores/Draft";
+import { Encrypted } from "./stores/Encrypted";
 import { Experiments } from "./stores/Experiments";
 import { Keybinds } from "./stores/Keybinds";
 import { Layout } from "./stores/Layout";
@@ -90,6 +91,7 @@ export class State {
   theme = new Theme(this);
   voice = new Voice(this);
   sounds = new Sounds(this);
+  e2e = new Encrypted(this);
 
   /**
    * Iterate over all available stores

--- a/packages/client/components/state/stores/Draft.ts
+++ b/packages/client/components/state/stores/Draft.ts
@@ -1,6 +1,6 @@
-import { Accessor, Setter, batch, createSignal } from "solid-js";
+import { Accessor, batch, createSignal, Setter } from "solid-js";
 
-import { API, Channel, Client, Message } from "stoat.js";
+import { API, Channel, Client, encrypt, Message } from "stoat.js";
 import { ulid } from "ulid";
 
 import { insecureUniqueId } from "@revolt/common";
@@ -301,75 +301,88 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
     ]);
 
     // Try sending the message
-    const { content, replies, files } = draft;
-
-    // Construct message object
-    const attachments: string[] = [];
-    const data: API.DataMessageSend = {
-      content,
-      replies,
-      attachments,
-    };
-
-    // Add any files if attached
-    if (files?.length) {
-      // TODO: keep track of % upload progress
-      // we could visually show this in chat like
-      // on Discord mobile and allow individual
-      // files to be cancelled
-      for (const fileId of files) {
-        // Prepare for upload
-        const body = new FormData();
-        const { file, autumnId, uploadProgress } = this.getFile(fileId);
-
-        // Use ID if already uploaded
-        if (autumnId) {
-          attachments.push(autumnId);
-          continue;
-        }
-
-        body.set("file", file);
-
-        // We have to use XMLHttpRequest because modern fetch duplex streams require QUIC or HTTP/2
-        const xhr = new XMLHttpRequest();
-
-        const [success, response] = await new Promise<
-          [boolean, { id: string }]
-        >((resolve) => {
-          xhr.upload.addEventListener("progress", (event) => {
-            if (event.lengthComputable) {
-              uploadProgress[1](event.loaded / event.total);
-            }
-          });
-
-          xhr.addEventListener("loadend", () => {
-            uploadProgress[1](1);
-            resolve([xhr.readyState === 4 && xhr.status === 200, xhr.response]);
-          });
-
-          xhr.open("POST", `${this.instance.mediaUrl}/attachments`, true);
-
-          const [authHeader, authHeaderValue] = client.authenticationHeader;
-          xhr.setRequestHeader(authHeader, authHeaderValue);
-          xhr.responseType = "json";
-
-          xhr.send(body);
-        });
-
-        if (!success) throw "Upload Error";
-
-        attachments.push(response.id);
-        this.fileCache[fileId].autumnId = response.id;
-      }
-    }
-
-    // TODO: fix bug with backend
-    if (!attachments.length) {
-      delete data.attachments;
-    }
-
-    // Send the message and clear the draft
     try {
+      const { content, replies, files } = draft;
+
+      // Construct message object
+      const attachments: string[] = [];
+      const data: API.DataMessageSend = {
+        content,
+        replies,
+        attachments,
+      };
+
+      // Add any files if attached
+      const key = channel.key;
+      if (files?.length) {
+        // TODO: keep track of % upload progress
+        // we could visually show this in chat like
+        // on Discord mobile and allow individual
+        // files to be cancelled
+        for (const fileId of files) {
+          // Prepare for upload
+          const body = new FormData();
+          const { file: fDat, autumnId, uploadProgress } = this.getFile(fileId);
+
+          // Use ID if already uploaded
+          if (autumnId) {
+            attachments.push(autumnId);
+            continue;
+          }
+
+          //Encrypt file
+          let file = fDat;
+          if (key) {
+            const buf = await encrypt(key, await file.arrayBuffer());
+            //Obfuscate filename but keep extension
+            const extIdx = file.name.indexOf("."),
+              ext = extIdx === -1 ? "" : file.name.slice(extIdx);
+            file = new File([buf], file.type + ext);
+          }
+
+          body.set("file", file);
+          if (key) body.set("e2e_id", channel.id);
+
+          // We have to use XMLHttpRequest because modern fetch duplex streams require QUIC or HTTP/2
+          const xhr = new XMLHttpRequest();
+
+          const [success, response] = await new Promise<
+            [boolean, { id: string }]
+          >((resolve) => {
+            xhr.upload.addEventListener("progress", (event) => {
+              if (event.lengthComputable) {
+                uploadProgress[1](event.loaded / event.total);
+              }
+            });
+
+            xhr.addEventListener("loadend", () => {
+              uploadProgress[1](1);
+              resolve([
+                xhr.readyState === 4 && xhr.status === 200,
+                xhr.response,
+              ]);
+            });
+
+            xhr.open("POST", `${this.instance.mediaUrl}/attachments`, true);
+
+            const [authHeader, authHeaderValue] = client.authenticationHeader;
+            xhr.setRequestHeader(authHeader, authHeaderValue);
+            xhr.responseType = "json";
+
+            xhr.send(body);
+          });
+
+          if (!success) throw "Upload Error";
+
+          attachments.push(response.id);
+          this.fileCache[fileId].autumnId = response.id;
+        }
+      }
+
+      // TODO: fix bug with backend
+      if (!attachments.length) delete data.attachments;
+
+      // Send the message and clear the draft
       await channel.sendMessage(data, idempotencyKey);
 
       if (files) {
@@ -385,7 +398,8 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
           (entry) => entry.idempotencyKey !== idempotencyKey,
         ),
       );
-    } catch {
+    } catch (e) {
+      console.error(e);
       this.set(
         "outbox",
         channel.id,

--- a/packages/client/components/state/stores/Encrypted.ts
+++ b/packages/client/components/state/stores/Encrypted.ts
@@ -1,0 +1,54 @@
+import { Channel, genKey } from "stoat.js";
+
+import { AbstractStore } from ".";
+import { State } from "..";
+
+export type TypeEncrypted = {
+  pwd: { [channelId: string]: string };
+};
+
+export const PwdMinLength = 6;
+
+export class Encrypted extends AbstractStore<"e2e", TypeEncrypted> {
+  constructor(state: State) {
+    super(state, "e2e");
+  }
+
+  default(): TypeEncrypted {
+    return { pwd: {} };
+  }
+
+  hydrate() {
+    //TODO Delete for channels that you don't have access to
+  }
+
+  clean(input: Partial<TypeEncrypted>): TypeEncrypted {
+    const e2e: TypeEncrypted = { pwd: {} };
+    if (input.pwd)
+      for (const [id, pwd] of Object.entries(input.pwd))
+        if (id?.length === 26 && typeof pwd === "string") e2e.pwd[id] = pwd;
+    return e2e;
+  }
+
+  /** Set password for channel */
+  async setPass(chan: Channel, pwd: string) {
+    if (pwd.length < PwdMinLength) throw "Password too short!";
+    chan.key = await genKey(chan.id, pwd);
+    this.set("pwd", chan.id, pwd);
+  }
+
+  /** Save password to store */
+  savePass(chanId: string, pwd: string) {
+    this.set("pwd", chanId, pwd);
+  }
+
+  getPass(chanId: string): string | undefined {
+    return this.get().pwd[chanId];
+  }
+
+  deletePass(chanId: string) {
+    const pwd = { ...this.get().pwd };
+    delete pwd[chanId];
+    this.set("pwd", pwd);
+  }
+}

--- a/packages/client/components/state/stores/index.ts
+++ b/packages/client/components/state/stores/index.ts
@@ -4,6 +4,7 @@ import { State } from "..";
 
 import { TypeAuth } from "./Auth";
 import { TypeDraft } from "./Draft";
+import { TypeEncrypted } from "./Encrypted";
 import { TypeExperiments } from "./Experiments";
 import { TypeKeybinds } from "./Keybinds";
 import { TypeLayout } from "./Layout";
@@ -34,6 +35,7 @@ export type Store = {
   sync: TypeSynchronisation;
   theme: TypeTheme;
   voice: TypeVoice;
+  e2e: TypeEncrypted;
 };
 
 /**

--- a/packages/client/components/ui/components/features/messaging/elements/Attachment.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Attachment.tsx
@@ -1,4 +1,4 @@
-import { Match, Show, Switch } from "solid-js";
+import { Match, Show, Switch, createEffect, onCleanup } from "solid-js";
 
 import { File, ImageEmbed, Message, VideoEmbed } from "stoat.js";
 import { css } from "styled-system/css";
@@ -30,6 +30,10 @@ export const AttachmentContainer = styled(Column, {
 export function Attachment(props: { file: File; message?: Message }) {
   const { openModal } = useModals();
   const { reactPicker } = useMessage();
+
+  //TODO Disk cache for decrypted attachments
+  createEffect(() => props.file.loadFile());
+  onCleanup(() => props.file.unloadFile());
 
   return (
     <Switch fallback={`Could not render ${props.file.metadata.type}!`}>

--- a/packages/client/components/ui/components/features/texteditor/codeMirrorWidgets.ts
+++ b/packages/client/components/ui/components/features/texteditor/codeMirrorWidgets.ts
@@ -9,15 +9,16 @@ import {
 } from "@codemirror/view";
 import { Channel, ServerMember, ServerRole, User } from "stoat.js";
 
+import { getChannelIcon } from "@revolt/common";
+import { useInstance } from "@revolt/instance";
 import {
   RE_UNICODE_EMOJI,
   unicodeEmojiUrl,
 } from "@revolt/markdown/emoji/UnicodeEmoji";
+import { parseUnicodeEmoji } from "@revolt/markdown/plugins/unicodeEmoji";
 import { userInformation } from "@revolt/markdown/users";
 import { useSmartParams } from "@revolt/routing";
 
-import { useInstance } from "@revolt/instance";
-import { parseUnicodeEmoji } from "@revolt/markdown/plugins/unicodeEmoji";
 import { isInCodeBlock } from "./codeMirrorCommon";
 
 export function codeMirrorWidgets() {
@@ -224,12 +225,12 @@ class ChannelMentionWidget extends WidgetType {
 
   toDOM() {
     const mention = document.createElement("span");
-    mention.classList.add("cm-mention-widget");
+    mention.className = "cm-mention-widget";
     mention.contentEditable = "false";
 
     const icon = document.createElement("span");
-    icon.innerText = "tag";
-    icon.classList.add("material-symbols-outlined");
+    icon.textContent = getChannelIcon(this.channel, "mention");
+    icon.className = "material-symbols-outlined";
     mention.appendChild(icon);
 
     const name = document.createElement("span");

--- a/packages/client/components/ui/components/utils/SizedContent.tsx
+++ b/packages/client/components/ui/components/utils/SizedContent.tsx
@@ -6,82 +6,47 @@ interface Props {
   /**
    * Pixel width of the content
    */
-  width: number;
+  width?: number;
 
   /**
    * Pixel height of the content
    */
-  height: number;
+  height?: number;
 
   /**
    * The content itself
    */
   children: JSX.Element;
+
+  class?: string;
 }
 
-const MIN_W = 160;
-const MIN_H = 120;
-const MAX_S = 420;
+const MIN_W = 160,
+  MIN_H = 120,
+  MAX_S = 420;
 
 /**
  * Automatic message content sizing for images, videos and embeds
  */
 export function SizedContent(props: Props) {
-  // const tall = () => props.width > props.height;
+  const style = createMemo(() => {
+    const width = props.width!,
+      height = props.height!;
 
-  // const desiredWidth = "max(var(--width), var(--layout-attachments-min-width))";
-  // const desiredHeight =
-  //   "max(var(--height), var(--layout-attachments-min-height))";
+    const setW =
+      (height > width
+        ? Math.floor(
+            (width * Math.min(Math.max(height, MIN_H), MAX_S)) / height,
+          ) //Set from height
+        : Math.min(Math.max(width, MIN_W), MAX_S)) || MAX_S; //Set from width
 
-  // const constrainedWidth = `calc(min(${desiredWidth}, (var(--width)/var(--height)) * min(${desiredHeight}, var(--layout-attachments-max-height))))`;
-  // const constrainedHeight = `calc(min(${desiredHeight}, (var(--height)/var(--width)) * min(${desiredWidth}, var(--layout-attachments-max-width))))`;
-
-  const size = createMemo(() => {
-    let width = props.width,
-      height = props.height;
-
-    // console.info("1", width, height);
-
-    // ensure min. size
-    if (width < MIN_W) {
-      height *= MIN_W / width;
-      width = MIN_W;
-    }
-    // console.info("2", width, height);
-
-    if (height < MIN_H) {
-      width *= MIN_H / height;
-      height = MIN_H;
-    }
-    // console.info("3", width, height);
-
-    // scale down to required size
-    if (width > MAX_S) {
-      height /= width / MAX_S;
-      width = MAX_S;
-    }
-    // console.info("4", width, height);
-
-    if (height > MAX_S) {
-      width /= height / MAX_S;
-      height = MAX_S;
-    }
-    // console.info("5", width, height);
-
-    return {
-      width,
-      height,
-    };
+    const sty: JSX.CSSProperties = { width: `min(${setW}px, 100%)` };
+    if (width && height) sty["aspect-ratio"] = `${width}/${height}`;
+    return sty;
   });
 
   return (
-    <Container
-      style={{
-        width: size().width + "px",
-        // height: size().height + "px",
-        "aspect-ratio": `${size().width} / ${size().height}`,
-      }}
-    >
+    <Container class={props.class} style={style()}>
       {props.children}
     </Container>
   );
@@ -90,34 +55,14 @@ export function SizedContent(props: Props) {
 const Container = styled("div", {
   base: {
     display: "grid",
-
     height: "auto",
-    maxWidth: "100%",
-
-    // // min. render size or chat width, whichever is smaller
-    // // minWidth: "calc(min(100%, var(--layout-attachments-min-width)))",
-    // minWidth: "var(--layout-attachments-min-width)",
-    // // max. render size or chat width, whichever is smaller
-    // // maxWidth: "calc(min(100%, var(--layout-attachments-max-width)))",
-    // maxWidth: "var(--layout-attachments-max-width)",
-    // // min. render size, whichever is smaller
-    // minHeight: "var(--layout-attachments-min-height)",
-    // // max. render size
-    // maxHeight: "calc(min(70vh, var(--layout-attachments-max-height)))",
-
-    // width: "auto",
-    // height: "var(--height)",
-    // aspectRatio: "var(--width) / var(--height)",
-
     overflow: "hidden",
     borderRadius: "var(--borderRadius-md)",
-
     gridTemplateColumns: "1fr",
     gridTemplateRows: "1fr",
 
     // scale to size of container
     "& > *": {
-      // gridArea: "1/1",
       // top-left corner to bottom-right corner
       gridArea: "1 / 1 / 2 / 2",
       width: "100%",
@@ -125,23 +70,7 @@ const Container = styled("div", {
 
       // special case for images
       minHeight: 0,
-
-      // testing:
       objectFit: "contain",
     },
-    // "& .Spoiler": {
-    //   width: "100%",
-    //   height: "100%",
-    // },
   },
-  // variants: {
-  //   tall: {
-  //     true: {
-  //       // // special case for image sizing:
-  //       // "& img": {
-  //       //   width: "unset",
-  //       // },
-  //     },
-  //   },
-  // },
 });

--- a/packages/client/components/ui/components/utils/Symbol.tsx
+++ b/packages/client/components/ui/components/utils/Symbol.tsx
@@ -1,7 +1,7 @@
 import { createMemo, JSX, splitProps } from "solid-js";
 
 import { css } from "styled-system/css";
-import { splitCssProps, styled } from "styled-system/jsx";
+import { splitCssProps } from "styled-system/jsx";
 import { HTMLStyledProps } from "styled-system/types";
 
 interface Props {
@@ -11,18 +11,14 @@ interface Props {
    */
   fill?: boolean;
   /**
-   * Font size for the symbol. This can be a number (in pixels) or any valid CSS size string (ex: "24px", "1.5em", "2rem").
-   * @deprecated passing to css() does nothing
-   */
-  fontSize?: string | number;
-  /**
    * The grade of the symbol, which adjusts the weight slightly. This can be a number between -25 and 700. To preview use the Google Fonts web app.
    */
   grade?: number;
   /**
-   * The optical size of the symbol, which adjusts the design for different sizes. This should be "auto" unless it causes issues.
+   * The optical size of the symbol, which adjusts the design for different sizes.
+   * Defaults to auto. This should be unset unless it causes issues.
    */
-  opticalSize?: number | "auto";
+  opticalSize?: number;
   /**
    * The type of symbol to use. This can be "outlined", "rounded", or "sharp". Defaults to "outlined".
    */
@@ -53,32 +49,25 @@ export function Symbol(rawProps: Props & HTMLStyledProps<"span">) {
   ]);
 
   const [cssProps, restProps] = splitCssProps(props);
-  const memoClassName = createMemo(() => {
-    return css(
-      {
-        fontSize: local.fontSize ?? "inherit",
-        fontWeight: `${local.weight} !important`,
-        fontOpticalSizing: local.opticalSize === "auto" ? "auto" : undefined,
-        userSelect: "none",
-      },
-      cssProps,
-    );
-  });
-
-  const memoFontVarSettings = createMemo(() => {
-    return `"FILL" ${local.fill ? 1 : 0}, "wght" 400, "GRAD" ${local.grade ?? 0}${
-      (local.opticalSize ?? "auto") === "auto"
-        ? ""
-        : `, "opsz" ${local.opticalSize}`
-    }`;
-  });
+  const className = createMemo(
+    () =>
+      `material-symbols-${local.type ?? "outlined"} ${css(
+        { display: "block !important", userSelect: "none" },
+        cssProps,
+      )}`,
+  );
+  const fontVarSettings = createMemo(
+    () =>
+      `"FILL" ${local.fill ? 1 : 0}, "wght" ${local.weight ?? 400}, "GRAD" ${local.grade ?? 0}${
+        local.opticalSize ? `, "opsz" ${local.opticalSize}` : ""
+      }`,
+  );
 
   return (
-    <styled.span
-      class={`material-symbols-${local.type ?? "outlined"} ${memoClassName()}`}
+    <span
+      class={className()}
       style={{
-        display: "block",
-        "font-variation-settings": memoFontVarSettings(),
+        "font-variation-settings": fontVarSettings(),
         "font-size": local.size ? `${local.size}px` : undefined,
       }}
       aria-hidden="true"

--- a/packages/client/src/interface/channels/AgeGate.tsx
+++ b/packages/client/src/interface/channels/AgeGate.tsx
@@ -2,6 +2,7 @@ import { createSignal, JSXElement, Match, Suspense, Switch } from "solid-js";
 
 import { Trans } from "@lingui/solid/macro";
 import { useQuery } from "@tanstack/solid-query";
+import { Channel } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
 import { useState } from "@revolt/state";
@@ -18,13 +19,7 @@ type GeoBlock = {
 /**
  * Age gate filter for any content
  */
-export function AgeGate(props: {
-  enabled: boolean;
-  contentId: string;
-  contentName: string;
-  contentType: "channel";
-  children: JSXElement;
-}) {
+export function AgeGate(props: { channel: Channel; children: JSXElement }) {
   const state = useState();
 
   const [confirmed, setConfirm] = createSignal(false);
@@ -49,7 +44,7 @@ export function AgeGate(props: {
       <Switch fallback={props.children}>
         <Match
           when={
-            props.enabled &&
+            props.channel.mature &&
             (geoQuery.isLoading ||
               geoQuery.error ||
               (geoQuery.data && geoQuery.data.isAgeRestrictedGeo))
@@ -58,7 +53,7 @@ export function AgeGate(props: {
           <Base>
             <MdWarning {...iconSize("8em")} />
             <Text class="headline" size="large">
-              {props.contentName}
+              {"#" + props.channel.name}
             </Text>
 
             <Text class="body" size="large">
@@ -77,11 +72,11 @@ export function AgeGate(props: {
             </Button>
           </Base>
         </Match>
-        <Match when={props.enabled && !allowed()}>
+        <Match when={props.channel.mature && !allowed()}>
           <Base>
             <MdWarning {...iconSize("8em")} />
             <Text class="headline" size="large">
-              {props.contentName}
+              {"#" + props.channel.name}
             </Text>
 
             <Text class="body" size="large">
@@ -101,6 +96,7 @@ export function AgeGate(props: {
               </Button>
               <Button
                 variant="filled"
+                isDisabled={!confirmed()}
                 onPress={() =>
                   confirmed() &&
                   state.layout.setSectionState(LAYOUT_SECTIONS.MATURE, true)
@@ -124,6 +120,7 @@ const Base = styled("div", {
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "center",
+    textAlign: "center",
     padding: "var(--gap-lg)",
     userSelect: "none",
     overflowY: "auto",

--- a/packages/client/src/interface/channels/AgeGate.tsx
+++ b/packages/client/src/interface/channels/AgeGate.tsx
@@ -1,13 +1,31 @@
-import { createSignal, JSXElement, Match, Suspense, Switch } from "solid-js";
+import {
+  createSignal,
+  JSXElement,
+  lazy,
+  Match,
+  Suspense,
+  Switch,
+} from "solid-js";
 
-import { Trans } from "@lingui/solid/macro";
-import { useQuery } from "@tanstack/solid-query";
-import { Channel } from "stoat.js";
+import { Trans, useLingui } from "@lingui/solid/macro";
+import { useMutation, useQuery } from "@tanstack/solid-query";
+import { Channel, decrypt, genKey } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
+import { useMessageCache } from "@revolt/app/interface/channels/text/MessageCache";
+import { useModals } from "@revolt/modal";
 import { useState } from "@revolt/state";
+import { PwdMinLength } from "@revolt/state/stores/Encrypted";
 import { LAYOUT_SECTIONS } from "@revolt/state/stores/Layout";
-import { Button, Checkbox, CircularProgress, iconSize, Text } from "@revolt/ui";
+import {
+  Button,
+  Checkbox,
+  CircularProgress,
+  iconSize,
+  Symbol,
+  Text,
+  TextField,
+} from "@revolt/ui";
 
 import MdWarning from "@material-design-icons/svg/round/warning.svg?component-solid";
 
@@ -21,8 +39,12 @@ type GeoBlock = {
  */
 export function AgeGate(props: { channel: Channel; children: JSXElement }) {
   const state = useState();
+  const cache = useMessageCache()!;
+  const { showError } = useModals();
+  const { t } = useLingui();
 
   const [confirmed, setConfirm] = createSignal(false);
+  const [pass, setPass] = createSignal("");
   const allowed = () =>
     state.layout.getSectionState(LAYOUT_SECTIONS.MATURE, false);
 
@@ -39,9 +61,104 @@ export function AgeGate(props: { channel: Channel; children: JSXElement }) {
     throwOnError: true,
   }));
 
+  const tryPass = useMutation(() => ({
+    mutationFn: async (pwd: string) => {
+      if (pwd.length < PwdMinLength) throw "Password too short!";
+      const key = await genKey(props.channel.id, pwd);
+
+      //Fetch live or cached messages
+      let msgList;
+      const msgCache = cache.unmanage(props.channel);
+      if (msgCache) {
+        msgList = msgCache.messages;
+        cache.manage(props.channel, msgCache);
+      } else msgList = await props.channel.fetchMessages({ limit: 10 });
+
+      //Test if key actually works before saving
+      //TODO Maybe we should store a known-value encrypted string in
+      // the channel that gives us easier access to test material
+      let b64;
+      for (const msg of msgList) if ((b64 = msg._rawContent())) break;
+      try {
+        if (b64) await decrypt(key, Uint8Array.fromBase64(b64).buffer);
+        else console.warn("Didn't find anything to test with :(");
+      } catch (e) {
+        if ((e as Error).name === "OperationError")
+          throw t`Wrong password, please try again.`;
+        throw e;
+      }
+
+      state.e2e.savePass(props.channel.id, pwd);
+      props.channel.key = key;
+    },
+    onError: showError,
+  }));
+
+  // eslint-disable-next-line solid/reactivity
+  const LoadKey = lazy(async () => {
+    const chan = props.channel;
+    if (chan.e2e && !chan.key) {
+      const pwd = state.e2e.getPass(chan.id);
+      if (pwd)
+        try {
+          chan.key = await genKey(chan.id, pwd);
+        } catch (e) {
+          showError(e);
+        }
+    }
+    return { default: () => undefined };
+  });
+
   return (
     <Suspense fallback={<CircularProgress />}>
       <Switch fallback={props.children}>
+        <Match when={props.channel.e2e && !props.channel.key}>
+          <LoadKey />
+          <Base>
+            <Symbol
+              size={128}
+              color="var(--md-sys-color-on-secondary-container)"
+              fill
+            >
+              encrypted
+            </Symbol>
+            <Text class="headline" size="large">
+              {"#" + props.channel.name}
+            </Text>
+
+            <Text class="body" size="large">
+              <Trans>
+                This channel is end-to-end encrypted!
+                <br />
+                You'll need the password to access it.
+              </Trans>
+            </Text>
+
+            <Field>
+              <TextField
+                label={t`Password`}
+                minlength={PwdMinLength}
+                onKeyUp={(e) => {
+                  setPass((e.target as HTMLInputElement).value);
+                  if (e.key === "Enter") tryPass.mutateAsync(pass());
+                }}
+              />
+            </Field>
+
+            <Actions>
+              <Button variant="text" onPress={() => history.back()}>
+                <Trans>Back</Trans>
+              </Button>
+              <Button
+                variant="filled"
+                isDisabled={pass().length < 6}
+                onPress={() => tryPass.mutateAsync(pass())}
+              >
+                <Trans>Enter Channel</Trans>
+              </Button>
+            </Actions>
+          </Base>
+        </Match>
         <Match
           when={
             props.channel.mature &&
@@ -132,6 +249,14 @@ const Base = styled("div", {
     },
 
     gap: "var(--gap-md)",
+  },
+});
+
+const Field = styled("div", {
+  base: {
+    width: "100%",
+    maxWidth: "500px",
+    padding: "var(--gap-md)",
   },
 });
 

--- a/packages/client/src/interface/channels/AgeGate.tsx
+++ b/packages/client/src/interface/channels/AgeGate.tsx
@@ -1,4 +1,4 @@
-import { JSXElement, Match, Suspense, Switch } from "solid-js";
+import { createSignal, JSXElement, Match, Suspense, Switch } from "solid-js";
 
 import { Trans } from "@lingui/solid/macro";
 import { useQuery } from "@tanstack/solid-query";
@@ -6,7 +6,7 @@ import { styled } from "styled-system/jsx";
 
 import { useState } from "@revolt/state";
 import { LAYOUT_SECTIONS } from "@revolt/state/stores/Layout";
-import { Button, Checkbox, CircularProgress, Text, iconSize } from "@revolt/ui";
+import { Button, Checkbox, CircularProgress, iconSize, Text } from "@revolt/ui";
 
 import MdWarning from "@material-design-icons/svg/round/warning.svg?component-solid";
 
@@ -27,10 +27,9 @@ export function AgeGate(props: {
 }) {
   const state = useState();
 
-  const confirmed = () =>
-    state.layout.getSectionState(LAYOUT_SECTIONS.MATURE, false);
+  const [confirmed, setConfirm] = createSignal(false);
   const allowed = () =>
-    state.layout.getSectionState(props.contentId + "-nsfw", false);
+    state.layout.getSectionState(LAYOUT_SECTIONS.MATURE, false);
 
   const geoQuery = useQuery(() => ({
     queryKey: ["geoblock"],
@@ -78,7 +77,7 @@ export function AgeGate(props: {
             </Button>
           </Base>
         </Match>
-        <Match when={props.enabled && (!confirmed() || !allowed())}>
+        <Match when={props.enabled && !allowed()}>
           <Base>
             <MdWarning {...iconSize("8em")} />
             <Text class="headline" size="large">
@@ -90,15 +89,7 @@ export function AgeGate(props: {
             </Text>
 
             <Confirmation>
-              <Checkbox
-                checked={state.layout.getSectionState(
-                  LAYOUT_SECTIONS.MATURE,
-                  false,
-                )}
-                onChange={() =>
-                  state.layout.toggleSectionState(LAYOUT_SECTIONS.MATURE, false)
-                }
-              />
+              <Checkbox onChange={() => setConfirm((v) => !v)} />
               <Text class="body" size="large">
                 <Trans>I confirm that I am at least 18 years old.</Trans>
               </Text>
@@ -112,7 +103,7 @@ export function AgeGate(props: {
                 variant="filled"
                 onPress={() =>
                   confirmed() &&
-                  state.layout.setSectionState(props.contentId + "-nsfw", true)
+                  state.layout.setSectionState(LAYOUT_SECTIONS.MATURE, true)
                 }
               >
                 <Trans>Enter Channel</Trans>

--- a/packages/client/src/interface/channels/ChannelHeader.tsx
+++ b/packages/client/src/interface/channels/ChannelHeader.tsx
@@ -6,7 +6,7 @@ import { css } from "styled-system/css";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
-import { useDevice } from "@revolt/common";
+import { getChannelIcon, useDevice } from "@revolt/common";
 import { TextWithEmoji } from "@revolt/markdown";
 import { useModals } from "@revolt/modal";
 import { useVoice } from "@revolt/rtc";
@@ -29,7 +29,6 @@ import MdSettings from "@material-design-icons/svg/outlined/settings.svg?compone
 
 import MdKeep from "../../svg/keep.svg?component-solid";
 import { HeaderIcon } from "../common/CommonHeader";
-
 import { canIHasSidebar, SidebarState } from "./text/TextChannel";
 
 interface Props {
@@ -78,7 +77,7 @@ export function ChannelHeader(props: Props) {
           }
         >
           <HeaderIcon>
-            <Symbol>grid_3x3</Symbol>
+            <Symbol>{getChannelIcon(props.channel)}</Symbol>
           </HeaderIcon>
           <NonBreakingText
             class={

--- a/packages/client/src/interface/channels/ChannelPage.tsx
+++ b/packages/client/src/interface/channels/ChannelPage.tsx
@@ -48,20 +48,10 @@ export const ChannelPage: Component = () => {
           <Navigate href={"../.."} />
         </Match>
         <Match when={TEXT_CHANNEL_TYPES.includes(channel()!.type)}>
-          <AgeGate
-            enabled={channel().mature}
-            contentId={channel().id}
-            contentName={"#" + channel().name}
-            contentType="channel"
-          >
+          <AgeGate channel={channel()}>
             <TextChannel channel={channel()} />
           </AgeGate>
         </Match>
-        {/* <Match when={channel()!.type === "VoiceChannel"}>
-            <Header placement="primary">
-              <ChannelHeader channel={channel()} />
-            </Header>
-          </Match> */}
       </Switch>
     </Base>
   );

--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -13,7 +13,7 @@ import { useLingui } from "@lingui/solid/macro";
 import type { API, Channel, Server, ServerFlags } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
-import { useDevice } from "@revolt/common";
+import { getChannelIcon, useDevice } from "@revolt/common";
 import { KeybindAction, createKeybind } from "@revolt/keybinds";
 import { TextWithEmoji } from "@revolt/markdown";
 import { useModals } from "@revolt/modal";
@@ -499,7 +499,7 @@ function Entry(
           <>
             <Icon
               channel={props.channel}
-              symbol={props.channel.isVoice ? "headset_mic" : "grid_3x3"}
+              symbol={getChannelIcon(props.channel)}
               color={inCall() ? "var(--md-sys-color-primary)" : undefined}
             />
             <Show when={props.channel.icon}>

--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -500,6 +500,7 @@ function Entry(
             <Icon
               channel={props.channel}
               symbol={getChannelIcon(props.channel)}
+              special={props.channel.mature ? "warning" : undefined}
               color={inCall() ? "var(--md-sys-color-primary)" : undefined}
             />
             <Show when={props.channel.icon}>
@@ -562,17 +563,23 @@ function Entry(
   );
 }
 
-function Icon(props: { channel: Channel; symbol: string; color?: string }) {
+function Icon(props: {
+  channel: Channel;
+  symbol: string;
+  special?: string;
+  color?: string;
+}) {
+  const maskId = "_m" + Date.now();
   return (
     <Show
-      when={props.channel.mature}
+      when={props.special}
       fallback={<Symbol color={props.color}>{props.symbol}</Symbol>}
     >
       <svg viewBox="0 0 24 24" width="24" height="24">
-        <mask id="m">
+        <mask id={maskId}>
           <rect x="0" y="0" width="24" height="24" fill="#fff" />
           <text {...warnProps} stroke="#000" stroke-width="3" color="#000">
-            warning
+            {props.special}
           </text>
         </mask>
         <text
@@ -583,12 +590,12 @@ function Icon(props: { channel: Channel; symbol: string; color?: string }) {
           }}
           x="0"
           y="24"
-          mask="url(#m)"
+          mask={`url(#${maskId})`}
         >
           {props.symbol}
         </text>
         <text {...warnProps} color={props.color}>
-          warning
+          {props.special}
         </text>
       </svg>
     </Show>

--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -29,16 +29,11 @@ import {
   OverflowingText,
   Row,
   Tooltip,
-  iconSize,
-  symbolSize,
   typography,
 } from "@revolt/ui";
 import { VoiceChannelPreview } from "@revolt/ui/components/features/voice/VoiceChannelPreview";
 import { createDragHandle } from "@revolt/ui/components/utils/Draggable";
 import { Symbol } from "@revolt/ui/components/utils/Symbol";
-
-import MdChevronRight from "@material-design-icons/svg/filled/chevron_right.svg?component-solid";
-import MdSettings from "@material-symbols/svg-400/outlined/settings-fill.svg?component-solid";
 
 import { SidebarBase } from "./common";
 
@@ -275,7 +270,9 @@ function ServerInfo(
           variant={props.server.banner ? "_header" : "standard"}
           onPress={props.openServerSettings}
         >
-          <MdSettings {...symbolSize(24)} />
+          <Symbol fill weight={350}>
+            settings
+          </Symbol>
         </IconButton>
       </Show>
     </Row>
@@ -359,7 +356,9 @@ function Category(
             {...createDragHandle(props.dragDisabled, props.setDragDisabled)}
           >
             {props.category.title}
-            <MdChevronRight {...iconSize(12)} />
+            <Symbol size={12} weight={300}>
+              chevron_right
+            </Symbol>
           </CategoryBase>
         </div>
       </Show>
@@ -431,14 +430,14 @@ const CategoryBase = styled("div", {
       "--color": "var(--md-sys-color-on-surface-variant)",
     },
 
-    "& svg": {
+    "& span": {
       transition: "var(--transitions-fast) transform",
     },
   },
   variants: {
     open: {
       true: {
-        "& svg": {
+        "& span": {
           transform: "rotateZ(90deg)",
         },
       },
@@ -498,19 +497,15 @@ function Entry(
         attention={attentionState()}
         icon={
           <>
-            <Switch fallback={<Symbol>grid_3x3</Symbol>}>
-              <Match when={props.channel.isVoice}>
-                <Symbol
-                  color={inCall() ? "var(--md-sys-color-primary)" : undefined}
-                >
-                  headset_mic
-                </Symbol>
-              </Match>
-            </Switch>
+            <Icon
+              channel={props.channel}
+              symbol={props.channel.isVoice ? "headset_mic" : "grid_3x3"}
+              color={inCall() ? "var(--md-sys-color-primary)" : undefined}
+            />
             <Show when={props.channel.icon}>
               <ChannelIcon
                 src={props.channel.iconURL}
-                css={{ marginEnd: "0.2em" }}
+                css={{ marginEnd: ".2em" }}
               />
             </Show>
           </>
@@ -566,6 +561,49 @@ function Entry(
     </Column>
   );
 }
+
+function Icon(props: { channel: Channel; symbol: string; color?: string }) {
+  return (
+    <Show
+      when={props.channel.mature}
+      fallback={<Symbol color={props.color}>{props.symbol}</Symbol>}
+    >
+      <svg viewBox="0 0 24 24" width="24" height="24">
+        <mask id="m">
+          <rect x="0" y="0" width="24" height="24" fill="#fff" />
+          <text {...warnProps} stroke="#000" stroke-width="3" color="#000">
+            warning
+          </text>
+        </mask>
+        <text
+          class={"material-symbols-outlined"}
+          style={{
+            "font-variation-settings": '"FILL" 0, "wght" 400, "GRAD" 0',
+            color: props.color,
+          }}
+          x="0"
+          y="24"
+          mask="url(#m)"
+        >
+          {props.symbol}
+        </text>
+        <text {...warnProps} color={props.color}>
+          warning
+        </text>
+      </svg>
+    </Show>
+  );
+}
+
+const warnProps = {
+  class: "material-symbols-rounded",
+  style: {
+    "font-variation-settings": '"FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24',
+    "font-size": "10px",
+  },
+  x: 13,
+  y: 10,
+};
 
 /**
  * Channel icon styling

--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -500,7 +500,13 @@ function Entry(
             <Icon
               channel={props.channel}
               symbol={getChannelIcon(props.channel)}
-              special={props.channel.mature ? "warning" : undefined}
+              special={
+                props.channel.e2e
+                  ? "lock"
+                  : props.channel.mature
+                    ? "warning"
+                    : undefined
+              }
               color={inCall() ? "var(--md-sys-color-primary)" : undefined}
             />
             <Show when={props.channel.icon}>

--- a/packages/client/src/serviceWorker.ts
+++ b/packages/client/src/serviceWorker.ts
@@ -6,6 +6,7 @@ declare let self: ServiceWorkerGlobalScope;
 interface ChannelPartial {
   channel_type: string;
   name?: string;
+  e2e?: boolean;
 }
 
 interface StoatPushNotification {
@@ -44,6 +45,10 @@ self.addEventListener("push", (event) => {
     } else {
       notification.title = "Stoat";
     }
+  }
+
+  if (notification.channel?.e2e) {
+    notification.body = "Sent an encrypted message";
   }
 
   notification.url ||= self.registration.scope;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,8 +561,8 @@ importers:
         specifier: 1.9.14
         version: 1.9.14
       stoat-api:
-        specifier: 0.15.3
-        version: 0.15.3
+        specifier: git+https://github.com/Pecacheu/javascript-client-api#8a612098dd853dbaaad6ae03baf2af40c079818c
+        version: https://codeload.github.com/Pecacheu/javascript-client-api/tar.gz/8a612098dd853dbaaad6ae03baf2af40c079818c
       ulid:
         specifier: ^3.0.2
         version: 3.0.2
@@ -6188,8 +6188,9 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
-  stoat-api@0.15.3:
-    resolution: {integrity: sha512-r08FplgeZWft4Hd2CK1tZ7EEzhocUyy/aeeOGBrKC6vy3ANsDhcMzGdJioYQ3jpzH+jFIPLQJzBaJK27Wf3Vug==}
+  stoat-api@https://codeload.github.com/Pecacheu/javascript-client-api/tar.gz/8a612098dd853dbaaad6ae03baf2af40c079818c:
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/Pecacheu/javascript-client-api/tar.gz/8a612098dd853dbaaad6ae03baf2af40c079818c}
+    version: 0.15.3
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -13610,7 +13611,7 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  stoat-api@0.15.3:
+  stoat-api@https://codeload.github.com/Pecacheu/javascript-client-api/tar.gz/8a612098dd853dbaaad6ae03baf2af40c079818c:
     dependencies:
       json-with-bigint: 3.4.4
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 allowBuilds:
   "@swc/core": true
   esbuild: true
+  stoat-api: true
 minimumReleaseAgeExclude:
   - stoat-api
 nodeLinker: isolated


### PR DESCRIPTION
# Note to the Stoat community
This is just a draft and e2ee is a large feature. Don't expect it to be merged soon. Discussion and (if you have a self-host to test with) testing welcome, but expect things to change and plz do not pester staff about timelines.

## Description

Based on lozaar's initial concept and the various discussions on e2ee, but fully willing to rewrite anything wherever team has input (this is why I didn't implement all TODOs yet, as there is 'this could change and make that TODO irrelevant' to be considered).

Prerequsites:

- \#1487
- <https://github.com/stoatchat/javascript-client-sdk/pull/192>
- https://github.com/stoatchat/stoatchat/pull/970

Known issues:
- Reacts and reply IDs aren't encrypted (meh, should we bother?)
- Date and author metadata also unencrypted and unlike the former two might be fundamentally impossible to do so with current architecture (this type of metadata leakage can happen in other e2ee protocols too, it's even possible with Matrix to some degree, so we shouldn't feel *too* bad about it)
- Embeds don't work for obvious reasons, they would have to be reimplemented client-side.
- Mentions also need a different approach.
- Attachments now fully working, but they should probably be cached better.
- The robust cryptography this uses is now officially built into the browser (and the AES module is even hardware-accelerated in Chromium) so no need for heavy external encryption lib (yayyy), unfortunately this requires a fairly recent browser (2024-2025). Might be good to fail gracefully with some feature detection, but will require testing on different devices (cough cough iPhones always being weird AF)
- Need to implement frontend search w/ client cache (maybe user-selectable size like Telegram.) Search is basically useless for regular messages atm anyhow though so it won't be missed for now.

## How was this PR tested?

Muchly

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

First you need to enable it in the group chat/channel settings: <img height=200 src="https://github.com/user-attachments/assets/5056ac0a-2cbd-4e4f-acdc-09286a02014c" /> <img height=200 src="https://github.com/user-attachments/assets/7675881c-82a4-4fdf-9c79-f6388b1bcfdb" />

Repurposing AgeGate screen for password gate: <img width=800 src="https://github.com/user-attachments/assets/4d8ea985-4a90-4667-982a-8e6a84897235" />

On mobile: <img width=200 src="https://github.com/user-attachments/assets/e30ca3c0-749a-469c-91d6-7e6194190b85" />

Messages display normally once authenticated, but with a special symbol: <img width=600 src="https://github.com/user-attachments/assets/d23c6551-462c-4879-84e8-052698fd5be2" />

Channel icons have a new padlock symbol, similar to warning symbol on NSFW channels in PR 1487: <img width=200 src="https://github.com/user-attachments/assets/ed7a9bf0-5d14-4293-a3cf-9d912326863c" />

</details>

## Checklist:

- [ ] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

AI big tech can't read your messages now, suck on them apples

- `main` <!-- branch-stack -->
  - \#1579 :point\_left:
