### PR TITLE
fix: Voice outline works in pip again

### DIFF
--- a/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
+++ b/packages/client/components/ui/components/features/voice/callCard/VoiceCallCardPiP.tsx
@@ -128,11 +128,8 @@ const UserIcon = styled("div", {
   variants: {
     speaking: {
       true: {
-        "& svg": {
-          outlineOffset: "1px",
-          outline: "2px solid var(--md-sys-color-primary)",
-          borderRadius: "var(--borderRadius-circle)",
-        },
+        outlineOffset: "1px",
+        outline: "2px solid var(--md-sys-color-primary)",
       },
     },
   },


### PR DESCRIPTION
The voice pip refactor made the avatar a square and that broke the outline. The outline was being clipped by the `overflow: hidden`. This PR moves the outline to the UserIcon wrapper div, which happens to be 24px now since the refactor.

Fixes #1344

No UI changes (UI fix)

## How was this PR tested?

Talked in voice with the pip up and observed the icon lighting up.

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<img width="362" height="290" alt="image" src="https://github.com/user-attachments/assets/f483d96f-3064-4dee-861c-8617407e714c" />
</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#1603 :point\_left:
