### PR TITLE
fix: keep the channel list from jumping to the top

### DIFF
--- a/packages/client/components/ui/components/utils/Draggable.tsx
+++ b/packages/client/components/ui/components/utils/Draggable.tsx
@@ -55,8 +55,11 @@ export function Draggable<T>(props: Props<T>) {
     props.dragHandles || false,
   );
 
+  // start off with the items we were given; filling this in from the effect
+  // below leaves the list empty for a frame, which loses the scroll position
   const [containerItems, setContainerItems] = createSignal<ContainerItem<T>[]>(
-    [],
+    // eslint-disable-next-line solid/reactivity
+    props.items.map((item) => ({ id: item.id, item })),
   );
 
   createEffect(() => setDragDisabled(props.dragHandles || false));


### PR DESCRIPTION
`Draggable` starts `containerItems` off as an empty array and only fills it in the `createEffect` underneath, which doesn't run until after the first render. So every `Draggable` that gets created renders with nothing in it to begin with.

Normally you'd never notice, but the sidebar hits it constantly. The wrappers are rebuilt on every update and `<For>` keys on reference, so as soon as
`server.orderedChannels` invalidates (it hands back fresh category objects on every read) the whole set of `Category` components gets thrown away and
rebuilt, and the `Draggable` inside them come up empty.

While the list is in that state the dnd zone initialises and measures it, and a forced layout read while a scroll container's content is shorter than its scroll offset makes the browser commit the clamp to 0. Putting the rows back afterwards doesn't undo it. Nothing needs to be painted in between, it all happens inside one synchronous update.

Seeding the signal from `props.items` means the rows are there in the first render, so there's no empty window to measure. The effect underneath still
handles everything after that, and the drag code is untouched.

I checked this with the real component in a nested layout matching the sidebar's, list parked at the bottom, then the outer list rebuilt:

- as-is: `scrollTop` 1720 -> 0
- with the signal seeded: 1720 -> 1720
- as-is, but with `use:dndzone` taken off: 1720 -> 1720

The third one is what pins the cause down: same empty first render, but with nothing measuring the list while it's empty the position survives.

This overlaps with #1489, which restores the position after the fact rather than avoiding the empty render. Same file, so they'll conflict.

Fixes #1574
Fixes #825
(Duplicates)

## How was this PR tested?

- [x] With CPU throttling on, scrolled a long channel list to the bottom and opened a channel, list stays where it is meant to be
- [x] Dragging channels and categories around still works
- [x] Reordering servers in the rail still works
- [x] Reordering roles in server settings still works
- [x] `tsc --noEmit`, eslint and prettier all clean

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

<!-- before/after screencast of clicking a channel near the bottom of the list -->

https://github.com/user-attachments/assets/513b54d3-bb55-499c-a753-bac2e6f96e20


https://github.com/user-attachments/assets/99b8854d-d9bf-401b-8414-7db88e824bc0


</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
None