### PR TITLE
fix: Don't allow message prefix to overflow to prevent bounce on sending

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/Container.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Container.tsx
@@ -286,6 +286,9 @@ const infoText = cva({
         width: "calc(7ch * var(--gap-sm))",
         fontSize: "0.7em",
 
+        overflow: "hidden",
+        overflowWrap: "none",
+
         display: "block",
         textAlign: "right",
         marginTop: "0.15em",
@@ -448,13 +451,17 @@ export function MessageContainer(props: Props) {
                   },
                 }}
               >
-                <Show when={props.edited}>(edited)</Show>
-                <Show when={!props.edited}>
-                  <Time
-                    value={props.timestamp}
-                    format="time"
-                    referenceTime={props._referenceTime}
-                  />
+                <Show
+                  when={props.edited}
+                  fallback={
+                    <Time
+                      value={props.timestamp}
+                      format="time"
+                      referenceTime={props._referenceTime}
+                    />
+                  }
+                >
+                  (edited)
                 </Show>
               </div>
             </Match>


### PR DESCRIPTION
Fixes a dumb visual bounce when sending messages. The prefix would fill with `Sending...` which would overflow and cause it to take two lines, falling back to one line after sending. That results in the text being `Sending..` But no one looks at that anyway... This PR removes the overflow for the prefix which shouldn't be needed ever since failed messages create a header.

## How was this PR tested?

Sent messages with throttling on to ensure that messages that sent didn't bounce after the change.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Before:

<https://github.com/user-attachments/assets/273248e4-9ef1-4b5e-9ab8-0d25996d3ed8>

After:

<https://github.com/user-attachments/assets/aa04885b-ebdf-4705-aacc-539d98774844>

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1598 :point\_left:
