### PR TITLE
feat: add google sans flex variable to font list

### DIFF
--- a/packages/client/components/ui/themes/fonts.ts
+++ b/packages/client/components/ui/themes/fonts.ts
@@ -122,6 +122,11 @@ export const FONTS = {
       await import("@fontsource-variable/plus-jakarta-sans/index.css");
     },
   },
+  "Google Sans Flex Variable": {
+    load: async () => {
+      await import("@fontsource-variable/google-sans-flex/full.css");
+    },
+  },
 };
 
 export const MONOSPACE_FONTS = {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -45,6 +45,7 @@
     "@codemirror/view": "^6.38.6",
     "@dschz/solid-auto-sizer": "^0.1.3",
     "@floating-ui/dom": "^1.7.0",
+    "@fontsource-variable/google-sans-flex": "^5.3.1",
     "@fontsource-variable/ibm-plex-sans": "^5.2.6",
     "@fontsource-variable/plus-jakarta-sans": "^5.2.6",
     "@fontsource/atkinson-hyperlegible": "^5.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.7.0
         version: 1.7.0
+      '@fontsource-variable/google-sans-flex':
+        specifier: ^5.3.1
+        version: 5.3.1
       '@fontsource-variable/ibm-plex-sans':
         specifier: ^5.2.6
         version: 5.2.6
@@ -2080,6 +2083,9 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@fontsource-variable/google-sans-flex@5.3.1':
+    resolution: {integrity: sha512-ItkWlFvW61+BmwOMJQfPY81KpvvslqbiTyfYKceOx+0kEFBzTcPbbMVcL9BKrmqhhqnq36kNs7YRbxonovOmNg==}
 
   '@fontsource-variable/ibm-plex-sans@5.2.6':
     resolution: {integrity: sha512-hnuya7tsdaEiub463GFrhKDnmViTFKkJb9S+H+Fk6sMnr5dL/5DlAxeCZyXMK8WfjHktDiaEOIWPRZBQVKV0dw==}
@@ -8502,6 +8508,8 @@ snapshots:
   '@floating-ui/utils@0.2.12': {}
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@fontsource-variable/google-sans-flex@5.3.1': {}
 
   '@fontsource-variable/ibm-plex-sans@5.2.6': {}
 


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #1588

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Font applies correctly
- [x] Font appears in interface font selection menu

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>
<!-- Learn more about providing effective screenshots & screencasts: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->

<!-- Add images here -->

<img width="1397" height="1194" alt="image" src="https://github.com/user-attachments/assets/00b8ad8d-98d5-4336-8ea5-fee71bee495e" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used to author this pull request.

- `main` <!-- branch-stack -->
  - \#1608 :point\_left:
