### PR TITLE
fix: fix channel icon animations and increase channel icon size

### DIFF
--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -513,8 +513,11 @@ function Entry(
             </Switch>
             <Show when={props.channel.icon}>
               <ChannelIcon
-                src={props.channel.iconURL}
-                css={{ marginEnd: "0.2em" }}
+                src={
+                  props.active
+                    ? props.channel.animatedIconURL
+                    : props.channel.iconURL
+                }
               />
             </Show>
           </>
@@ -576,8 +579,8 @@ function Entry(
  */
 const ChannelIcon = styled("img", {
   base: {
-    width: "16px",
-    height: "16px",
+    width: "24px",
+    height: "24px",
     objectFit: "contain",
   },
 });


### PR DESCRIPTION
…r visibility

<!-- Describe your changes -->

If a selected channel has an animated icon it will play, otherwise it will just be a still image.

Also makes them slightly larger so it's easier to see

Fixes #1395, Fixes #136

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] I click on channel, it animates

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

<https://github.com/user-attachments/assets/c70bc8be-e1e9-40b1-b025-80505d7c8039>

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1601 :point\_left:
