### PR TITLE
fix: Only prompt for MFA auth once on session manager page

### DIFF
--- a/packages/client/components/app/interface/settings/user/Sessions.tsx
+++ b/packages/client/components/app/interface/settings/user/Sessions.tsx
@@ -16,7 +16,7 @@ import {
 } from "solid-js";
 
 import { Trans } from "@lingui/solid/macro";
-import { Session } from "stoat.js";
+import { API, Session } from "stoat.js";
 import { styled } from "styled-system/jsx";
 
 import { useClient } from "@revolt/client";
@@ -129,8 +129,18 @@ function ManageCurrentSession(props: { otherSessions: Accessor<Session[]> }) {
  * List other logged in sessions
  */
 function ListOtherSessions(props: { otherSessions: Accessor<Session[]> }) {
-  const { openModal, mfaFlow } = useModals();
+  const { openModal, mfaFlowResp } = useModals();
   const client = useClient();
+
+  let mfa, mfa_resp: API.MFAResponse | undefined;
+  async function getTicket() {
+    //Prompt for MFA only first time
+    if (!mfa_resp) {
+      mfa = await client().account.mfa();
+      mfa_resp = await mfaFlowResp(mfa);
+    }
+    return mfa_resp && (await mfa!.createTicket(mfa_resp));
+  }
 
   return (
     <Show when={props.otherSessions().length}>
@@ -150,25 +160,16 @@ function ListOtherSessions(props: { otherSessions: Accessor<Session[]> }) {
                 <CategoryButton
                   icon="blank"
                   action="chevron"
-                  onClick={() =>
-                    openModal({
-                      type: "rename_session",
-                      session,
-                    })
-                  }
+                  onClick={() => openModal({ type: "rename_session", session })}
                 >
                   <Trans>Rename</Trans>
                 </CategoryButton>
                 <CategoryButton
                   icon="blank"
                   action="chevron"
-                  onClick={() => {
-                    (async () => {
-                      const mfa = await client().account.mfa();
-                      const ticket = await mfaFlow(mfa as never);
-                      session.delete(ticket!);
-                    })();
-                  }}
+                  onClick={() =>
+                    getTicket().then((t) => t && session.delete(t))
+                  }
                 >
                   <Trans>Log Out</Trans>
                 </CategoryButton>

--- a/packages/client/components/modal/index.tsx
+++ b/packages/client/components/modal/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "solid-js";
 import { SetStoreFunction, createStore } from "solid-js/store";
 
-import type { MFA, MFATicket } from "stoat.js";
+import type { API, MFA, MFATicket } from "stoat.js";
 
 import { Keybind, KeybindAction } from "@revolt/keybinds";
 import { dismissFloatingElements } from "@revolt/ui";
@@ -154,6 +154,20 @@ export class ModalControllerExtended extends ModalController {
       this.openModal({
         type: "mfa_flow",
         state: "known",
+        mfa,
+        callback,
+      }),
+    );
+  }
+
+  /**
+   * Perform MFA flow but return MFAResponse
+   */
+  mfaFlowResp(mfa: MFA) {
+    return new Promise((callback: (response?: API.MFAResponse) => void) =>
+      this.openModal({
+        type: "mfa_flow",
+        state: "known_resp_only",
         mfa,
         callback,
       }),

--- a/packages/client/components/modal/modals/MFAFlow.tsx
+++ b/packages/client/components/modal/modals/MFAFlow.tsx
@@ -51,7 +51,7 @@ export function MFAFlowModal(
 
   // Fetch available methods if they have not been provided.
   onMount(() => {
-    if (!methods() && props.state === "known") {
+    if (!methods() && props.state !== "unknown") {
       setMethods(props.mfa.availableMethods);
     }
   });

--- a/packages/client/components/modal/types.ts
+++ b/packages/client/components/modal/types.ts
@@ -197,6 +197,11 @@ export type Modals =
           callback: (ticket?: MFATicket) => void;
         }
       | {
+          mfa: MFA;
+          state: "known_resp_only";
+          callback: (response?: API.MFAResponse) => void;
+        }
+      | {
           state: "unknown";
           available_methods: API.MFAMethod[];
           callback: (response?: API.MFAResponse) => void;


### PR DESCRIPTION
In case you want to log out multiple sessions in the sessions manager quickly, it becomes *very* annoying that you have to enter your password again **for each one.** This small fix just allows it to remember your MFA creds after the first one so you can remove several more if desired.

For security, it only remembers them for as long as the session manager tab is open. As soon as you switch tabs or close settings, they are forgotten due to being local vars.

No UI change.

## How was this PR tested?

Removing some sessions (I do a lot of testing so, there are a lot of them there lol)

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Crazy? I was crazy once. They locked me in a room. A server room. A server room with AI. AI makes me crazy.

- `main` <!-- branch-stack -->
  - \#1587 :point\_left:
