### PR TITLE
feat: add functionality to mark attachments as spoilers

### DIFF
--- a/packages/client/components/app/interface/channels/text/DraftMessage.tsx
+++ b/packages/client/components/app/interface/channels/text/DraftMessage.tsx
@@ -1,4 +1,4 @@
-import { For, Match, Switch } from "solid-js";
+import { For, Match, Switch, Show } from "solid-js";
 
 import { Trans } from "@lingui/solid/macro";
 import type { Channel } from "stoat.js";
@@ -73,6 +73,7 @@ export function DraftMessage(props: Props) {
       <For each={props.draft.files}>
         {(id) => {
           const file = state.draft.getFile(id);
+          const spoiler = () => state.draft.isFileSpoiler(id);
 
           return (
             <>
@@ -86,7 +87,12 @@ export function DraftMessage(props: Props) {
                     width={file.dimensions![0]}
                     height={file.dimensions![1]}
                   >
-                    <img src={file.dataUri} />
+                    <PreviewWrapper>
+                      <PreviewImage src={file.dataUri} spoiler={spoiler()} />
+                      <Show when={spoiler()}>
+                        <SpoilerLabel>Spoiler</SpoilerLabel>
+                      </Show>
+                    </PreviewWrapper>
                   </SizedContent>
                 </Match>
               </Switch>
@@ -110,5 +116,61 @@ const BreakText = styled("div", {
       overflowY: "hidden",
       maxHeight: "100vh",
     },
+  },
+});
+
+/**
+ * Positioning context for the image + spoiler label, independent of whatever
+ * SizedContent itself does internally
+ */
+const PreviewWrapper = styled("div", {
+  base: {
+    position: "relative",
+    display: "grid",
+
+    "& > img": {
+      gridArea: "1 / 1",
+    },
+  },
+});
+
+/**
+ * Attachment preview image, blurred while marked as spoiler
+ */
+const PreviewImage = styled("img", {
+  base: {
+    display: "block",
+    width: "100%",
+    height: "100%",
+    transition: "var(--transitions-fast) filter",
+  },
+  variants: {
+    spoiler: {
+      true: {
+        filter: "blur(28px)",
+      },
+    },
+  },
+});
+
+/**
+ * Centered label shown over a spoiler-marked upload preview
+ */
+const SpoilerLabel = styled("button", {
+  base: {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    zIndex: 2,
+    transform: "translate(-50%, -50%)",
+
+    padding: "4px var(--gap-sm)",
+    borderRadius: "var(--borderRadius-lg)",
+    border: "none",
+
+    color: "var(--md-sys-color-on-surface)",
+    background: "var(--md-sys-color-surface)",
+
+    textTransform: "uppercase",
   },
 });

--- a/packages/client/components/app/interface/channels/text/DraftMessage.tsx
+++ b/packages/client/components/app/interface/channels/text/DraftMessage.tsx
@@ -1,4 +1,4 @@
-import { For, Match, Switch, Show } from "solid-js";
+import { For, Match, Show, Switch } from "solid-js";
 
 import { Trans } from "@lingui/solid/macro";
 import type { Channel } from "stoat.js";

--- a/packages/client/components/state/stores/Draft.ts
+++ b/packages/client/components/state/stores/Draft.ts
@@ -104,6 +104,7 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
       dimensions?: [number, number];
       autumnId?: string;
       uploadProgress: [Accessor<number>, Setter<number>];
+      spoiler: [Accessor<boolean>, Setter<boolean>];
     }
   >;
 
@@ -125,6 +126,8 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
     this.fileCache = {};
 
     this.getFile = this.getFile.bind(this);
+    this.isFileSpoiler = this.isFileSpoiler.bind(this);
+    this.toggleFileSpoiler = this.toggleFileSpoiler.bind(this);
     this.setEditingMessageContent = this.setEditingMessageContent.bind(this);
     this.instance = useInstance();
   }
@@ -328,7 +331,11 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
           continue;
         }
 
-        body.set("file", file);
+        body.set(
+          "file",
+          file,
+          this.isFileSpoiler(fileId) ? `SPOILER_${file.name}` : file.name,
+        );
 
         // We have to use XMLHttpRequest because modern fetch duplex streams require QUIC or HTTP/2
         const xhr = new XMLHttpRequest();
@@ -602,6 +609,8 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
       // we know what we're doing here...
       // eslint-disable-next-line solid/reactivity
       uploadProgress: createSignal(0),
+      // eslint-disable-next-line solid/reactivity
+      spoiler: createSignal(false),
     };
 
     if (this.fileCache[id].dataUri) {
@@ -657,6 +666,24 @@ export class Draft extends AbstractStore<"draft", TypeDraft> {
    */
   getFile(fileId: string) {
     return this.fileCache[fileId];
+  }
+
+  /**
+   * Whether a file is currently marked as a spoiler
+   * @param fileId File ID
+   */
+  isFileSpoiler(fileId: string): boolean {
+    return this.fileCache[fileId]?.spoiler[0]() ?? false;
+  }
+
+  /**
+   * Toggle spoiler state for a file
+   * @param fileId File ID
+   */
+  toggleFileSpoiler(fileId: string) {
+    const entry = this.fileCache[fileId];
+    if (!entry) return;
+    entry.spoiler[1]((value) => !value);
   }
 
   /**

--- a/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
@@ -6,10 +6,9 @@ import { styled } from "styled-system/jsx";
 import { useInstance } from "@revolt/instance";
 import { ALLOWED_IMAGE_TYPES } from "@revolt/state";
 import { Ripple, typography } from "@revolt/ui/components/design";
-import { OverflowingText, iconSize } from "@revolt/ui/components/utils";
+import { iconSize, OverflowingText, Symbol } from "@revolt/ui/components/utils";
 
 import MdAdd from "@material-design-icons/svg/outlined/add.svg?component-solid";
-import MdCancel from "@material-design-icons/svg/outlined/cancel.svg?component-solid";
 import MdFile from "@material-design-icons/svg/outlined/description.svg?component-solid";
 
 interface Props {
@@ -37,6 +36,18 @@ interface Props {
    * @param fileId ID
    */
   removeFile(fileId: string): void;
+
+  /**
+   * Whether a file is currently marked as a spoiler
+   * @param fileId ID
+   */
+  isSpoiler(fileId: string): boolean;
+
+  /**
+   * Toggle spoiler state for a file
+   * @param fileId ID
+   */
+  toggleSpoiler(fileId: string): void;
 }
 
 /**
@@ -72,6 +83,19 @@ export function FileCarousel(props: Props) {
               const file = () => props.getFile(id);
 
               /**
+               * Whether this file is marked as a spoiler
+               */
+              const spoiler = () => props.isSpoiler(id);
+
+              /**
+               * Handler for toggling spoiler state
+               */
+              const onToggleSpoiler = (event: MouseEvent) => {
+                event.stopPropagation();
+                props.toggleSpoiler(id);
+              };
+
+              /**
                * Handler for removing the file
                */
               const onClick = () => props.removeFile(id);
@@ -84,7 +108,6 @@ export function FileCarousel(props: Props) {
 
                   <Entry ignored={index() >= limits().message_attachments}>
                     <PreviewBox
-                      onClick={onClick}
                       image={ALLOWED_IMAGE_TYPES.includes(file().file.type)}
                     >
                       <Switch
@@ -101,12 +124,31 @@ export function FileCarousel(props: Props) {
                             src={file().dataUri}
                             alt={file().file.name}
                             loading="eager"
+                            spoiler={spoiler()}
                           />
                         </Match>
                       </Switch>
-                      <Overlay>
-                        <MdCancel {...iconSize(36)} />
-                      </Overlay>
+
+                      <Show when={spoiler()}>
+                        <SpoilerLabel onClick={onToggleSpoiler}>
+                          Spoiler
+                        </SpoilerLabel>
+                      </Show>
+
+                      <ActionBox>
+                        <ActionIcon onClick={onToggleSpoiler}>
+                          <Switch
+                            fallback={<Symbol size={16}>visibility</Symbol>}
+                          >
+                            <Match when={spoiler()}>
+                              <Symbol size={16}>visibility_off</Symbol>
+                            </Match>
+                          </Switch>
+                        </ActionIcon>
+                        <ActionIcon danger onClick={onClick}>
+                          <Symbol size={16}>delete</Symbol>
+                        </ActionIcon>
+                      </ActionBox>
                     </PreviewBox>
                     <FileName>
                       <OverflowingText>{file().file.name}</OverflowingText>
@@ -132,11 +174,11 @@ export function FileCarousel(props: Props) {
  */
 const PreviewBox = styled("div", {
   base: {
+    position: "relative",
     display: "grid",
     justifyItems: "center",
     gridTemplate: `"main" var(--preview-size) / minmax(var(--preview-size), 1fr)`,
 
-    cursor: "pointer",
     overflow: "hidden",
     borderRadius: "var(--gap-md)",
 
@@ -163,30 +205,89 @@ const Image = styled("img", {
     objectFit: "cover",
     marginBottom: "var(--gap-md)",
     height: "var(--preview-size)",
+    transition: "var(--transitions-fast) filter",
+  },
+  variants: {
+    spoiler: {
+      true: {
+        filter: "blur(28px)",
+      },
+    },
   },
 });
 
 /**
- * Overlay container
+ * Centered pill label shown over a spoiler-marked thumbnail; click to unmark
  */
-const Overlay = styled("div", {
+const SpoilerLabel = styled("button", {
   base: {
-    zIndex: 1,
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    zIndex: 2,
+    transform: "translate(-50%, -50%)",
 
-    display: "grid",
-    alignItems: "center",
-    justifyContent: "center",
+    padding: "4px var(--gap-sm)",
+    borderRadius: "999px",
+    border: "none",
 
-    width: "100%",
-    height: "100%",
-
-    opacity: 0,
+    cursor: "pointer",
     color: "white",
-    background: "rgba(0, 0, 0, 0.8)",
-    transition: "var(--transitions-fast) opacity",
+    background: "rgba(0, 0, 0, 0.6)",
+
+    textTransform: "uppercase",
+    ...typography.raw({ class: "label", size: "small" }),
+  },
+});
+
+/**
+ * Grouped action toolbar, pinned to the top-right corner
+ */
+const ActionBox = styled("div", {
+  base: {
+    position: "absolute",
+    top: "var(--gap-sm)",
+    right: "var(--gap-sm)",
+    zIndex: 3,
+
+    display: "flex",
+    alignItems: "center",
+    gap: "2px",
+
+    padding: "3px",
+    borderRadius: "var(--borderRadius-md)",
+    background: "rgba(0, 0, 0, 0.6)",
+  },
+});
+
+/**
+ * Individual icon button inside the action box
+ */
+const ActionIcon = styled("button", {
+  base: {
+    display: "grid",
+    placeItems: "center",
+
+    width: "22px",
+    height: "22px",
+    padding: 0,
+    borderRadius: "var(--borderRadius-sm, 4px)",
+    border: "none",
+
+    cursor: "pointer",
+    color: "white",
+    background: "transparent",
+    transition: "var(--transitions-fast) background",
 
     "&:hover": {
-      opacity: 1,
+      background: "rgba(255, 255, 255, 0.15)",
+    },
+  },
+  variants: {
+    danger: {
+      true: {
+        color: "var(--md-sys-color-error)",
+      },
     },
   },
 });

--- a/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
@@ -227,12 +227,13 @@ const SpoilerLabel = styled("button", {
     zIndex: 2,
     transform: "translate(-50%, -50%)",
 
-    display: "grid",
+    padding: "4px var(--gap-sm)",
+    borderRadius: "var(--borderRadius-lg)",
     border: "none",
 
     cursor: "pointer",
-    color: "white",
-    background: "rgba(0, 0, 0, 0.6)",
+    color: "var(--md-sys-color-on-surface)",
+    background: "var(--md-sys-color-surface)",
 
     textTransform: "uppercase",
     ...typography.raw({ class: "label", size: "small" }),
@@ -255,7 +256,7 @@ const ActionBox = styled("div", {
 
     padding: "3px",
     borderRadius: "var(--borderRadius-md)",
-    background: "rgba(0, 0, 0, 0.6)",
+    background: "var(--md-sys-color-surface)",
   },
 });
 
@@ -279,7 +280,8 @@ const ActionIcon = styled("button", {
     transition: "var(--transitions-fast) background",
 
     "&:hover": {
-      background: "rgba(255, 255, 255, 0.15)",
+      background:
+        "color-mix(in srgb, var(--md-sys-color-on-surface) 15%, transparent)",
     },
   },
   variants: {

--- a/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
+++ b/packages/client/components/ui/components/features/messaging/composition/FileCarousel.tsx
@@ -227,8 +227,7 @@ const SpoilerLabel = styled("button", {
     zIndex: 2,
     transform: "translate(-50%, -50%)",
 
-    padding: "4px var(--gap-sm)",
-    borderRadius: "999px",
+    display: "grid",
     border: "none",
 
     cursor: "pointer",

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -305,6 +305,22 @@ export function MessageComposition(props: Props) {
     state.draft.removeFile(props.channel.id, fileId);
   }
 
+  /**
+   * Check if a file is marked as a spoiler
+   * @param fileId File ID
+   */
+  function isSpoiler(fileId: string) {
+    return state.draft.isFileSpoiler(fileId);
+  }
+
+  /**
+   * Toggle spoiler state for a file
+   * @param fileId File ID
+   */
+  function toggleSpoiler(fileId: string) {
+    state.draft.toggleFileSpoiler(fileId);
+  }
+
   const searchSpace = useSearchSpace(() => props.channel, client);
 
   return (
@@ -320,6 +336,8 @@ export function MessageComposition(props: Props) {
         getFile={state.draft.getFile}
         addFile={addFile}
         removeFile={removeFile}
+        isSpoiler={isSpoiler}
+        toggleSpoiler={toggleSpoiler}
       />
       <For each={draft().replies ?? []}>
         {(reply) => {


### PR DESCRIPTION
<!-- Describe your changes -->

Refactors the FileCarousel UI and adds a button to be able to mark attachments as spoilers
Fixes #1402

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Sent two images one was not marked, the other was marked, the marked one correct sent as SPOILER\_filename

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

<img width="271" height="182" alt="image" src="https://github.com/user-attachments/assets/a6528ae0-c0d1-4b18-acf0-cc830cf79781" />
<img width="547" height="572" alt="image" src="https://github.com/user-attachments/assets/7ab2947b-e08c-49d1-a63f-64cbf3544b48" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

I don't need rusty metal to write bad code

- `main` <!-- branch-stack -->
  - \#1597 :point\_left:
