### PR TITLE
fix(auth): handle null response body when verifying email

### DIFF
--- a/packages/client/components/auth/src/flows/FlowVerify.tsx
+++ b/packages/client/components/auth/src/flows/FlowVerify.tsx
@@ -52,9 +52,12 @@ export default function FlowVerify() {
 
       const data = (await api.post(`/auth/account/verify/${params.token}`)) as {
         ticket?: { token: string };
-      };
+      } | null;
 
-      setState({ state: "success", mfa_ticket: data.ticket?.token });
+      // the API returns a null body when verification succeeds without
+      // issuing an MFA ticket (e.g. confirming an email change), so this
+      // must not assume `data` is an object
+      setState({ state: "success", mfa_ticket: data?.ticket?.token });
     } catch (err) {
       setState({ state: "error", error: err });
     }


### PR DESCRIPTION
<!-- Describe your changes -->

`POST /auth/account/verify/:code` returns a `null` JSON body on success when no MFA ticket is issued this happens when confirming an email *change*, as opposed to verifying a brand-new account (which does get a ticket). `FlowVerify.tsx` accessed `data.ticket` without checking `data` itself for null, so a successful email-change verification threw a `TypeError`, which was caught and shown to the user as "Failed to verify!" even though the verification had already succeeded server-side. Matches the report: the page shows failure, but the new email is already active in settings.

Fixes #1089 

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] `tsc --noEmit` — zero errors in `FlowVerify.tsx`.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

...
